### PR TITLE
Fixed a reference error with get_post.

### DIFF
--- a/common/php/class-module.php
+++ b/common/php/class-module.php
@@ -198,7 +198,7 @@ class EF_Module {
 		global $post, $typenow, $pagenow, $current_screen;
 		//get_post() needs a variable
 		$post_int;
-		if(isset($_REQUEST['post']))
+		if( isset( $_REQUEST['post'] ) )
 			$post_int = (int)$_REQUEST['post'];
 
 		if ( $post && $post->post_type )


### PR DESCRIPTION
This pull relates to a [problem encountered](http://wordpress.org/support/topic/class-module-error-on-update?replies=4). on the Edit Flow plugin forums. 

There's an issue with [get_post](http://codex.wordpress.org/Function_Reference/get_post) where the $post_id needs to be a variable. In this situation it was being passed into get_post without being variabalized correctly. Might have something to do with the casting or $_REQUEST in general. It's actually kind of a weird thing, I'm gonna look into it in more depth.

I'm unsure how to test this effectively. I just messed around as much as I could to see if anything happened, and nothing triggered. I might just try and set it so that the esleif its contained it automatically triggers every time and see what happens. 
