### PR TITLE
Remove unnecessary `$edit_flow` global

### DIFF
--- a/modules/calendar/calendar.php
+++ b/modules/calendar/calendar.php
@@ -27,7 +27,6 @@ class EF_Calendar extends EF_Module {
 	 * Construct the EF_Calendar class
 	 */
 	function __construct() {
-		global $edit_flow;
 	
 		$this->module_url = $this->get_module_url( __FILE__ );
 		// Register the module with Edit Flow

--- a/modules/custom-status/custom-status.php
+++ b/modules/custom-status/custom-status.php
@@ -23,7 +23,6 @@ class EF_Custom_Status extends EF_Module {
 	 * Register the module with Edit Flow but don't do anything else
 	 */
 	function __construct() {
-		global $edit_flow;
 		
 		$this->module_url = $this->get_module_url( __FILE__ );
 		// Register the module with Edit Flow

--- a/modules/dashboard/dashboard.php
+++ b/modules/dashboard/dashboard.php
@@ -21,7 +21,6 @@ class EF_Dashboard extends EF_Module {
 	 * Load the EF_Dashboard class as an Edit Flow module
 	 */
 	function __construct() {
-		global $edit_flow;
 		
 		// Register the module with Edit Flow
 		$this->module_url = $this->get_module_url( __FILE__ );

--- a/modules/editorial-comments/editorial-comments.php
+++ b/modules/editorial-comments/editorial-comments.php
@@ -14,7 +14,6 @@ class EF_Editorial_Comments extends EF_Module
 	const comment_type = 'editorial-comment';
 	
 	function __construct() {
-		global $edit_flow;
 		
 		$this->module_url = $this->get_module_url( __FILE__ );
 		// Register the module with Edit Flow

--- a/modules/editorial-metadata/editorial-metadata.php
+++ b/modules/editorial-metadata/editorial-metadata.php
@@ -36,7 +36,6 @@ class EF_Editorial_Metadata extends EF_Module {
 	 * Construct the EF_Editorial_Metadata class
 	 */
 	function __construct() {
-		global $edit_flow;
 		
 		$this->module_url = $this->get_module_url( __FILE__ );
 		// Register the module with Edit Flow

--- a/modules/notifications/notifications.php
+++ b/modules/notifications/notifications.php
@@ -24,7 +24,6 @@ class EF_Notifications extends EF_Module {
 	 * Register the module with Edit Flow but don't do anything else
 	 */
 	function __construct () {
-		global $edit_flow;
 		
 		// Register the module with Edit Flow
 		$this->module_url = $this->get_module_url( __FILE__ );

--- a/modules/settings/settings.php
+++ b/modules/settings/settings.php
@@ -10,7 +10,6 @@ class EF_Settings extends EF_Module {
 	 * Register the module with Edit Flow but don't do anything else
 	 */
 	function __construct() {	
-		global $edit_flow;
 		
 		// Register the module with Edit Flow
 		$this->module_url = $this->get_module_url( __FILE__ );

--- a/modules/story-budget/story-budget.php
+++ b/modules/story-budget/story-budget.php
@@ -32,8 +32,6 @@ class EF_Story_Budget extends EF_Module {
 	 */
 	function __construct() {
 	
-		global $edit_flow;
-		
 		$this->module_url = $this->get_module_url( __FILE__ );
 		// Register the module with Edit Flow
 		$args = array(

--- a/modules/user-groups/user-groups.php
+++ b/modules/user-groups/user-groups.php
@@ -31,7 +31,6 @@ class EF_User_Groups extends EF_Module {
 	 * @since 0.7
 	 */
 	function __construct( ) {
-		global $edit_flow;
 		
 		$this->module_url = $this->get_module_url( __FILE__ );
 		


### PR DESCRIPTION
We're accessing the Edit Flow instance through `EditFlow()`, so no longer
necessary to globalize the variable.
