### PR TITLE
add editorial meta data content to table view for cpt

### DIFF
--- a/modules/editorial-metadata/editorial-metadata.php
+++ b/modules/editorial-metadata/editorial-metadata.php
@@ -100,7 +100,7 @@ class EF_Editorial_Metadata extends EF_Module {
 		$supported_post_types = $this->get_post_types_for_module( $this->module );
 		foreach( $supported_post_types as $post_type ) {
 			add_filter( "manage_{$post_type}_posts_columns", array( $this, 'filter_manage_posts_columns' ) );
-			add_action( 'manage_posts_custom_column', array( $this, 'action_manage_posts_custom_column' ), 10, 2 );
+			add_action( "manage_{$post_type}_posts_custom_column", array( $this, 'action_manage_posts_custom_column' ), 10, 2 );
 		}
 		
 		// Add Editorial Metadata to the calendar if the calendar is activated


### PR DESCRIPTION
add editorial meta data content to the edit.php table view for custom post types, previously it was displaying empty cells.
