### PR TITLE
Only subscribe to actions in "admin mode"

### DIFF
--- a/edit_flow.php
+++ b/edit_flow.php
@@ -142,12 +142,14 @@ class edit_flow {
 	 * @uses add_action() To add various actions
 	 */
 	private function setup_actions() {
-		add_action( 'init', array( $this, 'action_init' ) );
-		add_action( 'init', array( $this, 'action_init_after' ), 1000 );
+        if(is_admin()) {
+            add_action( 'init', array( $this, 'action_init' ) );
+            add_action( 'init', array( $this, 'action_init_after' ), 1000 );
 
-		add_action( 'admin_init', array( $this, 'action_admin_init' ) );
+            add_action( 'admin_init', array( $this, 'action_admin_init' ) );
 
-		do_action_ref_array( 'editflow_after_setup_actions', array( &$this ) );
+            do_action_ref_array( 'editflow_after_setup_actions', array( &$this ) );
+        }
 	}
 
 	/**


### PR DESCRIPTION
The plugin doesn't need to load all of the modules if the user is not in an admin page.

Changing this improves the user experience while looking at articles.

The profiler was assigning 8% of the read article time to this plugin. (The profiler was run only on views to the content)

**_BEFORE:**_
![screen shot 2014-05-14 at 6 34 28 pm](https://cloud.githubusercontent.com/assets/1568357/2978303/f48a59a4-dbb7-11e3-8ae7-e1f426151175.png)

**_AFTER**_:
![screen shot 2014-05-14 at 6 26 33 pm](https://cloud.githubusercontent.com/assets/1568357/2978261/393f5348-dbb7-11e3-9e53-06b42af7d0fd.png)
