### PR TITLE
Fixed permalinks

### DIFF
--- a/modules/custom-status/custom-status.php
+++ b/modules/custom-status/custom-status.php
@@ -1393,7 +1393,6 @@ class EF_Custom_Status extends EF_Module {
 		if ( $ptype->hierarchical ) {
 			static $i;
 			$i++;
-			//Check if on second filter call
 			if ( $i > 1 ){
 				return sanitize_title( $post->post_title );
 			}

--- a/modules/notifications/notifications.php
+++ b/modules/notifications/notifications.php
@@ -279,9 +279,8 @@ class EF_Notifications extends EF_Module {
 		
 		// Add current user to following users
 		$user = wp_get_current_user();
-		if ( $user && apply_filters( 'ef_notification_auto_subscribe_current_user', true, 'subscription_action' ) ){
+		if ( $user && apply_filters( 'ef_notification_auto_subscribe_current_user', true, 'subscription_action' ) )
 			$users[] = $user->ID;
-		}
 
 		// Add post author to following users
 		if ( apply_filters( 'ef_notification_auto_subscribe_post_author', true, 'subscription_action' ) )
@@ -636,7 +635,7 @@ class EF_Notifications extends EF_Module {
 	 * @param $append bool Whether users should be added to following_users list or replace existing list
 	 */
 	function follow_post_user( $post, $users, $append = true ) {
-		
+
 		// Clean up data we're using
 		$post_id = ( is_int($post) ) ? $post : $post->ID;
 		if( !is_array($users) ) $users = array($users);


### PR DESCRIPTION
This should fix the page permalink issue. I tested it as much as I could but it could most definitely use more.

There's an odd quirk, even on a clean install of WordPress, where the direct page parent doesn't show up unless published or you explicitly modify the permalink, not sure what that's about.

Sorry about all the rando commits, somehow I had touched the notifications file when I was committing this. Took me a while how to figure that one out...

Still working on figuring out a better way to solve the permalinks problem in general. Gonna try and cut down on the number of hacks needed.
