### PR TITLE
Fix for issue #77 - add "Delete" as a command in the Calendar view

### DIFF
--- a/modules/calendar/calendar.php
+++ b/modules/calendar/calendar.php
@@ -666,6 +666,8 @@ class EF_Calendar extends EF_Module {
 									} elseif ( 'trash' != $post->post_status ) {
 										$item_actions['view'] = '<a href="' . get_permalink( $post->ID ) . '" title="' . esc_attr( sprintf( __( 'View &#8220;%s&#8221;', 'edit-flow' ), $post->post_title ) ) . '" rel="permalink">' . __( 'View', 'edit-flow' ) . '</a>';
 									}
+									
+									// Delete this post
 									$item_actions['delete'] = '<a href="'. get_delete_post_link( $post->ID) . '" title="' . esc_attr( __( 'Delete this item' ) ) . '">' . __( 'Delete', 'edit-flow' ) . '</a>';
 								}
 								// Allow other plugins to add actions


### PR DESCRIPTION
Per the discussion in issue #77, I added a "Delete" option so that when you click on a post in the calendar view you now have 3 options:

Edit  |  (View|Preview)  |  Delete

The "Delete" command uses the 'get_delete_post_link' template tag and will immediately move an item into the trash.  There is no confirmation message, but the post is only moved into the Trash and can be retrieved from there via the usual method.

Kudos again on having such well-documented code that it was easy to find where to add this fix.
