### PR TITLE
First go at editorial comments widget

### DIFF
--- a/modules/dashboard/lib/dashboard.css
+++ b/modules/dashboard/lib/dashboard.css
@@ -12,6 +12,25 @@
 
 #post_status_widget span.small a:hover {border-bottom:1px dotted #989898;}
 
+
+/* Posts I'm Following */
+
+.ef-myposts li {
+  list-style-type: none;
+  padding-bottom: 5px;
+}
+
+.ef-myposts li a {
+  font-weight: normal;
+}
+
+.ef-myposts li .ef-myposts-timestamp {
+  color: #999;
+  font-style: italic;
+  font-family: "Lucida Grande",Verdana,Arial,"Bitstream Vera Sans",sans-serif;
+  font-size: 10px;
+}
+
 /* QuickPitch */
 
 .quick-pitch-notice {
@@ -76,24 +95,6 @@
 	text-align: right;
 }
 
-/* Posts I'm Following */
-
-.ef-myposts li {
-	list-style-type: none;
-	padding-bottom: 5px;
-}
-
-.ef-myposts li a {
-	font-weight: normal;
-}
-
-.ef-myposts li .ef-myposts-timestamp {
-	color: #999;
-	font-style: italic;
-	font-family: "Lucida Grande",Verdana,Arial,"Bitstream Vera Sans",sans-serif;
-	font-size: 10px;
-}
-
 /** Dashboard Notepad **/
 #dashboard-notepad #dashboard-notepad-submit-buttons {
 	float: right;
@@ -107,4 +108,5 @@
 
 #dashboard-notepad .submit #dashboard-notepad-last-updated {
 	float: left;
+	font-size: 11px;
 }

