### PR TITLE
Fix an issue with get_user_following_posts

### DIFF
--- a/modules/notifications/notifications.php
+++ b/modules/notifications/notifications.php
@@ -874,7 +874,7 @@ class EF_Notifications extends EF_Module {
 		$post_args = array(
 			'tax_query' => array(
 					array(
-						'taxonomy' => 'following_users',
+						'taxonomy' => $this->following_users_taxonomy,
 						'field' => 'slug',
 						'terms' => $user,
 					)


### PR DESCRIPTION
This only ends up getting used in the "My Posts" dashboard widget, but the problem is it shows all posts, regardless of whether the user is following them or not. The extra tax_query array forces get_posts to act correctly. I'm not sure why the original code was not working correctly (since the codex seems to claim that [both methods should work the same](http://codex.wordpress.org/Class_Reference/WP_Query#Taxonomy_Parameters)), so if anybody knows what's up with that, hit me up cause I'm curious. In the meantime I'm gonna dig through get_posts() and see if I can figure it out. 
