### PR TITLE
Change to event delegation for ef click event

### DIFF
--- a/modules/custom-status/custom-status.php
+++ b/modules/custom-status/custom-status.php
@@ -415,12 +415,14 @@ class EF_Custom_Status extends EF_Module {
 
  			$post_type_obj = get_post_type_object( $this->get_current_post_type() );
 			
+			$default_custom_status = $this->get_default_custom_status()->slug;
+			
 			// Now, let's print the JS vars
 			?>
 			<script type="text/javascript">
 				var custom_statuses = <?php echo json_encode( $all_statuses ); ?>;
 				var ef_text_no_change = '<?php echo esc_js( __( "&mdash; No Change &mdash;" ) ); ?>';
-				var ef_default_custom_status = '<?php echo esc_js( $this->get_default_custom_status()->slug ); ?>';
+				var ef_default_custom_status = '<?php echo esc_js( $default_custom_status ); ?>';
 				var current_status = '<?php echo esc_js( $selected ); ?>';
 				var current_status_name = '<?php echo esc_js( $selected_name ); ?>';
 				var status_dropdown_visible = <?php echo esc_js( $always_show_dropdown ); ?>;
@@ -637,8 +639,10 @@ class EF_Custom_Status extends EF_Module {
 	 */
 	function get_default_custom_status() {
 		$default_status = $this->get_custom_status_by( 'slug', $this->module->options->default_status );
-		if ( ! $default_status )
-			$default_status = array_shift( $this->get_custom_statuses() );
+		if ( ! $default_status ) {
+			$custom_statuses = $this->get_custom_statuses();
+			$default_status = array_shift( $custom_statuses );
+		}
 		return $default_status;
 		
 	}

--- a/modules/notifications/lib/notifications.js
+++ b/modules/notifications/lib/notifications.js
@@ -6,7 +6,7 @@ jQuery(document).ready(function($) {
 		post_id: $('#post_ID').val(),
 	};
 
-	$('.ef-post_following_list li input:checkbox, .ef-following_usergroups li input:checkbox').click(function() {
+	$(document).on( 'click', '.ef-post_following_list li input:checkbox, .ef-following_usergroups li input:checkbox', function() {
 		var user_group_ids = [];
 		var parent_this = $(this);
 		params.ef_notifications_name = $(this).attr('name');


### PR DESCRIPTION
I had a problem in WP 3.9.2 while using chrome where the checkbox selector was running incredibly slowly and incorrectly adding event handlers to the extent that the post list admin pages were unusable for up to 30 seconds.

![html-parse-timings](https://cloud.githubusercontent.com/assets/23417/4493576/834ab3f4-4a4a-11e4-8769-1e5f00ad79cf.png)

Changing line 9 to use `.on()` fixed it.

Possibly to do with changes in the sizzle library but this fixes it.