### PR TITLE
Removed $supported_post_types from get_filters()

### DIFF
--- a/modules/calendar/calendar.php
+++ b/modules/calendar/calendar.php
@@ -334,16 +334,14 @@ class EF_Calendar extends EF_Module {
 	 * @return array $filters All of the set or saved calendar filters
 	 */
 	function get_filters() {
-		
-		$supported_post_types = $this->get_post_types_for_module( $this->module );
-		
+				
 		$current_user = wp_get_current_user();
 		$filters = array();
 		$old_filters = $this->get_user_meta( $current_user->ID, self::usermeta_key_prefix . 'filters', true );
 
 		$default_filters = array(
 				'post_status' => '',
-				'cpt' => $supported_post_types,
+				'cpt' => '',
 				'cat' => '',
 				'author' => '',
 				'start_date' => date( 'Y-m-d', current_time( 'timestamp' ) ),


### PR DESCRIPTION
Removed the $supported_post_types variable from get_filters() to fix #166. The responsibility for determining if a post_type is legit exists in [get_calendar_posts_for_week()](https://github.com/danielbachhuber/Edit-Flow/blob/master/modules/calendar/calendar.php#L925). 
