### PR TITLE
Preview link broken for posts assigned a custom status

### DIFF
--- a/modules/custom-status/custom-status.php
+++ b/modules/custom-status/custom-status.php
@@ -1453,23 +1453,7 @@ class EF_Custom_Status extends EF_Module {
 			|| ! in_array( $post->post_type, $this->get_post_types_for_module( $this->module ) ) )
 			return $preview_link;
 
-		if ( 'page' == $post->post_type ) {
-			$args = array(
-					'page_id'    => $post->ID,
-				);
-		} else if ( 'post' == $post->post_type ) {
-			$args = array(
-					'p'          => $post->ID,
-				);
-		} else {
-			$args = array(
-					'p'          => $post->ID,
-					'post_type'  => $post->post_type,
-				);
-		}
-		$args['preview'] = 'true';
-		$preview_link = add_query_arg( $args, home_url() );
-		return $preview_link;
+		return $this->get_preview_link( $post );
 	}
 
 	/**
@@ -1505,8 +1489,16 @@ class EF_Custom_Status extends EF_Module {
 			&& !isset( $_POST['wp-preview'] ) )
 			return $permalink;
 
-		//Ok, so it looks like we're calling get_permalink on a non-published post
-		//Let's actually do some stuff then.
+		return $this->get_preview_link( $post );
+	}
+
+	/**
+	 * Get the proper preview link for a post
+	 * 
+	 * @since 0.8
+	 */
+	private function get_preview_link( $post ) {
+
 		if ( 'page' == $post->post_type ) {
 			$args = array(
 					'page_id'    => $post->ID,


### PR DESCRIPTION
Both [core](http://core.trac.wordpress.org/browser/trunk/src/wp-admin/includes/meta-boxes.php#L45) and the calendar apply the `preview_post_link` filter to the permalink. 

Edit Flow was using this filter to correct the preview link, but @cojennin removed that in ac462ad for reasons that aren't communicated in the changeset.