--- a/modules/dashboard/widgets/activity-feed/activity-feed.php
+++ b/modules/dashboard/widgets/activity-feed/activity-feed.php
@@ -1,0 +1,459 @@
+<?php
+/*
+ * A widget to follow user activity. 
+ *
+ */
+class EF_Activity_Feed_Widget {
+
+	public $edit_cap = 'edit_post';
+
+	function __construct() {
+		add_action( 'wp_ajax_ef_activity_feed_add_comment', array( $this, 'activity_feed_add_comment' ) );
+	}
+
+	/**
+	 * Add some localization to labels.
+	 *
+	 * @since 0.8
+	 */
+	function add_admin_scripts() {
+		EditFlow()->dashboard->enqueue_datepicker_resources();
+		wp_enqueue_script( 'edit-flow-activity-feed-widget-js', plugins_url( '/activity-feed/lib/activity-feed.js', dirname(__FILE__) ), false, EDIT_FLOW_VERSION );
+		wp_localize_script( 'edit-flow-activity-feed-widget-js', 'af_widget_text_labels', array(
+			'hide_metadata' => __( 'Hide metadata', 'edit-flow' ),
+			'view_metadata' => __( 'View metadata', 'edit-flow' ),
+			'show_parents' => __('View parents', 'edit-flow'),
+			'show_children' => __('View children', 'edit-flow'),
+			'hide_parents' => __('Hide parents', 'edit-flow'),
+			'hide_children' => __('Hide children', 'edit-flow'),
+			)
+		);
+		wp_enqueue_style( 'edit-flow-activity-feed-widget-css', plugins_url( '/activity-feed/lib/activity-feed.css', dirname( __FILE__ ) ), false, EDIT_FLOW_VERSION );
+	}
+	
+	/**
+	 * Add Activity Feed widget
+	 * Shows a list of comments and posts sorted by most recent
+	 */
+	public function init() {
+		wp_add_dashboard_widget( 'activity_feed_widget', __( 'Activity Feed', 'edit-flow' ), array( $this, 'activity_feed_widget_wrapper' ) );
+		add_action( 'admin_enqueue_scripts', array( $this, 'add_admin_scripts' ) );  
+		$this->edit_cap = apply_filters( 'ef_activity_feed_edit_cap', $this->edit_cap );
+	}
+
+	/**
+	 * In order to preserve event delegation when making modifications to html
+	 * with jQuery, need a wrapper div that all events will bind to. activity_feed_widget_init()
+	 * will be called to refresh the widget on adding a comment, so the wrapper
+	 * needs to be added one level above.
+	 *
+	 * @since 0.8
+	 */
+	public function activity_feed_widget_wrapper() {
+		echo '<div id="af-outer-wrap">';
+		echo $this->activity_feed_widget_init();
+		echo '</div>';
+	}
+
+	 /**
+	  * Initial generation of Activity Feed widget content. Will be used to refresh
+	  * the widget when a comment is made.
+	  *
+	  * @since 0.8
+	  */
+	public function activity_feed_widget_init() {
+		//Get a list of recent posts and comments.
+		$recent_posts_and_comments = $this->recent_posts_and_comments();
+
+		//To Do: Allow filter to sort by more than posts and comments (add pages, post types, etc).
+		$show_posts_and_comments = apply_filters('ef_activity_feed_show_posts_and_comments', array( 'post', 'comment' ) );
+		?>
+			<div id="af-inner-wrap">
+				<ul id="af-mixed-list">
+				<?php 
+					if( !empty( $recent_posts_and_comments ) ) :
+						//Loop through the combined list of posts and comments
+						foreach( $recent_posts_and_comments as $post_or_comment ) :
+							//Determine if we're looking at a comment or a post
+							if( get_class( $post_or_comment ) == "WP_Post" 
+								&&  array_search('post', $show_posts_and_comments) !== false )
+								$this->single_post( $post_or_comment );
+							else if ( get_class ( $post_or_comment ) != "WP_Post"
+								&& array_search('comment', $show_posts_and_comments) !== false )
+								$this->single_comment( $post_or_comment );
+							else
+								continue;
+							
+						endforeach;
+					else:
+						echo "No recent activity.";
+					endif;
+				?>
+				</ul>
+				<?php echo EditFlow()->editorial_comments->the_comment_form( true ); ?>
+			</div>	
+		<?php
+	}
+
+	/**
+	 * Get the combined list of recent posts and comments.
+	 * @return (WP_Post|stdClass)	  Mixed list of posts and comments
+	 *
+	 * @since 0.8
+	 */
+	function recent_posts_and_comments() {
+		global $current_user;
+
+		get_currentuserinfo();
+
+		//Get recent posts and comments the user is following
+		$num_items_to_show = apply_filters( 'af_num_items_to_show', $num_items_to_show = 5 );
+		$recent_posts = $recent_comments = array();
+
+		$recent_posts = EditFlow()->notifications->get_user_following_posts( $current_user->ID, array( 'posts_per_page' => $num_items_to_show ) );
+		
+		if( EditFlow()->helpers->module_enabled( 'editorial_comments' ) )
+			$recent_comments = EditFlow()->notifications->get_user_following_comments( $num_items_to_show );
+
+		//Organize and sort by date (filter this somehow to display certain number of each/total?)
+		$posts_and_comments = array_merge( $recent_posts, $recent_comments );
+		usort( $posts_and_comments, array( $this, "sort_posts_and_comments" ) );
+		array_splice( $posts_and_comments, $num_items_to_show );
+
+		return $posts_and_comments;
+	}
+
+	/**
+	 * Sorting function for array of comments and posts
+	 * @param  WP_Post $a A post object
+	 * @param  stdClass $b An stdClass object representing a comment
+	 * @return int Representing less than, greater than or equal to
+	 *
+	 * @since 0.8
+	 */
+	static function sort_posts_and_comments( $a, $b ) {
+		$a_date = ( get_class( $a ) == 'WP_Post' ) ? $a->post_modified : $a->comment_date;
+		$b_date = ( get_class( $b ) == 'WP_Post' ) ? $b->post_modified : $b->comment_date;
+
+		if( strtotime( $a_date ) == strtotime( $b_date ) )
+			return 0;
+
+		return ( strtotime( $a_date ) > strtotime( $b_date ) ) ? -1 : +1;
+	}
+
+	/**
+	 * Generate a single post list item
+	 * @param  WP_Post  $post
+	 * @param  int $li_id List item identifier
+	 *
+	 * @since 0.8
+	 */
+	function single_post( $post ) {
+		global $current_user;
+
+		$url = esc_url( get_edit_post_link( $post->ID ) );
+		$title = esc_html( $post->post_title );
+		$status = EditFlow()->custom_status->get_custom_status_by( 'slug', $post->post_status );
+		
+		//If it's not a custom status, it's published?
+		if( !$status ) {
+			$status_slug = get_post_status( $post->ID );
+			switch( $status_slug ) {
+				//Same way post.php handles statuses
+				case 'private':
+					$status_name = __( 'Privately Published', 'edit-flow' );
+					break;
+				case 'publish':
+					$status_name =  __( 'Published', 'edit-flow' );
+					break;
+				case 'future':
+					$status_name =  __( 'Scheduled', 'edit-flow' );
+					break;
+				case 'pending':
+					$status_name = __( 'Pending Review', 'edit-flow' );
+					break;
+				case 'draft':
+				case 'auto-draft':
+					$status_name =  __( 'Draft', 'edit-flow' );
+				break;
+				default:
+					$status_name = "";
+				break;
+			}
+
+		}
+		else {
+			$status_slug = $status->slug;
+			$status_name = $status->name;
+		}
+
+		$status_slug = esc_html( $status_slug );
+		$status_name = esc_html( $status_name );
+
+		if( EditFlow()->helpers->module_enabled( 'editorial_metadata' ) )
+			$view_meta = $this->activity_feed_view_efmeta( $post );
+
+		get_currentuserinfo();
+
+		?>
+			<li id="post-<?php echo $post->ID ?>" class="af-post">
+				<h4 class="af-bigger <?php echo $status_slug; ?>"><a href="<?php echo $url ?>" title="<?php _e( 'Edit this post', 'edit-flow' ) ?>"><?php echo $title; ?></a><span class="af-light"><?php if( !empty( $status_name ) ) { ?> &nbsp;-&nbsp;</span> <?php echo $status_name; } ?></h4>
+				<span class="af-timestamp"><?php _e( 'Updated on', 'edit-flow' ) ?> <?php echo get_post_modified_time( 'F j, Y \\a\\t g:i a', false, $post ) ?></span>
+				<?php if( current_user_can( $this->edit_cap , $post->ID ) ): ?>
+					<p class="af-row-actions af-row-hidden">
+						<?php if( EditFlow()->helpers->module_enabled( 'editorial_comments' ) ): ?>
+							<span class="af-new-comment"><a href="#" onclick="inlineEditorialCommentMeta.open(this, 0, <?php echo esc_html( $post->ID ) ?>);return false;"><?php _e( 'New comment', 'edit_flow' ); ?></a></span>
+						<?php endif; ?>
+						<?php if( EditFlow()->helpers->module_enabled( 'editorial_metadata' ) ): ?>
+							<?php if( current_user_can( $this->edit_cap, $post->ID ) && !empty( $view_meta ) ): ?>
+								<span class="af-view-meta"><?php if( EditFlow()->helpers->module_enabled( 'editorial_comments' ) ) { ?> | <?php } ?><a href="#" onclick="inlineEditorialCommentMeta.viewContent(this);return false;"><?php _e( 'View metadata', 'edit_flow' ); ?></a></span>
+							<?php endif; ?>
+						<?php endif; ?>
+					</p>
+				<?php endif; ?>
+				<input type="hidden" name="af-item-post_id" value="<?php echo esc_html( $post->ID ); ?>" />
+				<div class="hidden-post-information">
+					<?php 
+						if( current_user_can( $this->edit_cap, $post->ID ) && isset( $view_meta ) ) 
+							echo '<div class="af-view-metadata hide-af-feed-info">' . $view_meta . '</div>';
+					?>
+				</div>
+			</li>
+		<?php
+	}
+
+	/**
+	 * Generate a single comment list item
+	 * @param  stdClass  $comment
+	 * @param  integer $li_id
+	 *
+	 * @since 0.8
+	 */
+	function single_comment( $comment ) {
+		global $current_user;
+
+		$list_of_parents = $list_of_children = array();
+
+		//Useful information about the comment
+		$comment_post = get_post( $comment->comment_post_ID );
+		$text = esc_html( get_comment_excerpt( $comment->comment_ID ) );
+
+		//Useful information to be displayed about that post
+		$url = esc_url( get_edit_post_link( $comment_post->ID ) );
+		$comment_url = $url.'#comment-'.$comment->comment_ID;
+		$title = esc_html( $comment_post->post_title );
+
+		//Get the parent and grand-parent of this comment
+		$list_of_parents = $this->get_parent_comments( $comment, 2 );
+
+		//Get the child and grand-child of this comment
+		$parent_comment = get_comments( array( 'parent' => $comment->comment_ID, 'status' => 'editorial-comment', 'number' => 1 ) );
+		$list_of_children = $this->get_children_comments( $parent_comment, 2 );
+
+		get_currentuserinfo();
+
+		$from = ( ( !empty( $comment->comment_parent ) ) ? $from = 'Reply from ' : $from = 'From ' ) . esc_html( $comment->comment_author ) . ' on ';
+
+		?>
+			<li id="comment-<?php echo $comment->comment_ID ?>" class="af-comment">
+				<h4 class="af-larger"><span class="af-comment-from"><?php echo $from ?></span><a href="<?php echo $url ?>" title="<?php __( 'View this post', 'edit-flow' ) ?>"><?php echo $title; ?></a> <a href="<?php echo $comment_url ?>" title="<?php __( 'View this comment', 'edit-flow' ) ?>">#</a></h4>
+					<ul class="af-outer-comment-wrap">
+						<?php $this->format_comment_text( $comment, true ); ?>
+					</ul>
+					<?php if( current_user_can( $this->edit_cap, $comment->comment_post_ID ) ): ?>
+						<p class="af-row-actions af-row-hidden">
+							<span class="af-new-comment"><a href="#" onclick="inlineEditorialCommentMeta.open(this, 0, <?php echo esc_html( $comment->comment_post_ID ) ?>);return false;" >New comment</a></span> | 
+							<span class="af-comment-reply"><a href="#" onclick="inlineEditorialCommentMeta.open(this, <?php echo esc_html( $comment->comment_ID ) ?>, <?php echo esc_html( $comment->comment_post_ID ) ?>);return false;" >Reply to comment</a></span>
+							<?php if( !empty( $list_of_parents ) ) { ?>
+									<span class="af-comment-parent"> | <a href="#" onclick="inlineEditorialCommentMeta.viewContent(this);return false;">View parents</a></span>
+							<?php } if( !empty( $list_of_children ) ) { ?>
+									<span class="af-comment-children"> | <a href="#" onclick="inlineEditorialCommentMeta.viewContent(this);return false;">View children</a></span>
+							<?php } ?>
+						</p>
+					<?php endif; ?>
+					<div class="hidden-post-information">
+						<?php 
+							if( current_user_can( $this->edit_cap, $comment->comment_post_ID ) ) {
+								if( !empty( $list_of_parents ) )
+									echo '<div class="af-show-parents hide-af-feed-info">' . $this->activity_feed_view_conversation( $list_of_parents, 'parents' ) . '</div>';
+								if( !empty( $list_of_children ) )
+									echo '<div class="af-show-children hide-af-feed-info">' . $this->activity_feed_view_conversation( $list_of_children, 'children' ) . '</div>';
+							}
+						?>
+					</div>
+			</li>
+		<?php
+	}
+
+	/**
+	 * Loop to get parent comments of comment
+	 * @param  $comment WP_Comment
+	 * @param  $num_parents int
+	 * @return array
+	 *
+	 * @since 0.8
+	 */
+	function get_parent_comments( $comment, $num_parents ) {
+		$list_of_parents = array();
+
+		for( $parents_count = 0; $parents_count < $num_parents; $parents_count++ ) {
+			if( $comment && $comment->comment_parent ) {
+				$list_of_parents[] = $comment->comment_parent;
+				$comment = get_comment( $comment->comment_parent );
+			}
+		}
+		return $list_of_parents;
+	}
+
+	/**
+	 * Loop to get comment children
+	 * @param  WP_Comment $comment
+	 * @param  int $num_children
+	 * @return array List of comment children
+	 *
+	 * @since 0.8
+	 */
+	function get_children_comments( $comment, $num_children ) {
+		//Loop through and get child comments
+		$list_of_children = array();
+
+		if( !empty( $comment ) ) {
+			for( $i = 0; $i < $num_children; $i++ ) {
+				if( isset( $comment[0] ) ) {
+					$list_of_children[] = $comment[0]->comment_ID;
+					$comment = get_comments( array( 'parent' => $comment[0]->comment_ID, 'status' => 'editorial-comment', 'number' => 1 ) );
+				}
+			}
+		}
+		return $list_of_children;
+	}
+
+	/**
+	 * Format the text of a comment. If it's a single comment,
+	 * it's a comment anchor. If it's a conversation it's a list
+	 * of parent of children
+	 * @param WP_Comment $comment
+	 * @param $conversation_or_single
+	 *
+	 * @since 0.8
+	 */
+	function format_comment_text( $comment, $conversation_or_single = false ) { 
+		$time = date( 'F j, Y \\a\\t g:i a', strtotime( $comment->comment_date ) );
+		$classes = 'af-inner-comment-wrap';
+		$classes .= ( $conversation_or_single ) ? ' af-anchor-li' : '';
+		echo '<li class="' . $classes . '">';
+		echo '<span class="af-comment-content">' . esc_html( $comment->comment_content ) . '</span>';
+		if( $comment->comment_author && $time )
+			echo '<p class="af-comment-user-time">' . esc_html( $comment->comment_author ) . ' said on ' . $time . '</p>';
+		echo '</li>';
+	}
+
+	/**
+	 * Generate a comment conversation
+	 * @param array $comment_ids
+	 * @return string List of comments
+	 * 
+	 * @since 0.8
+	 */
+	function activity_feed_view_conversation( $comment_ids  ) {
+		//Get comment parents
+
+		if( empty( $comment_ids ) )
+			return;
+
+		$list_of_comments = '<ul>';
+
+		foreach( $comment_ids as $comment_key => $comment_id ) {
+			if( $comment_id ) {
+				ob_start();
+					$comment = get_comment( $comment_id );
+					$this->format_comment_text( $comment );
+					$list_of_comments .= ob_get_contents();
+				ob_end_clean();
+			}
+		}
+
+		$list_of_comments .= '</ul>';
+
+		return $list_of_comments;
+	}
+
+	/**
+	 * Generate static metadata to display
+	 * @param  WP_Post $post
+	 * @return string 
+	 *
+	 * @since 0.8
+	 */
+	function activity_feed_view_efmeta( $post ) {
+
+		$editorial_metadata_info = "";
+		$editorial_metadata_table = '<table class="af-ed-metadata"><tbody>';
+		$terms = EditFlow()->editorial_metadata->get_editorial_metadata_terms();
+
+		foreach( $terms as $term ) {
+			if( !$term->viewable )
+				continue;
+
+			$editorial_metadata_value = get_post_meta( $post->ID, '_ef_editorial_meta_' . $term->type . '_' . $term->slug, true );
+			
+			if( empty( $editorial_metadata_value ) )
+				continue;
+
+			$editorial_metadata_info .= '<tr class="af-single-ed-meta">';
+			$editorial_metadata_info .= '<th>' . $term->name . ': </th>';
+			$editorial_metadata_info .= '<td>' . EditFlow()->editorial_metadata->generate_editorial_metadata_term_output( $term, $editorial_metadata_value ) . '</td>';
+			$editorial_metadata_info .= '</tr>';
+		}
+
+		$editorial_metadata_table .= $editorial_metadata_info;
+		$editorial_metadata_table .= '</tbody></table>';
+		
+		if( empty( $editorial_metadata_info ) )
+			return;
+		else
+			return $editorial_metadata_table;
+	}
+
+	/**
+	 * Add a comment to post with ajax.
+	 * @return WP_Ajax_Response
+	 *
+	 * @since 0.8
+	 */
+	function activity_feed_add_comment() {
+		global $current_user;
+
+		$id = absint( $_POST['post_id'] );
+		// Verify nonce
+		if ( !wp_verify_nonce( $_POST['_nonce'], 'comment') )
+			die( __( "Nonce check failed. Please ensure you're supposed to be adding editorial comments.", 'edit-flow' ) );
+
+		get_currentuserinfo();
+
+		//This should be taken care of when calling ajax_insert_comment(),
+		//but it never hurts to be careful
+      	if ( ! current_user_can( $this->edit_cap, $id ) )
+			die( __('Sorry, you don\'t have the privileges to view editorial metadata. Please talk to your Administrator.', 'edit-flow' ) );
+
+     	$comment_id = EditFlow()->editorial_comments->ajax_insert_comment();
+
+		$response = new WP_Ajax_Response();
+		
+		ob_start();
+			$this->activity_feed_widget_init();
+			$posts_and_comments = ob_get_contents();
+		ob_end_clean();
+		
+		$response->add( array(
+			'what' => 'posts_and_comments',
+			'data' => $posts_and_comments,
+			'id' => $comment_id,
+		));
+	
+		$response->send();
+
+		die();
+	}
+} //End Activity Feed widget class
+?>

