### PR TITLE
Fix permalink custom stati

### DIFF
--- a/modules/custom-status/custom-status.php
+++ b/modules/custom-status/custom-status.php
@@ -1350,22 +1350,21 @@ class EF_Custom_Status extends EF_Module {
 		 * 2) Did the permalink change
 		 */
 		if( !get_post_meta($post['ID'], 'edit_flow_changed_slug', true ) ){
-			//The title has been changed
 			if( $post['post_title'] != $current_post->post_title ) {
-				$unique_slug = wp_unique_post_slug( $post['post_title'], $post['ID'], $post['post_status'], $post['post_type'], $post['post_parent'] );
+				$unique_slug = wp_unique_post_slug( sanitize_title($post['post_title']), $post['ID'], $post['post_status'], $post['post_type'], $post['post_parent'] );
 				$data['post_name'] = sanitize_title( $unique_slug );
-			} else if ($current_post->post_name != $data['post_name'] && !empty( $current_post->post_name ) ) {
+			} else if ($current_post->post_name != $data['post_name'] && (!empty( $current_post->post_name ) && $current_post->post_name != "auto-draft" ) ) {
 				//Our post name has changed. What should we do?
 				$data['post_name'] = sanitize_title( $post['post_name'] );
 				update_post_meta( $post['ID'], 'edit_flow_changed_slug', true );
-			}
+			} else if( wp_unique_post_slug( sanitize_title($current_post->post_name, $post['ID'], $post['post_status'], $post['post_type'], $post['post_parent'] ) == $data['post_name'] ) ) {
+				$data['post_name'] = $data['post_name'];
+			} 
 		} else {
-			if ($current_post->post_name != $data['post_name'] && !empty( $current_post->post_name ) ) {
 				//Our post name has changed. What should we do?
 				$data['post_name'] = sanitize_title( $post['post_name'] );
 				update_post_meta( $post['ID'], 'edit_flow_changed_slug', true );
 			}
-		}
 		return $data;
 	}
 


### PR DESCRIPTION
Related to #137 

Here is one avenue of attack I've taken on fixing permalinks with custom stati (my new word of choice for the plural of status). It relies on two extra post meta fields, but it simulates the way wp core handles permalinks (in a very weird way...). This is just one idea, and I'll continue working on this if it seems a little too wonky. 

It can also be [cleaned up](https://f.cloud.github.com/assets/1888152/102802/110b43ee-693c-11e2-9a93-3338c9fd1556.png). Those $wpdb calls can be axed in a few places and shifted to the bottom. I'll update this again with a few readability/good practices fixes, but I figure I'd push it out so you could take a look at it before I hit the sack for a few.
