### PR TITLE
Develop

### DIFF
--- a/modules/notifications/notifications.php
+++ b/modules/notifications/notifications.php
@@ -41,7 +41,7 @@ class EF_Notifications extends EF_Module {
 					'post' => 'on',
 					'page' => 'on',
 				),
-				'always_notify_admin' => 'on',
+				'always_notify_admin' => 'off',
 			),
 			'configure_page_cb' => 'print_configure_view',
 			'post_type_support' => 'ef_notification',


### PR DESCRIPTION
Hey I think it might have sense to set this default to off. 

We enabled the plugin across 20 sites and our emails got flooded with Edit-Flow messages right away.
