### PR TITLE
Removed a double check in notifications module

### DIFF
--- a/modules/dashboard/dashboard.php
+++ b/modules/dashboard/dashboard.php
@@ -175,9 +175,6 @@ class EF_Dashboard extends EF_Module {
 	function myposts_widget() {
 		global $edit_flow;
 
-		if ( !$this->module_enabled( 'notifications' ) )
-			return;
-		
 		$myposts = $edit_flow->notifications->get_user_following_posts();
 		
 		?>


### PR DESCRIPTION
A check is made on $this->module_enabled( 'notifications' ) in add_dashboard_widget when myposts_widget is initialized and a second identical check takes place in myposts_widget(). I don't believe the second check is needed because the first check will make sure myposts_widget() is never called if the notifications module is disabled.
