### PR TITLE
PHP 5.2 compatibility (ternary operator)

### DIFF
--- a/modules/calendar/calendar.php
+++ b/modules/calendar/calendar.php
@@ -1553,7 +1553,7 @@ class EF_Calendar extends EF_Module {
 		$post_type_slug = $this->module->options->quick_create_post_type;
 		$post_type_obj = get_post_type_object( $post_type_slug );
 
-		return $post_type_obj->labels->singular_name ?: $post_type_slug;
+		return $post_type_obj->labels->singular_name ? $post_type_obj->labels->singular_name : $post_type_slug;
 	}
 
 	/**


### PR DESCRIPTION
PHP 5.2 does not support the dyadic form of the ternary operator (`expr1 ?: expr2`).  This single instance is the only compatibility problem with PHP 5.2 I've run into so far.