--- a/modules/dashboard/widgets/activity-feed/lib/activity-feed.css
+++ b/modules/dashboard/widgets/activity-feed/lib/activity-feed.css
@@ -1,0 +1,123 @@
+/* Activity Feed */
+
+.ef-myposts li, #af-inner-wrap li {
+	list-style-type: none;
+	padding-bottom: 5px;
+}
+
+.ef-myposts li a, #af-inner-wrap li a {
+	font-weight: normal;
+}
+
+.ef-myposts li .ef-myposts-timestamp, #af-inner-wrap ul li .af-timestamp {
+	color: #999;
+	font-family: "Lucida Grande",Verdana,Arial,"Bitstream Vera Sans",sans-serif;
+	font-size: 11px;
+}
+
+#af-inner-wrap li h4 .af-status-name {
+	color: #333;
+	font-family: "Lucida Grande",Verdana,Arial,"Bitstream Vera Sans", sans-serif;
+	font-size:12px;
+}
+
+#af-inner-wrap li .af-comment-from {
+	color: #777;
+}
+
+#af-inner-wrap li .af-comment-content {
+	margin: 3px 0px;
+	color: #333;
+	font-family: "Lucida Grande",Verdana,Arial,"Bitstream Vera Sans", sans-serif;
+	font-size:12px;
+}
+
+#af-inner-wrap li .publish {
+	color: red !important
+}
+
+#af-inner-wrap .af-row-actions {
+	margin: .3em 0 0 0;
+}
+
+#af-inner-wrap .af-outer-comment-wrap {
+	background-color: #eee;
+    padding: 6px 0px;
+}
+
+#af-inner-wrap .af-inner-comment-wrap {
+	background-color: white;
+    padding: 6px;
+    margin:0px;
+    border-left: 5px solid #e5e5e5;
+    border-right: 5px solid #e5e5e5;
+    border-top: 1px solid #e5e5e5;
+    border-bottom: 1px solid #e5e5e5;
+}
+
+#af-inner-wrap .af-comment-user-time {
+	margin: 2px 0 0 0;
+    text-align: right;
+    color: #999;
+}
+
+#af-inner-wrap .af-bigger {
+	font-size:14px !important;
+}
+
+#af-inner-wrap #ef-replycontent {
+	width:100%;
+	margin-top:5px;
+}
+
+#af-inner-wrap .ef-replysave {
+	margin-left:3px;
+}
+
+#af-inner-wrap .af-light {
+	color:#999;
+}
+
+.af-row-hidden {
+	visibility:hidden;
+}
+
+.af-row-dont-show {
+	display:none;
+}
+
+.red {
+	color:red;
+}
+
+.ef-metacancel {margin-right:10px !important;}
+
+.af-comment-indent{margin-left:10px;}
+
+/* Taken from editorial-comments.css */
+#af-inner-wrap #ef-comments {
+	margin-bottom: 10px;
+	border-top: 1px solid #e5e5e5;
+	background: #eee;
+}
+
+.hide-af-feed-info{display:none;}
+
+.af-ed-metadata {
+	margin-bottom: 15px;
+}
+
+.af-ed-metadata tr {
+	max-width: 70px;
+	word-wrap: normal;
+}
+
+.af-ed-metadata th {
+	text-align: right;
+	vertical-align: top;
+}
+
+.af-ed-metadata td {
+	padding-left: 10px;
+	padding-left: 10px;
+}

