### PR TITLE
Keep js on calendar to prevent conflicts with other plugins/themes.

### DIFF
--- a/modules/calendar/calendar.php
+++ b/modules/calendar/calendar.php
@@ -189,6 +189,10 @@ class EF_Calendar extends EF_Module {
 	 * @uses wp_enqueue_script()
 	 */
 	function enqueue_admin_scripts() {
+		global $pagenow;
+		// Only load calendar scripts on the calendar page
+		if ( $pagenow != 'index.php' || !isset( $_GET['page'] ) || $_GET['page'] != 'calendar' )
+			return false;
 
 		$this->enqueue_datepicker_resources();
 		


### PR DESCRIPTION
The following should solve this problem http://wordpress.org/support/topic/mail-poet-former-wysija-newsletter-conflict/ and other issues that might arise from Edit Flow js getting enqueued on the wrong pages. 