### PR TITLE
Filters on budget

### DIFF
--- a/modules/story-budget/story-budget.php
+++ b/modules/story-budget/story-budget.php
@@ -597,7 +597,6 @@ class EF_Story_Budget extends EF_Module {
 	 * Print the table navigation and filter controls, using the current user's filters if any are set.
 	 */
 	function table_navigation() {
-		$post_statuses = $this->get_post_statuses();
 	?>
 	<div class="tablenav" id="ef-story-budget-tablenav">
 		<div class="alignleft actions">
@@ -719,6 +718,7 @@ class EF_Story_Budget extends EF_Module {
 	function story_budget_filter_options( $select_id, $select_name, $filters ) {
 		switch( $select_id ) {
 			case 'post_status': 
+			$post_statuses = $this->get_post_statuses();
 			?>
 				<select id="post_status" name="post_status"><!-- Status selectors -->
 						<option value=""><?php _e( 'View all statuses', 'edit-flow' ); ?></option>


### PR DESCRIPTION
This is the same sort of code from the calendar applied to the budget to fix issue #105. This pull requests gives the user the ability to add any number of select elements to the top navigation in the budget.

The only significant difference between the code from the calendar and this code is how the user needs to deal with the 'posts_query_args_filter'. In the calendar, the filter would be applied like so:

```
function add_genre_query($args){
    if(!empty($_GET['genre'])){
        $args['tax_query'] = array (
            array (
                    'taxonomy' => 'genre',
                    'field' => 'slug',
                    'terms' => esc_attr($_GET['genre']),
                ),
        );
    }
    return $args;
}
```

Now, it should look something like this:

```
function sb_add_genre_query($args){
    if(!empty($_GET['genre'])){
        $temp_args = $args['tax_query'];
        $temp_args[] =  array (
                            'taxonomy' => 'genre',
                            'field' => 'slug',
                            'terms' => esc_attr($_GET['genre']),
                        );
        $args['tax_query'] = $temp_args;
    }
    return $args;
}
```

The budget relies on using the category taxonomy to organize stories, so someone who wants to utilize the posts_query_filter would need to just add another taxonomy array so they don't overwrite the taxonomy array for category.
