### PR TITLE
Adds follower feedback in comments/replies as part of #270

### DIFF
--- a/modules/editorial-comments/editorial-comments.php
+++ b/modules/editorial-comments/editorial-comments.php
@@ -200,7 +200,7 @@ class EF_Editorial_Comments extends EF_Module
 			<?php
 			if ($this->module_enabled( 'notifications' )) {
 			// Only show the input if notifications are enabled ?>
-			<label for="ef-reply-notifier">The following will be notified:
+			<label for="ef-reply-notifier"><?php _e('The following will be notified:', 'edit-flow'); ?>
 				<input id="ef-reply-notifier" class="ef-reply-notifier-message" readonly>
 			</label>
 			<?php } ?>
@@ -234,9 +234,9 @@ class EF_Editorial_Comments extends EF_Module
 		if ($notification) {
 			if ($notification == 1) {
 				// There were no users or user groups selected when this comment was posted
-				$message = '<em>No users or groups were notified</em>';
+				$message = '<em>'.__('No users or groups were notified', 'edit-flow').'</em>';
 			} else {
-				$message = '<strong>Notified:</strong> ' . $notification;
+				$message = '<strong>'.__('Notified', 'edit-flow').':</strong> ' . $notification;
 			}
 			echo '<p class="ef-notification-meta">' . $message . '</p>';
 		}

--- a/modules/editorial-comments/editorial-comments.php
+++ b/modules/editorial-comments/editorial-comments.php
@@ -197,6 +197,14 @@ class EF_Editorial_Comments extends EF_Module
 				<textarea id="ef-replycontent" name="replycontent" cols="40" rows="5"></textarea>
 			</div>
 		
+			<?php
+			if ($this->module_enabled( 'notifications' )) {
+			// Only show the input if notifications are enabled ?>
+			<label for="ef-reply-notifier">The following will be notified:
+				<input id="ef-reply-notifier" class="ef-reply-notifier-message" readonly>
+			</label>
+			<?php } ?>
+
 			<p id="ef-replysubmit">
 				<a class="ef-replysave button-primary alignright" href="#comments-form">
 					<span id="ef-replybtn"><?php _e('Submit Response', 'edit-flow') ?></span>

--- a/modules/editorial-comments/editorial-comments.php
+++ b/modules/editorial-comments/editorial-comments.php
@@ -299,6 +299,7 @@ class EF_Editorial_Comments extends EF_Module
       	// Set up comment data
 		$post_id = absint( $_POST['post_id'] );
 		$parent = absint( $_POST['parent'] );
+		$notification = $_POST['notification'];
       	
       	// Only allow the comment if user can edit post
       	// @TODO: allow contributers to add comments as well (?)
@@ -339,6 +340,11 @@ class EF_Editorial_Comments extends EF_Module
 			// Insert Comment
 			$comment_id = wp_insert_comment($data);
 			$comment = get_comment($comment_id);
+
+			// Save the list of notified users/usergroups
+			if ($this->module_enabled( 'notifications' )) {
+				add_comment_meta( $comment_id, 'notification_list', $notification, false );
+			}
 			
 			// Register actions -- will be used to set up notifications and other modules can hook into this
 			if ( $comment_id )

--- a/modules/editorial-comments/editorial-comments.php
+++ b/modules/editorial-comments/editorial-comments.php
@@ -227,6 +227,22 @@ class EF_Editorial_Comments extends EF_Module
 	}
 	
 	/**
+	 * Print a list of notified users/usergroups
+	 */
+	function get_comment_notification_meta($comment_id) {
+		$notification = get_comment_meta( $comment_id, 'notification_list', true );
+		if ($notification) {
+			if ($notification == 1) {
+				// There were no users or user groups selected when this comment was posted
+				$message = '<em>No users or groups were notified</em>';
+			} else {
+				$message = '<strong>Notified:</strong> ' . $notification;
+			}
+			echo '<p class="ef-notification-meta">' . $message . '</p>';
+		}
+	}
+
+	/**
 	 * Displays a single comment
 	 */
 	function the_comment($comment, $args, $depth) {
@@ -276,6 +292,7 @@ class EF_Editorial_Comments extends EF_Module
 				</h5>
 	
 				<div class="comment-content"><?php comment_text(); ?></div>
+				<?php $this->get_comment_notification_meta($comment->comment_ID);	?>
 				<p class="row-actions"><?php echo $actions_string; ?></p>
 	
 			</div>

--- a/modules/editorial-comments/lib/editorial-comments.css
+++ b/modules/editorial-comments/lib/editorial-comments.css
@@ -24,7 +24,13 @@
 		border-bottom: 1px solid #e5e5e5;
 		background: #fff;
 	}
