### PR TITLE
Update isset to empty for _POST superglobal

### DIFF
--- a/modules/custom-status/custom-status.php
+++ b/modules/custom-status/custom-status.php
@@ -1326,7 +1326,7 @@ class EF_Custom_Status extends EF_Module {
 		// Don't run this if Edit Flow isn't active, or we're on some other page
 		if ( $this->disable_custom_statuses_for_post_type()
 			|| ! isset( $edit_flow )
-			|| ! isset( $_POST ) )
+			|| empty( $_POST ) )
 			return $data;
 		$status_slugs = wp_list_pluck( $this->get_custom_statuses(), 'slug' );
 		$ef_normalize_post_date_gmt = true;


### PR DESCRIPTION
`$_POST` is always set as a superglobal. Need to check if it is empty instead.
