### PR TITLE
Use add_meta_boxes to register meta boxes, not admin_init

### DIFF
--- a/modules/editorial-comments/editorial-comments.php
+++ b/modules/editorial-comments/editorial-comments.php
@@ -116,7 +116,7 @@ class EF_Editorial_Comments extends EF_Module
 		
 		$supported_post_types = $this->get_post_types_for_module( $this->module );
 		foreach ( $supported_post_types as $post_type )
-			add_meta_box('edit-flow-editorial-comments', __('Editorial Comments', 'edit-flow'), array(&$this, 'editorial_comments_meta_box'), $post_type, 'normal', 'high');
+			add_meta_box('edit-flow-editorial-comments', __('Editorial Comments', 'edit-flow'), array(&$this, 'editorial_comments_meta_box'), $post_type, 'normal' );
 			
 	}
 	

--- a/modules/notifications/notifications.php
+++ b/modules/notifications/notifications.php
@@ -204,7 +204,7 @@ class EF_Notifications extends EF_Module {
 		
 		$usergroup_post_types = $this->get_post_types_for_module( $this->module );
 		foreach ( $usergroup_post_types as $post_type ) {
-			add_meta_box( 'edit-flow-notifications', __( 'Notifications', 'edit-flow'), array( &$this, 'notifications_meta_box'), $post_type, 'advanced', 'high');
+			add_meta_box( 'edit-flow-notifications', __( 'Notifications', 'edit-flow'), array( &$this, 'notifications_meta_box'), $post_type, 'advanced' );
 		}
 	}
 	


### PR DESCRIPTION
Registering meta boxes on `admin_init`, rather than `add_meta_boxes` is earlier than most plugin author might expect, and makes it difficult to control the default metabox order, as EF metaboxes area always the first metaboxes registered, and thus always on the top of the stack.