--- a/modules/dashboard/widgets/activity-feed/lib/activity-feed.js
+++ b/modules/dashboard/widgets/activity-feed/lib/activity-feed.js
@@ -1,0 +1,321 @@
+jQuery(document).ready(function ($) {
+	inlineEditorialCommentMeta.init();
+
+	// Check if certain hash flag set and take action
+	if (location.hash == '#editorialcomments/add') {
+		inlineEditorialCommentMeta.open();
+	} else if (location.hash.search(/#editorialcomments\/reply/) > -1) {
+		var reply_id = location.hash.substring(location.hash.lastIndexOf('/')+1);
+		inlineEditorialCommentMeta.open(reply_id);
+	}
+
+});
+
+/**
+ * Blatantly stolen and modified from /wp-admin/js/edit-comment.dev.js -- yay!
+ * Handles inline stuff on the dashboard
+ */
+inlineEditorialCommentMeta = {
+	stored_html: "",
+	container_to_restore: "",
+	view_comment_id: "",
+
+	init : function() {
+		var object_this = this;
+
+		// Bind click events to cancel and submit buttons
+		jQuery('#af-outer-wrap').on('click', 'a.ef-replycancel', function(event) {
+				return object_this.revert();
+			}
+		);
+
+		jQuery('#af-outer-wrap').on('click', 'a.ef-replysave', function(event) {
+				return object_this.send();
+			}
+		);
+
+		jQuery('#af-outer-wrap').on('hover', '.date-pick',  function(event) {
+			if(!jQuery(this).hasClass('hasDatepicker')) {
+				jQuery(this).datetimepicker({
+					dateFormat: 'M dd yy',
+					firstDay: ef_week_first_day,
+					alwaysSetTime: false,
+					controlType: 'select'
+				});
+			}
+		});
+
+		jQuery('#af-outer-wrap').on('mouseenter', '#af-mixed-list li', function(event) {
+				jQuery(this).find('.af-row-actions').removeClass('af-row-hidden');
+			}
+		);
+
+		jQuery('#af-outer-wrap').on('mouseleave', '#af-mixed-list li', function(event) {
+				jQuery(this).find('.af-row-actions').addClass('af-row-hidden');
+			}
+		);
+	},
+
+	revert : function() {
+		var object_this = this; 
+
+		// Fade out slowly, slowly, slowly...
+		jQuery('#ef-replyrow').fadeOut('fast', function(){
+			object_this.close();
+		});
+
+		return false;
+	},
+
+	close : function() {		
+		//Prevent visual bug
+		jQuery('.af-row-actions, .af-row-actions span').show();
+
+		jQuery('#ef-replyrow').hide();
+
+		if(jQuery('#af-active-link').length !== 0)
+			this.closeOutOpenLinksWindows(jQuery('#af-active-link'));
+
+		//If a selector has been stored, restore content
+		if(this.container_to_restore)
+			jQuery(this.container_to_restore).html(this.stored_html);
+
+		if(this.view_comment_id)
+			jQuery(this.view_comment_id).parent().removeClass('af-row-dont-show');
+		
+		// Empty out all the form values
+		jQuery('#ef-replycontent').val('');
+		jQuery('#ef-comment_parent').val('');
+
+		// Hide error and waiting
+		jQuery('#ef-replysubmit .error').html('').hide();
+		jQuery('#ef-comment_loading').hide();
+
+		jQuery('#ef-savecancel-buttons').hide()
+	},
+
+	/**
+	 * @e = event
+	 * @id = comment id
+	 * @post_id = post id
+	 */
+	open : function(e, id, post_id) {
+		var comment_id = (id) ? id : 0;
+		var comment_post_id = (post_id) ? post_id : null;
+		var clicked_id = jQuery(e);
+		var is_post = clicked_id.closest('.af-post, .af-comment').hasClass('post');
+		
+		// Close any open reply boxes
+		this.close();
+
+		if(comment_id)
+			jQuery('#ef-comment_parent').val(comment_id);
+
+		jQuery('#ef-post_id').val(comment_post_id);
+
+		if(is_post || (!is_post && !id)) 
+			jQuery('#ef-replybtn').text('Submit Response'); //It's a post or new comment
+		else 
+			jQuery('#ef-replybtn').text('Submit Reply');  //It's a reply
+		
+		jQuery('#'+clicked_id.closest('.af-post, .af-comment').attr('id'))
+			.append(jQuery('#ef-replyrow').show());
+
+		jQuery(clicked_id.closest('.af-row-actions')).hide();
+
+		return false;
+	},
+
+	/**
+	 * Sends the ajax response to save the commment
+	 * @param bool reply - indicates whether the comment is a reply or not 
+	 */
+	send : function(reply) {
+		var post = {};
+		var object_this = this;
+
+		jQuery('#ef-replysubmit .error').html('').hide();
+		
+		// Validation: check to see if comment entered
+		post.content = jQuery.trim(jQuery('#ef-replycontent').val());
+		if(!post.content) {
+			jQuery('#ef-replyrow .error').html('<span class="red">Please enter a comment</span>').show();
+			return false;
+		}
+		
+		jQuery('#ef-comment_loading').show();
+
+		// Prepare data
+		post.action = 'ef_activity_feed_add_comment';
+		post.parent = (jQuery("#ef-comment_parent").val()=='') ? 0 : jQuery("#ef-comment_parent").val();
+		post._nonce = jQuery("#ef_comment_nonce").val();
+		post.post_id = jQuery("#ef-post_id").val();
+		post.send_response = 'yes';
+
+		// Send the request
+		jQuery.ajax({
+			type : 'POST',
+			url : (ajaxurl) ? ajaxurl : wpListL10n.url,
+			data : post,
+			success : function(x) { object_this.show(x); },
+			error : function(r) { object_this.error(r); }
+		});
+
+		return false;
+	},
+
+	show : function(xml) {
+		var response, widget_html;
+		
+		// Didn't pass validation, so let's throw an error
+		if ( typeof(xml) == 'string' ) {
+			this.error({'responseText': xml});
+			return false;
+		}
+		
+		// Parse the response
+		response = wpAjax.parseAjaxResponse(xml);
+		if ( response.errors ) {
+			// Uh oh, errors found
+			this.error({'responseText': wpAjax.broken});
+			return false;
+		}
+		
+		response = response.responses[0];
+		widget_html = response.data;
+		
+		jQuery('#af-inner-wrap').replaceWith(widget_html);
+		jQuery('#af-inner-wrap').animate({'opacity': '0'}, 0).animate({'opacity': '1'},400)
+	},
+
+	viewContent: function(e){
+
+		//We've encountered a new link!
+		if( jQuery(e).attr('id') !== 'af-active-link') {
+			//close everything out
+			this.close()
+			//Can we find an active link?
+			if(jQuery('#af-active-link').length !== 0) {
+				this.closeOutOpenLinksWindows(jQuery('#af-active-link'));
+				this.closeOutOpenLinksWindows(jQuery(e));
+			} else {
+				this.closeOutOpenLinksWindows(jQuery(e));
+			}
+			
+		}
+		else {
+			this.closeOutOpenLinksWindows(jQuery(e));
+		}
+	},
+
+	closeOutOpenLinksWindows: function(being_clicked) {
+		var current_text;
+		var init_box;
+		var list_items;
+		var being_clicked_class = being_clicked.parent().attr('class');
+		//Can these be localized?
+		//Possibly better comparisons?
+
+		switch(being_clicked_class) {
+			case 'af-view-meta':
+				var current_process = (being_clicked_class == 'af-edit-meta') ? af_widget_text_labels.edit_metadata : af_widget_text_labels.view_metadata;
+				var find_class = (being_clicked_class == 'af-edit-meta') ? '.af-edit-metadata' : '.af-view-metadata';
+
+				//It's an editable metadata. Whats the current links text?
+				current_text = jQuery(being_clicked).text();
+				if(current_text == current_process) {
+					jQuery(being_clicked).text(af_widget_text_labels.hide_metadata);
+					jQuery(being_clicked).attr('id', 'af-active-link');
+					
+					init_box = jQuery(being_clicked).closest('.af-post, .af-comment')
+						.find(find_class);
+					
+					init_box.clone()
+						.appendTo(init_box.parent())
+						.removeClass('hide-af-feed-info')
+						.attr('id', 'af-active-element')
+					
+					if(being_clicked_class == 'af-edit-meta')
+						jQuery('#ef-savecancel-buttons').appendTo(init_box.parent()).show();
+				}
+				else {
+					jQuery(being_clicked).text(current_process)
+
+					jQuery(being_clicked).attr('id', '');
+					jQuery(being_clicked).closest('.af-post, .af-comment')
+						.find('#af-active-element')
+						.remove();
+					jQuery('#ef-savecancel-buttons').hide();
+				}
+			break;
+			case 'af-comment-parent':
+			case 'af-comment-children':
+				var clone_item;
+				var anchor_li;
+				var current_text = jQuery(being_clicked).text();
+				var num_parents_counted = 0;
+				var num_list_items = 0;
+				var list_to_attach_to;
+				var hide_item = (being_clicked_class == 'af-comment-parent') ? af_widget_text_labels.hide_parents : af_widget_text_labels.hide_children;
+				var show_item = (being_clicked_class == 'af-comment-parent') ? af_widget_text_labels.show_parents : af_widget_text_labels.show_children;
+				var lists_to_find = (being_clicked_class == 'af-comment-parent') ? '.af-show-parents li' : '.af-show-children li';
+
+				if(current_text == show_item) {
+					jQuery(being_clicked).text(hide_item).attr('id', 'af-active-link')
+
+					list_items = jQuery(being_clicked).closest('.af-post, .af-comment')
+						.find(lists_to_find);				
+					list_to_attach_to = jQuery(being_clicked).closest('.af-post, .af-comment')
+						.find('.af-outer-comment-wrap');
+
+					anchor_li = list_to_attach_to.find('li');
+					num_list_items = list_items.length;
+
+					list_items.each(function(i, val) {
+						if(being_clicked_class == 'af-comment-parent') {
+							clone_item = jQuery(this).clone().css('margin-left', (num_list_items - 1) * 10).addClass('active-list-item');
+							jQuery(clone_item).prependTo(list_to_attach_to);
+							num_list_items -= 1;
+						}
+						else {
+							clone_item = jQuery(this).clone().css('margin-left', (1 + i) * 10).addClass('active-list-item');
+							jQuery(clone_item).appendTo(list_to_attach_to);
+						}
+						
+						num_parents_counted += i;
+					});
+
+					if(being_clicked_class == 'af-comment-parent')
+						anchor_li.css('margin-left', (num_parents_counted + 1) * 10);
+				}
+				else {
+					var ul;
+					var anchor_li; 
+
+					jQuery(being_clicked).attr('id', '').text(show_item);
+
+					ul = jQuery(being_clicked).closest('.af-post, .af-comment')
+						.find('.af-outer-comment-wrap');
+
+					anchor_li = ul.find('.af-anchor-li');
+					ul.empty().append(anchor_li);
+
+					anchor_li.css('margin-left', '');
+				}
+			break;
+		}
+	},
+
+	error : function(r) {
+		// Oh noes! We haz an error!
+		jQuery('#ef-comment_loading').hide();
+
+		if ( r.responseText ) {
+			er = r.responseText.replace( /<.[^<>]*?>/g, '' );
+		}
+
+		if ( er ) {
+			jQuery('#ef-replysubmit .error').html(er).show();
+		}
+	}
+};

--- a/modules/editorial-comments/editorial-comments.php
+++ b/modules/editorial-comments/editorial-comments.php
@@ -185,12 +185,13 @@ class EF_Editorial_Comments extends EF_Module
 	/**
 	 * Displays the main commenting form
 	 */
-	function the_comment_form( ) {
+	function the_comment_form( $dashboard = false ) {
 		global $post;
-		
+		$post_id = ($dashboard) ? "" : esc_attr($post->ID);
 		?>
-		<a href="#" id="ef-comment_respond" onclick="editorialCommentReply.open();return false;" class="button-primary alignright hide-if-no-js" title=" <?php _e( 'Respond to this post', 'edit-flow' ); ?>"><span><?php _e( 'Respond to this Post', 'edit-flow' ); ?></span></a>
-		
+		<?php if(!$dashboard) { ?>
+			<a href="#" id="ef-comment_respond" onclick="editorialCommentReply.open();return false;" class="button-primary alignright hide-if-no-js" title=" <?php _e( 'Respond to this post', 'edit-flow' ); ?>"><span><?php _e( 'Respond to this Post', 'edit-flow' ); ?></span></a>
+		<?php } ?>
 		<!-- Reply form, hidden until reply clicked by user -->
 		<div id="ef-replyrow" style="display: none;">
 			<div id="ef-replycontainer">
@@ -208,7 +209,7 @@ class EF_Editorial_Comments extends EF_Module
 			</p>
 		
 			<input type="hidden" value="" id="ef-comment_parent" name="ef-comment_parent" />
-			<input type="hidden" name="ef-post_id" id="ef-post_id" value="<?php echo esc_attr( $post->ID ); ?>" />
+			<input type="hidden" name="ef-post_id" id="ef-post_id" value="<?php echo $post_id ?>" />
 			
 			<?php wp_nonce_field('comment', 'ef_comment_nonce', false); ?>
 			
@@ -291,10 +292,16 @@ class EF_Editorial_Comments extends EF_Module
       	// Set up comment data
 		$post_id = absint( $_POST['post_id'] );
 		$parent = absint( $_POST['parent'] );
+		if($_POST['send_response'] == 'no' ) 
+			$send_response = false;
+		else if($_POST['send_response'] == 'yes')
+			$send_response = true;
+		else
+			$send_response = false;
       	
       	// Only allow the comment if user can edit post
       	// @TODO: allow contributers to add comments as well (?)
-		if ( ! current_user_can( 'edit_post', $post_id ) )
+		if ( ! current_user_can( 'edit_post', $_POST['post_id'] ) )
 			die( __('Sorry, you don\'t have the privileges to add editorial comments. Please talk to your Administrator.', 'edit-flow' ) );
 		
 		// Verify that comment was actually entered
@@ -330,6 +337,12 @@ class EF_Editorial_Comments extends EF_Module
 			
 			// Insert Comment
 			$comment_id = wp_insert_comment($data);
+
+			if($send_response){
+				return $comment_id;
+				die();
+			}
+
 			$comment = get_comment($comment_id);
 			
 			// Register actions -- will be used to set up notifications and other modules can hook into this
@@ -440,7 +453,6 @@ class EF_Editorial_Comments extends EF_Module
 
 		return $calendar_fields;
 	}
-
 }
 
 }

