### PR TITLE
Fix for #77 - Added "Trash" as command option in Calendar View

### DIFF
--- a/modules/calendar/calendar.php
+++ b/modules/calendar/calendar.php
@@ -667,8 +667,8 @@ class EF_Calendar extends EF_Module {
 										$item_actions['view'] = '<a href="' . get_permalink( $post->ID ) . '" title="' . esc_attr( sprintf( __( 'View &#8220;%s&#8221;', 'edit-flow' ), $post->post_title ) ) . '" rel="permalink">' . __( 'View', 'edit-flow' ) . '</a>';
 									}
 									
-									// Delete this post
-									$item_actions['delete'] = '<a href="'. get_delete_post_link( $post->ID) . '" title="' . esc_attr( __( 'Delete this item' ) ) . '">' . __( 'Delete', 'edit-flow' ) . '</a>';
+									// Move this post to the trash
+									$item_actions['trash'] = '<a href="'. get_delete_post_link( $post->ID) . '" title="' . esc_attr( __( 'Move this item to the Trash' ) ) . '">' . __( 'Trash', 'edit-flow' ) . '</a>';
 								}
 								// Allow other plugins to add actions
 								$item_actions = apply_filters( 'ef_calendar_item_actions', $item_actions, $post->ID );


### PR DESCRIPTION
Added one line of code to add a "Trash" command to the Calendar view.  Now when you click on a post in calendar view, you get three options:

Edit  |  (View|Preview)  |  Trash

The "Trash" command uses `get_delete_post_link()` to get a link to send the post to the Trash.  This move happens immediately without any confirmation.  Users can always retrieve the posts from the Trash using the regular "Posts" view in the WordPress admin interface.

As noted in the commits, I originally had the link text as "Delete", but changed it to "Trash" to be consistent with the core WordPress user interface for working with Posts.

I have tested the code on a instance of WordPress 3.3 MultiSite where Edit Flow is enabled for one of the sites.
