### PR TITLE
Fixed undefined Index warning in get_plugin_options on settings page

### DIFF
--- a/edit_flow.php
+++ b/edit_flow.php
@@ -217,7 +217,7 @@ class edit_flow {
 	 *
 	 */
 	function get_plugin_option ( $name ) {
-		if(is_array($this->options) && $option = $this->options[$name])
+		if(is_array($this->options) && isset( $this->options[$name] ) && $option = $this->options[$name])
 			return $option;
 		else 
 			return null;


### PR DESCRIPTION
fixed service engine soon light on edit-flow settings page (undefined index)