--- a/modules/editorial-comments/lib/editorial-comments.js
+++ b/modules/editorial-comments/lib/editorial-comments.js
@@ -101,6 +101,7 @@ editorialCommentReply = {
 		post.parent = (jQuery("#ef-comment_parent").val()=='') ? 0 : jQuery("#ef-comment_parent").val();
 		post._nonce = jQuery("#ef_comment_nonce").val();
 		post.post_id = jQuery("#ef-post_id").val();
+		post.send_response = 'no';
 		
 		// Send the request
 		jQuery.ajax({

--- a/modules/notifications/notifications.php
+++ b/modules/notifications/notifications.php
@@ -807,6 +807,11 @@ jQuery(document).ready(function($) {
 		if ( ! is_array( $users ) )
 			$users = array( $users );
 
+		// Clean up data we're using
+		$post_id = ( is_int($post) ) ? $post : $post->ID;
+
+		if( !is_array($users) ) $users = array($users);
+
 		$user_terms = array();
 		foreach( $users as $user ) {
 
@@ -1023,7 +1028,7 @@ jQuery(document).ready(function($) {
 	 * @param array $args  
 	 * @return array $posts Posts a user is following
 	 */
-	function get_user_following_posts( $user = 0, $args = null ) {
+	function get_user_following_posts( $user = 0, $args = array() ) {
 		if ( !$user )
 			$user = (int) wp_get_current_user()->ID;
 
@@ -1043,12 +1048,45 @@ jQuery(document).ready(function($) {
 			'order' => 'DESC',
 			'post_status' => 'any',
 		);
+		$post_args = array_merge( $post_args, $args );
 		$post_args = apply_filters( 'ef_user_following_posts_query_args', $post_args );
 		$posts = get_posts( $post_args );
 		return $posts;
 
 	}
-	
+
+	/**
+	 * Get comments from posts the user is following, orderd
+	 * by most recent. Necessary in order to get comments from posts
+	 * the user is following by most recent. 
+	 * 
+	 * @param  string $user_name Name of user
+	 * @param  int $num_of_comments Number of comments to return
+	 * @return array $most_recent_comments Comments to return
+	 */
+	public function get_user_following_comments( $num_comments ) {
+		global $wpdb;
+		$current_user = wp_get_current_user()->user_login;
+
+		//This query grew up on the wrong side of the tracks
+		$recent_comments = $wpdb->get_results (
+				$wpdb->prepare(
+						"
+						SELECT wp_comments.comment_ID,wp_comments.comment_content, wp_comments.comment_date, wp_comments.comment_author, wp_comments.comment_parent, wp_comments.comment_post_ID FROM $wpdb->posts 
+						JOIN $wpdb->term_relationships AS wtr ON wp_posts.ID = wtr.object_id 
+						JOIN $wpdb->term_taxonomy AS wtt ON wtt.taxonomy = 'following_users' AND wtr.term_taxonomy_id = wtt.term_taxonomy_id 
+						JOIN $wpdb->terms ON wp_terms.term_id = wtt.term_taxonomy_id AND wp_terms.name = %s 
+						JOIN $wpdb->comments ON wp_posts.ID = wp_comments.comment_post_ID AND wp_comments.comment_type = 'editorial-comment'
+						ORDER BY wp_comments.comment_date DESC LIMIT %d;
+						",
+						$current_user, $num_comments
+					)
+			);
+
+		return $recent_comments;
+
+	}
+
 	/**
 	 * Register settings for notifications so we can partially use the Settings API
 	 * (We use the Settings API for form generation, but not saving)


### PR DESCRIPTION
This is the first go at fixing #120. It solves the following issues and adds some of the following functionality:
- Shows unpublished and published posts, makes visual distinction between two
- Shows editorial comments on posts your following
- Allows posting of comments on new stories
- Allows posting new or reply comments on editorial comments on posts
- Allows the viewing of an editorial comment conversation up to two parent comments
- Denotes the difference between new comments on a post and comments that are replies

Things to note:
- I ended up moving this widget to its own class just given the amount of extra functionality it required. Could probably crunch it all down into one function if that makes more sense.
-  I created an entirely new javascript object to handle the posting of comments and viewing of comment history from this widget. Could instead add this functionality to the existing javascript object for handling ajax comment posting, and just add that js file to this widget
- I ended up having to construct some odd sql query to fetch the comments that the user is following, given that I thought of it as the following logic: "Get all the recent comments on posts that the user is following." You could get recent comments or recent posts, but I couldn't see a way to use a standard function (get_post or get_comment), to get recent comments on posts that the user is following. "The user is following" is a bit of a curveball in terms of comment retrieval.
- The widget overall might have too much going on. I guess it would come down to whether people find it more worthwhile to be presented with all their recent "activity," instead of recent posts or recent comments in separate widgets (or toggled in some fashion). Not sure.
