### PR TITLE
Fix PHP notice: Undefined variable: wp_post_statuss

### DIFF
--- a/modules/custom-status/custom-status.php
+++ b/modules/custom-status/custom-status.php
@@ -557,12 +557,12 @@ class EF_Custom_Status extends EF_Module {
 
 		// If this post type doesn't support custom statuses, we should return WP default in our format.
 		if ( $disable_custom_statuses ) {
-			$draft = isset( $wp_post_statuses['draft'] ) ? $wp_post_statuss['draft'] : new stdClass();
+			$draft = isset( $wp_post_statuses['draft'] ) ? $wp_post_statuses['draft'] : new stdClass();
 			$draft->slug = 'draft';
 			$draft->position = 1;
 			$draft->name = 'Draft';
 
-			$pending = isset( $wp_post_statuses['pending'] ) ? $wp_post_statuss['pending'] : new stdClass();
+			$pending = isset( $wp_post_statuses['pending'] ) ? $wp_post_statuses['pending'] : new stdClass();
 			$pending->slug = 'pending';
 			$pending->position = 2;
 			$pending->name = 'Pending Review';


### PR DESCRIPTION
```
[09-Dec-2013 23:26:32 UTC] PHP Notice:  Undefined variable: wp_post_statuss in /srv/www/vocativ.dev/content/plugins/edit-flow/modules/custom-status/custom-status.php on line 565
[09-Dec-2013 23:26:32 UTC] PHP Warning:  Creating default object from empty value in /srv/www/vocativ.dev/content/plugins/edit-flow/modules/custom-status/custom-status.php on line 566
```

Introduced in 39969cfd48f8cb1220e12f251bdee4e70d6454a0
