### PR TITLE
Updating custom status hack to prevent publishing when scheduling

### DIFF
--- a/modules/custom-status/custom-status.php
+++ b/modules/custom-status/custom-status.php
@@ -1327,7 +1327,7 @@ class EF_Custom_Status extends EF_Module {
 		if ( $this->disable_custom_statuses_for_post_type()
 			|| ! isset( $edit_flow )
 			|| empty( $_POST ) 
-			|| ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) ) )
+			|| ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) )
 			return $data;
 		$status_slugs = wp_list_pluck( $this->get_custom_statuses(), 'slug' );
 		$ef_normalize_post_date_gmt = true;

--- a/modules/custom-status/custom-status.php
+++ b/modules/custom-status/custom-status.php
@@ -1326,7 +1326,8 @@ class EF_Custom_Status extends EF_Module {
 		// Don't run this if Edit Flow isn't active, or we're on some other page
 		if ( $this->disable_custom_statuses_for_post_type()
 			|| ! isset( $edit_flow )
-			|| empty( $_POST ) )
+			|| empty( $_POST ) 
+			|| ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) ) )
 			return $data;
 		$status_slugs = wp_list_pluck( $this->get_custom_statuses(), 'slug' );
 		$ef_normalize_post_date_gmt = true;


### PR DESCRIPTION
This is a fix for ticket #301. After setting a scheduled datetime for a post and saving it as a custom status and the user makes any changes the autosave fires. This calls the `fix_custom_status_timestamp` function that has a conditional to blank out `$data['post_date_gmt']` if `$_POST['aa']` is empty. `$_POST['aa']` is not passed on autosaves causing WordPress to publish the current post when clicking schedule.