### PR TITLE
Issue with inserting user_id in ajax_insert_comment()

### DIFF
--- a/modules/editorial-comments/editorial-comments.php
+++ b/modules/editorial-comments/editorial-comments.php
@@ -317,7 +317,7 @@ class EF_Editorial_Comments extends EF_Module
 			    'comment_content' => wp_kses($comment_content, array('a' => array('href' => array(),'title' => array()),'b' => array(),'i' => array(),'strong' => array(),'em' => array(),'u' => array(),'del' => array(), 'blockquote' => array(), 'sub' => array(), 'sup' => array() )),
 			    'comment_type' => self::comment_type,
 			    'comment_parent' => (int) $parent,
-			    'user_ID' => (int) $user_ID,
+			    'user_id' => (int) $user_ID,
 			    'comment_author_IP' => esc_sql($_SERVER['REMOTE_ADDR']),
 			    'comment_agent' => esc_sql($_SERVER['HTTP_USER_AGENT']),
 			    'comment_date' => $time,


### PR DESCRIPTION
The array of data to be committed contained the key 'user_ID'. I believe it needs to be 'user_id' in order to be inserted into wp_comments correctly.

**Edit:** Linking to the codex on [wp_insert_comment](http://codex.wordpress.org/Function_Reference/wp_insert_comment) for reference. And some grammatical issues. And they capitalize id in comment_post_ID but not user_id...?
