### PR TITLE
Fix Last Modified values on Story Budget

### DIFF
--- a/modules/story-budget/story-budget.php
+++ b/modules/story-budget/story-budget.php
@@ -517,7 +517,7 @@ class EF_Story_Budget extends EF_Module {
 				return $output;
 				break;
 			case 'post_modified':
-				$modified_time_gmt = strtotime( $post->post_modified_gmt );
+				$modified_time_gmt = strtotime( $post->post_modified_gmt . " GMT" );
 				return $this->timesince( $modified_time_gmt );
 				break;
 			default:


### PR DESCRIPTION
When the server's timezone is not set to GMT, running the post_modified_gmt value through strtotime yields an incorrect timestamp because WordPress does not automatically append the timezone identifier and strtotime just assumes the value you provided is local. So, we just add " GMT" to the end of post_modified_gmt before running it through strtotime and everything is fixed.

Sorry, I know you wanted pull requests done against the develop branch, but I can't seem to find it in the repo.
