### PR TITLE
Fix issue where auto setting a usergroup to follow a post creates a new usergroup based off of the usergroups id

### DIFF
--- a/modules/notifications/notifications.php
+++ b/modules/notifications/notifications.php
@@ -884,8 +884,6 @@ jQuery(document).ready(function($) {
 	 *
 	 */
 	function follow_post_usergroups( $post, $usergroups = 0, $append = true ) {
-		global $edit_flow;
-		
 		if ( !$this->module_enabled( 'user_groups' ) )
 			return;
 
@@ -893,13 +891,12 @@ jQuery(document).ready(function($) {
 		if( !is_array($usergroups) )
 			$usergroups = array($usergroups);
 
-		$usergroup_terms = array();
-		
-		foreach( $usergroups as $usergroup ) {
-			// Name and slug of term is the usergroup slug
-			$usergroup_data = $edit_flow->user_groups->get_usergroup_by( 'id', $usergroup ); 
+		// make sure each usergroup id is an integer and not a number stored as a string
+		foreach( $usergroups as $key => $usergroup ) {
+			$usergroups[$key] = intval($usergroup);
 		}
-		$set = wp_set_object_terms( $post_id, $usergroups, $this->following_usergroups_taxonomy, $append );
+
+		wp_set_object_terms( $post_id, $usergroups, $this->following_usergroups_taxonomy, $append );
 		return;
 	}
 	


### PR DESCRIPTION
...s and force usergroup IDs to be integers

$user_group->term_id returns an ID of the term as a string and when wp_set_object_terms is run it creates a new group with that ID name instead of finding the term. The fix is to force each of the $usergroup values to be an integer.
