### PR TITLE
Fix post_date_gmt error

### DIFF
--- a/modules/custom-status/custom-status.php
+++ b/modules/custom-status/custom-status.php
@@ -1330,6 +1330,9 @@ class EF_Custom_Status extends EF_Module {
 			return $data;
 		$status_slugs = wp_list_pluck( $this->get_custom_statuses(), 'slug' );
 		$ef_normalize_post_date_gmt = true;
+		
+		if( !in_array( $postarr[ 'post_status' ], $status_slugs ) )
+			return $data;
 
 		//If the time isn't set, don't set it.
 		if( empty( $_POST['aa'] ) ) {


### PR DESCRIPTION
With the current code, it sets the post_date_gmt to 0000-00-00 00:00:00 even if the post_status is publish when posts are published programmatically rather than via the admin (for example, via XMLRPC). I don't see any reason to massage the post_date_gmt at all if the status of the post is not a custom post status.