### PR TITLE
Javascript performance

### DIFF
--- a/modules/notifications/lib/notifications.js
+++ b/modules/notifications/lib/notifications.js
@@ -6,7 +6,7 @@ jQuery(document).ready(function($) {
 		post_id: $('#post_ID').val(),
 	};
 
-	$('.ef-post_following_list li input[type="checkbox"], .ef-following_usergroups li input[type="checkbox"]').click(function() {
+	$(document).on('click','.ef-post_following_list li input:checkbox, .ef-following_usergroups li input:checkbox', function() {
 		var user_group_ids = [];
 		var parent_this = $(this);
 		params.ef_notifications_name = $(this).attr('name');


### PR DESCRIPTION
Fix for current version of jQuery and the "All posts" page. Would
previously hang on page load with current versions of WordPress.