-	#ef-comments li:hover p.row-actions {
+
+	.row-actions {
+		margin-top: 0;
+	}
+
+	#ef-comments li:hover p.row-actions,
+	#ef-comments li:hover .ef-notification-meta {
 		visibility: visible;
 	}
 	#ef-comments li p.row-actions {
@@ -112,3 +118,32 @@
 	margin-top: 10px;
 	margin-bottom: 10px;
 }
+
+input[readonly].ef-reply-notifier-message {
+	height: 2em;
+	width: 100%;
+	padding: 0.5em;
+	border: none;
+	font-size: 1em;
+}
+
+	label[for="ef-reply-notifier"] {
+		margin: 0.75em 0;
+		display: block;
+		cursor: default;
+	}
+
+	input[readonly].ef-selection-success {
+		border-left: 0.5em solid #80a029;
+	}
+
+	input[readonly].ef-none-selected {
+		border-left: 0.5em solid #a00;
+	}
+
+.ef-notification-meta {
+	text-align: right;
+	margin-bottom: 0;
+	visibility: hidden;
+}
+

--- a/modules/editorial-comments/lib/editorial-comments.js
+++ b/modules/editorial-comments/lib/editorial-comments.js
@@ -65,6 +65,9 @@ editorialCommentReply = {
 		}
 		
 		jQuery('#ef-comment_respond').hide();
+
+		// Display who will be notified for this comment
+		editorialCommentReply.notify();
 		
 		// Show reply textbox
 		jQuery('#ef-replyrow')
@@ -112,6 +115,45 @@ editorialCommentReply = {
 		});
 
 		return false;
