### PR TITLE
Don't allow display or update of user groups from network users page.

### DIFF
--- a/modules/user-groups/user-groups.php
+++ b/modules/user-groups/user-groups.php
@@ -640,6 +640,10 @@ class EF_User_Groups extends EF_Module {
 		
 		if ( !$user_id || !current_user_can( $this->manage_usergroups_cap ) )
 			return;
+
+		//Don't allow display of user groups from network
+		if( get_current_screen()->is_network )
+			return;
 		
 		// Assemble all necessary data
 		$usergroups = $this->get_usergroups();
@@ -683,6 +687,10 @@ class EF_User_Groups extends EF_Module {
 		
 		if ( !$update )
 			return array( &$errors, $update, &$user );
+
+		//Don't allow update of user groups from network
+		if( get_current_screen()->is_network )
+			return;
 
 		if ( current_user_can( $this->manage_usergroups_cap ) && wp_verify_nonce( $_POST['ef_edit_profile_usergroups_nonce'], 'ef_edit_profile_usergroups_nonce' ) ) {
 			// Sanitize the data and save


### PR DESCRIPTION
A fix for #115. When the user is on the network admin user administration page, don't allow display or update of user groups.
