### PR TITLE
Tighten the scope of search for .editing elements in the page

### DIFF
--- a/modules/calendar/lib/calendar.js
+++ b/modules/calendar/lib/calendar.js
@@ -43,7 +43,7 @@ jQuery(document).ready(function ($) {
 
 
 	function reset_editorial_metadata() {
-		$('.editing').removeClass('editing')
+		$('.dashboard_page_calendar').find('.editing').removeClass('editing')
 			.addClass('hidden')
 			.prev()
 			.removeClass('hidden');


### PR DESCRIPTION
reset_editorial_metadata() is hiding elements from another plugin we're using. The selector $('.editing') is overly-broad. This PR narrows the focus of the selector to just look on the Calendar page, although you might want to address this conflict differently (closer to the click handler?).

Addresses issue #295