+	},
+
+	/**
+	 * Display who will be notified of the new comment
+	 */
+	notify : function() {
+		var checked_notifiers = [], username = "", message = "";
+
+		// Get notification field and make sure it's empty
+		// If there is no wrapper, we need to get out
+		var message_wrapper = jQuery('#ef-reply-notifier');
+		if (message_wrapper[0]) {
+			message_wrapper.val('');
+		} else {
+			return;
+		}
+
+		// Get checked checkboxes
+		checked_notifiers = jQuery('.ef-post_following_list li input:checkbox:checked');
+
+		if (checked_notifiers.length > 0) {
+			var current_item;
+			// There are checked users/usergroups
+			// Set the class to 'selection-success'
+			message_wrapper.removeClass('ef-none-selected').addClass('ef-selection-success');
+			for (var i = 0; i < checked_notifiers.length; i++) {
+				current_item = checked_notifiers[i];
+				username = jQuery(current_item).next();
+				// Create the message
+				// We don't want a comma on the last item or if there is only one item
+				message += username.html() + ((i === checked_notifiers.length -1 || checked_notifiers.length === 1) ? '' : ', ') ;
+				message_wrapper.val(message);
+			}
+		} else {
+			// There are no checked users/usergroups
+			// Set input class to 'none-selected' and display message
+			message_wrapper.removeClass('ef-selection-success').addClass('ef-none-selected');
+			message_wrapper.val('No one will be notified');
+		}
 	},
 
 	show : function(xml) {

--- a/modules/editorial-comments/lib/editorial-comments.js
+++ b/modules/editorial-comments/lib/editorial-comments.js
@@ -123,7 +123,7 @@ editorialCommentReply = {
 	 * Display who will be notified of the new comment
 	 */
 	notify : function() {
-		var checked_notifiers = [], username = "", message = "";
+		var checked_notifiers = [], usernames = [], message = "", lastUser = "";
 
 		// Get notification field and make sure it's empty
 		// If there is no wrapper, we need to get out
@@ -144,12 +144,21 @@ editorialCommentReply = {
 			message_wrapper.removeClass('ef-none-selected').addClass('ef-selection-success');
 			for (var i = 0; i < checked_notifiers.length; i++) {
 				current_item = checked_notifiers[i];
-				username = jQuery(current_item).next();
-				// Create the message
-				// We don't want a comma on the last item or if there is only one item
-				message += username.html() + ((i === checked_notifiers.length -1 || checked_notifiers.length === 1) ? '' : ', ') ;
-				message_wrapper.val(message);
+				// Add usernames to the usernames array
+				usernames.push(jQuery(current_item).next().html());
 			}
+			// Create the message
+			// We don't want a comma on the last item or if there is only one item
+			lastUser = usernames.pop();
+			if (usernames.length > 0) {
+				// There is still at least one item in the array after popping off the last item
+				message = usernames.join(', ') + ' and ' + lastUser;
+			} else {
+				// There was only one item to begin with
+				message = lastUser;
+			}
+			// Display the message
+			message_wrapper.val(message);
 		} else {
 			// There are no checked users/usergroups
 			// Set input class to 'none-selected' and display message

--- a/modules/editorial-comments/lib/editorial-comments.js
+++ b/modules/editorial-comments/lib/editorial-comments.js
@@ -104,6 +104,8 @@ editorialCommentReply = {
 		post.parent = (jQuery("#ef-comment_parent").val()=='') ? 0 : jQuery("#ef-comment_parent").val();
 		post._nonce = jQuery("#ef_comment_nonce").val();
 		post.post_id = jQuery("#ef-post_id").val();
+		post.notification = (jQuery('#ef-reply-notifier').val() == 'No one will be notified' ||
+					jQuery('#ef-reply-notifier').val() == '') ? 1 : jQuery('#ef-reply-notifier').val()
 		
 		// Send the request
 		jQuery.ajax({

--- a/modules/notifications/lib/notifications.js
+++ b/modules/notifications/lib/notifications.js
@@ -28,6 +28,11 @@ jQuery(document).ready(function($) {
 			url : (ajaxurl) ? ajaxurl : wpListL10n.url,
 			data : params,
 			success : function(x) { 
+			// Update the list of users/groups to be notified of new comment
+			// Check for editorialCommentReply, in case EF Comments are disabled
+			if (typeof editorialCommentReply == 'object') {
+				editorialCommentReply.notify();
+			}
 				var backgroundColor = parent_this.css( 'background-color' );
 				$(parent_this.parent().parent())
 					.animate( { 'backgroundColor':'#CCEEBB' }, 200 )

--- a/modules/notifications/lib/notifications.js
+++ b/modules/notifications/lib/notifications.js
@@ -28,11 +28,11 @@ jQuery(document).ready(function($) {
 			url : (ajaxurl) ? ajaxurl : wpListL10n.url,
 			data : params,
 			success : function(x) { 
-			// Update the list of users/groups to be notified of new comment
-			// Check for editorialCommentReply, in case EF Comments are disabled
-			if (typeof editorialCommentReply == 'object') {
-				editorialCommentReply.notify();
-			}
+				// Update the list of users/groups to be notified of new comment
+				// Check for editorialCommentReply, in case EF Comments are disabled
+				if (typeof editorialCommentReply == 'object') {
+					editorialCommentReply.notify();
+				}
 				var backgroundColor = parent_this.css( 'background-color' );
 				$(parent_this.parent().parent())
 					.animate( { 'backgroundColor':'#CCEEBB' }, 200 )


### PR DESCRIPTION
Indicates whether or not any users or user groups were selected to receive a notification of a new comment (the first part of #270). Feedback is given both in the comment/reply form and in the comment itself (on hover, like the reply link). The indicator in the comment persists, for transparency's sake, when/if Edit Flow Notifications are turned off.

I split #270 up into two pull requests - I believe them to be two separate features.
