### PR TITLE
Use 16x16 icon in admin menu

### DIFF
--- a/common/css/edit-flow-admin.css
+++ b/common/css/edit-flow-admin.css
@@ -1,0 +1,5 @@
+/* Admin menu icon size */
+#adminmenu .toplevel_page_ef-settings .wp-menu-image img {
+	width: 16px;
+	height: 16px;
+}

--- a/edit_flow.php
+++ b/edit_flow.php
@@ -326,6 +326,8 @@ class edit_flow {
 	 * Registers commonly used scripts + styles for easy enqueueing
 	 */	
 	function register_scripts_and_styles() {
+		wp_enqueue_style( 'ef-admin-css', EDIT_FLOW_URL . 'common/css/edit-flow-admin.css', false, EDIT_FLOW_VERSION, 'all' );
+
 		wp_register_script( 'jquery-listfilterizer', EDIT_FLOW_URL . 'common/js/jquery.listfilterizer.js', array( 'jquery' ), EDIT_FLOW_VERSION, true );
 		wp_register_style( 'jquery-listfilterizer', EDIT_FLOW_URL . 'common/css/jquery.listfilterizer.css', false, EDIT_FLOW_VERSION, 'all' );
 


### PR DESCRIPTION
The 32px icon that's being included now does not look right in the admin menu:
![screen shot 2013-09-25 at 4 42 34 pm](https://f.cloud.github.com/assets/1437322/1214437/9b28acb4-263e-11e3-9d79-f68bb5211120.png)
