### PR TITLE
Adds follower feedback in post submit box as part of #270

### DIFF
--- a/modules/notifications/lib/notifications.css
+++ b/modules/notifications/lib/notifications.css
@@ -92,3 +92,7 @@
 #ef-usergroup-users h4 {
 	margin-top: 0;
 }
+
+.misc-pub-follower-count span {
+	font-weight: bold;
+}

--- a/modules/notifications/lib/notifications.js
+++ b/modules/notifications/lib/notifications.js
@@ -6,6 +6,9 @@ jQuery(document).ready(function($) {
 		post_id: $('#post_ID').val(),
 	};
 
+	// Display the user/group follower count in the post submit box
+	ef_displayFollowerCountInSubmitBox();
+
 	$('.ef-post_following_list li input:checkbox, .ef-following_usergroups li input:checkbox').click(function() {
 		var user_group_ids = [];
 		var parent_this = $(this);
@@ -28,6 +31,8 @@ jQuery(document).ready(function($) {
 			url : (ajaxurl) ? ajaxurl : wpListL10n.url,
 			data : params,
 			success : function(x) { 
+				// Update the user/group follower count in the post submit box
+				ef_displayFollowerCountInSubmitBox();
 				var backgroundColor = parent_this.css( 'background-color' );
 				$(parent_this.parent().parent())
 					.animate( { 'backgroundColor':'#CCEEBB' }, 200 )
@@ -39,3 +44,44 @@ jQuery(document).ready(function($) {
 		});
 	});
 });
+
+/**
+ * Count the users and user groups who will be notified of a status change
+ * Display the message in the submit box
+ */
+var ef_displayFollowerCountInSubmitBox = function() {
+	var checkedFollowers, checkedUserGroups, countDisplay, message = '', followerMessage = '', userGroupMessage = '',conjunction = '';
+
+	// Get checked checkboxes
+	checkedFollowers = jQuery('.ef-post_following_list li input:checkbox:checked');
+	checkedUserGroups = jQuery('#ef-following_usergroups li input:checkbox:checked');
+	// checkedFollowers includes user groups
+	userCount = checkedFollowers.length - checkedUserGroups.length;
+	userGroupCount = checkedUserGroups.length;
+
+	// The <span> within which the message will be displayed
+	countDisplay = jQuery('#post-follower-count-display');
+
+	// Create the individual messages
+	if (userCount > 0) {
+		followerMessage = userCount + ((userCount === 1) ? ' user' : ' users');
+	}
+	if (userGroupCount > 0) {
+		userGroupMessage = userGroupCount + ((userGroupCount === 1) ? ' user group' : ' user groups');
+	}
+
+	if (userCount > 0 && userGroupCount > 0) {
+		// Both will be displayed, so we need a conjunction
+		conjunction = ' & ';
+		message = (followerMessage + conjunction + userGroupMessage);
+	} else if (userCount > 0 || userGroupCount > 0) {
+		// Only one will be displayed, the other is an empty string
+		message = (followerMessage + userGroupMessage);
+	} else {
+		// Default message
+		message = 'none';
+	}
+
+	// Print the message
+	countDisplay.html(message);
+};

--- a/modules/notifications/notifications.php
+++ b/modules/notifications/notifications.php
@@ -417,10 +417,10 @@ jQuery(document).ready(function($) {
 	function submitbox_followers_message() {
 		?>
 		<hr>
-		<div class="misc-pub-section misc-pub-follower-count" id="follower-count">Followers: <span id="post-follower-count-display"></span>
+		<div class="misc-pub-section misc-pub-follower-count" id="follower-count"><?php _e('Followers', 'edit-flow'); ?>: <span id="post-follower-count-display"></span>
 			<a href="#edit-flow-notifications">
-				<span aria-hidden="true">Edit</span>
-				<span class="screen-reader-text">Edit followers</span>
+				<span aria-hidden="true"><?php _e('Edit', 'edit-flow'); ?></span>
+				<span class="screen-reader-text"><?php _e('Edit followers', 'edit-flow'); ?></span>
 			</a>
 		</div>
 		<?php

--- a/modules/notifications/notifications.php
+++ b/modules/notifications/notifications.php
@@ -78,6 +78,7 @@ class EF_Notifications extends EF_Module {
 		add_action( 'ef_post_insert_editorial_comment', array( $this, 'notification_comment') );
 		add_action( 'delete_user',  array($this, 'delete_user_action') );
 		add_action( 'ef_send_scheduled_email', array( $this, 'send_single_email' ), 10, 4 );
+		add_action( 'post_submitbox_misc_actions', array($this, 'submitbox_followers_message') );
 		
 		add_action( 'admin_init', array( $this, 'register_settings' ) );
 		
@@ -410,6 +411,20 @@ jQuery(document).ready(function($) {
 		$this->print_ajax_response( 'success', (object)$this->get_follow_action_parts( $post ) );
 	}
 
+	/**
+	 * Set up the submit box for displaying the number of users/user groups following a page/post
+	 */
+	function submitbox_followers_message() {
+		?>
+		<hr>
+		<div class="misc-pub-section misc-pub-follower-count" id="follower-count">Followers: <span id="post-follower-count-display"></span>
+			<a href="#edit-flow-notifications">
+				<span aria-hidden="true">Edit</span>
+				<span class="screen-reader-text">Edit followers</span>
+			</a>
+		</div>
+		<?php
+	}
 
 	/**
 	 * Called when post is saved. Handles saving of user/usergroup followers


### PR DESCRIPTION
Indicates whether or not any users or user groups are following a page/post (the second part of #270). Feedback is given in the post submit box, based on the users and groups selected in the Edit Flow Notifications meta box.
