### PR TITLE
Use GMT time for start and end dates in iCalendar feeds.

### DIFF
--- a/modules/calendar/calendar.php
+++ b/modules/calendar/calendar.php
@@ -383,8 +383,8 @@ class EF_Calendar extends EF_Module {
 			foreach( $week_posts as $date => $day_posts ) {
 				foreach( $day_posts as $num => $post ) {
 
-					$start_date = date( 'Ymd', strtotime( $post->post_date ) ) . 'T' . date( 'His', strtotime( $post->post_date ) ) . 'Z';
-					$end_date = date( 'Ymd', strtotime( $post->post_date ) + (5 * 60) ) . 'T' . date( 'His', strtotime( $post->post_date ) + (5 * 60) ) . 'Z';
+					$start_date = date( 'Ymd', strtotime( $post->post_date_gmt ) ) . 'T' . date( 'His', strtotime( $post->post_date_gmt ) ) . 'Z';
+					$end_date = date( 'Ymd', strtotime( $post->post_date_gmt ) + (5 * 60) ) . 'T' . date( 'His', strtotime( $post->post_date_gmt ) + (5 * 60) ) . 'Z';
 					$last_modified = date( 'Ymd', strtotime( $post->post_modified_gmt ) ) . 'T' . date( 'His', strtotime( $post->post_modified_gmt ) ) . 'Z';
 
 					// Remove the convert chars and wptexturize filters from the title


### PR DESCRIPTION
Fixes Issue #243

Use post_date_gmt for start and end date in iCalendar feeds.
