### PR TITLE
Fix PHP notice: PHP Strict standards: Only variables should be assigned ...

### DIFF
--- a/common/php/class-module.php
+++ b/common/php/class-module.php
@@ -561,7 +561,7 @@ class EF_Module {
 		global $wp_roles;
 		
 		if ( $wp_roles->is_role( $role ) ) {
-			$role =& get_role( $role );
+			$role = &get_role( $role );
 			foreach ( $caps as $cap )
 				$role->add_cap( $cap );
 		}


### PR DESCRIPTION
...by reference

Fix PHP Notice:

PHP Strict standards: Only variables should be assigned by reference in add_caps_to_role() on line 564
