### PR TITLE
Initial commit for ajax capabilities in saving checkboxes in the notific...

### DIFF
--- a/modules/notifications/lib/notifications.css
+++ b/modules/notifications/lib/notifications.css
@@ -44,6 +44,10 @@
 		-moz-border-radius: 3px;
 	}
 
+	#ef-post_following_box .error{
+		color:red;
+	}
+
 	#ef-post_following_box label.ef-select_all_box {
 		float: right;
 		margin: -20px 10px;

--- a/modules/notifications/lib/notifications.js
+++ b/modules/notifications/lib/notifications.js
@@ -10,6 +10,7 @@ jQuery(document).ready(function($) {
 		var user_group_ids = [];
 		var parent_this = $(this);
 		params.ef_notifications_name = $(this).attr('name');
+		params._nonce = $("#ef_notifications_nonce").val();
 
 		$(this)
 			.parent()
@@ -26,9 +27,13 @@ jQuery(document).ready(function($) {
 			type : 'POST',
 			url : (ajaxurl) ? ajaxurl : wpListL10n.url,
 			data : params,
-			success : function(x) { },
+			success : function(x) { 
+				$(parent_this.parent().parent())
+					.animate( { 'backgroundColor':'#CCEEBB' }, 200 )
+					.animate( { 'backgroundColor':'#fff' }, 200 );
+			},
 			error : function(r) { 
-				$('#ef-post_following_users_box').prev().insertAfter('There was an error. Please reload the page.');
+				$('#ef-post_following_users_box').prev().append(' <p class="error">There was an error. Please reload the page.</p>');
 			}
 		});
 	});

--- a/modules/notifications/notifications.php
+++ b/modules/notifications/notifications.php
@@ -248,6 +248,7 @@ class EF_Notifications extends EF_Module {
 			<?php endif; ?>
 			<div class="clear"></div>
 			<input type="hidden" name="ef-save_followers" value="1" /> <?php // Extra protection against autosaves ?>
+			<?php wp_nonce_field('save_user_usergroups', 'ef_notifications_nonce', false); ?>
 		</div>
 		
 		<?php
@@ -257,10 +258,14 @@ class EF_Notifications extends EF_Module {
 	 * Called when a notification editorial metadata checkbox is checked. Handles saving of a user/usergroup to a post.
 	 */
 	function ajax_save_post_subscriptions() {
-		global $wpdb, $edit_flow;
+		global $edit_flow;
 		
+		// Verify nonce
+		if ( !wp_verify_nonce( $_POST['_nonce'], 'save_user_usergroups') )
+			die( __( "Nonce check failed. Please ensure you can add users or user groups to a post.", 'edit-flow' ) );
+
 		$post_id = (int)$_POST['post_id'];
-		$user_usergroup_ids = $_POST['user_group_ids'];
+		$user_usergroup_ids = array_map( 'intval', $_POST['user_group_ids'] );
 		if( ( !wp_is_post_revision( $post_id ) && !wp_is_post_autosave( $post_id ) )  && current_user_can( $this->edit_post_subscriptions_cap ) ) {
 			if( $_POST['ef_notifications_name'] === 'ef-selected-users[]' ) {
 				$this->save_post_following_users( $post_id, $user_usergroup_ids );


### PR DESCRIPTION
...ations editorial metadata.

This is the initial commit for saving users/usergroups to a post with ajax (related to #159). Might be worthwhile to add some sort of visual cue so users know a user/usergroup was saved correctly (maybe animate the background like when an editorial comment is added?).
