### PR TITLE
Quick-post post-type setting

### DIFF
--- a/common/php/class-module.php
+++ b/common/php/class-module.php
@@ -27,6 +27,25 @@ class EF_Module {
 	}
 
 	/**
+	 * Gets an array of allowed post types for a module
+	 * 
+	 * @return array post-type-slug => post-type-label
+	 */
+	function get_all_post_types() {
+
+		$allowed_post_types = array(
+			'post' => __( 'Post' ),
+			'page' => __( 'Page' ),
+		);
+		$custom_post_types = $this->get_supported_post_types_for_module();
+		
+		foreach( $custom_post_types as $custom_post_type => $args ) {
+			$allowed_post_types[$custom_post_type] = $args->label;
+		}
+		return $allowed_post_types;
+	}
+
+	/**
 	 * Cleans up the 'on' and 'off' for post types on a given module (so we don't get warnings all over)
 	 * For every post type that doesn't explicitly have the 'on' value, turn it 'off'
 	 * If add_post_type_support() has been used anywhere (legacy support), inherit the state
@@ -39,9 +58,7 @@ class EF_Module {
 	 */
 	function clean_post_type_options( $module_post_types = array(), $post_type_support = null ) {
 		$normalized_post_type_options = array();
-		$all_post_types = wp_list_pluck( $this->get_supported_post_types_for_module(), 'name' );
-		array_push( $all_post_types, 'post', 'page' );
-		$all_post_types = array_merge( $all_post_types, array_keys( $module_post_types ) );
+		$all_post_types = array_keys( $this->get_all_post_types() );
 		foreach( $all_post_types as $post_type ) {
 			if ( ( isset( $module_post_types[$post_type] ) && $module_post_types[$post_type] == 'on' ) || post_type_supports( $post_type, $post_type_support ) )
 				$normalized_post_type_options[$post_type] = 'on';

--- a/modules/calendar/calendar.php
+++ b/modules/calendar/calendar.php
@@ -1107,36 +1107,12 @@ class EF_Calendar extends EF_Module {
 	 */
 	function settings_quick_create_post_type_option() {
 		
-		$allowed_post_types = $this->get_allowed_post_types();
+		$allowed_post_types = $this->get_all_post_types();
 
 		echo "<select name='" . $this->module->options_group_name . "[quick_create_post_type]'>";
 		foreach( $allowed_post_types as $post_type => $title ) 
 			echo "<option value='" . esc_attr( $post_type ) . "' " . selected( $post_type, $this->module->options->quick_create_post_type, false ) . ">".esc_html( $title )."</option>";
 		echo "</select>";
-
-	}
-
-	/**
-	 * Gets an array of allowed post types that can be created for the calendar. 
-	 * 
-	 * @return array post-type-slug => post-type-label
-	 */
-	function get_allowed_post_types(){
-
-		global $edit_flow;
-
-		$allowed_post_types = array(
-			'post' => __( 'Post' ),
-			'page' => __( 'Page' ),
-		);
-
-		$custom_post_types = $edit_flow->settings->get_supported_post_types_for_module();
-		
-		foreach( $custom_post_types as $custom_post_type => $args ) {
-			$allowed_post_types[$custom_post_type] = $args->label;
-		}
-
-		return $allowed_post_types;
 
 	}
 
@@ -1156,22 +1132,15 @@ class EF_Calendar extends EF_Module {
 	 * @since 0.7
 	 */
 	function settings_validate( $new_options ) {
-		
-		// Whitelist validation for the post type options
-		if ( !isset( $new_options['post_types'] ) )
-			$new_options['post_types'] = array();
 
-		$new_options['post_types'] = $this->clean_post_type_options( $new_options['post_types'], $this->module->post_type_support );
+		$options = (array)$this->module->options;
 
-		// Whitelist validation for the quick_create_post_type option
-		if( 
-			! isset( $new_options['quick_create_post_type'] ) 
-			|| ! in_array( $new_options['quick_create_post_type'], array_keys( $this->get_allowed_post_types() ) ) 
-		) {
-			$new_options['quick_create_post_type'] = 'post';
-		}
+		$options['post_types'] = $this->clean_post_type_options( $new_options['post_types'], $this->module->post_type_support );
 
-		return $new_options;
+		if ( in_array( $new_options['quick_create_post_type'], array_keys( $this->get_all_post_types() ) ) )
+			$options['quick_create_post_type'] = $new_options['quick_create_post_type'];
+
+		return $options;
 	}
 	
 	/**


### PR DESCRIPTION
Adds a setting to let users specify what type of post should be created
using the 'quick post' feature of the calendar
