### PR TITLE
Fix issue with previewing posts with custom statuses.

### DIFF
--- a/modules/custom-status/custom-status.php
+++ b/modules/custom-status/custom-status.php
@@ -104,7 +104,6 @@ class EF_Custom_Status extends EF_Module {
 		add_action( 'wp_insert_post', array( $this, 'fix_post_name' ), 10, 2 );
 		add_action( 'edit_form_after_title', array( $this, 'action_edit_form_after_title' ) );
 		add_filter( 'editable_slug', array( $this, 'fix_editable_slug' ) );
-		add_filter( 'preview_post_link', array( $this, 'fix_preview_link_part_one' ) );
 		add_filter( 'post_link', array( $this, 'fix_preview_link_part_two' ), 10, 3 );
 		add_filter( 'page_link', array( $this, 'fix_preview_link_part_two' ), 10, 3 );
 		add_filter( 'post_type_link', array( $this, 'fix_preview_link_part_two' ), 10, 3 );
@@ -1416,46 +1415,6 @@ class EF_Custom_Status extends EF_Module {
 
 		return $slug;
 
-	}
-
-	/**
-	 * Another hack! hack! hack! until core better supports custom statuses
-	 *
-	 * @since 0.7.4
-	 *
-	 * The preview link for an unpublished post should always be ?p=
-	 */
-	public function fix_preview_link_part_one( $preview_link ) {
-		global $pagenow;
-
-		$post = get_post( get_the_ID() );
-
-		// Only modify if we're using a pre-publish status on a supported custom post type
-		$status_slugs = wp_list_pluck( $this->get_custom_statuses(), 'slug' );
-		if ( ! $post
-			|| ! is_admin()
-			|| 'post.php' != $pagenow
-			|| ! in_array( $post->post_status, $status_slugs ) 
-			|| ! in_array( $post->post_type, $this->get_post_types_for_module( $this->module ) ) )
-			return $preview_link;
-
-		if ( 'page' == $post->post_type ) {
-			$args = array(
-					'page_id'    => $post->ID,
-				);
-		} else if ( 'post' == $post->post_type ) {
-			$args = array(
-					'p'          => $post->ID,
-				);
-		} else {
-			$args = array(
-					'p'          => $post->ID,
-					'post_type'  => $post->post_type,
-				);
-		}
-		$args['preview'] = 'true';
-		$preview_link = add_query_arg( $args, home_url() );
-		return $preview_link;
 	}
 
 	/**


### PR DESCRIPTION
This is a possible fix for issue #206. It looks like the other function fix_preview_link_part_two is still necessary in order to preview and set custom statuses correctly.
