### PR TITLE
fix typo for module messages

### DIFF
--- a/modules/custom-status/custom-status.php
+++ b/modules/custom-status/custom-status.php
@@ -808,7 +808,7 @@ class EF_Custom_Status extends EF_Module {
 			wp_die( $this->module->messages['invalid-permissions'] );
 
 		if ( !$existing_status = $this->get_custom_status_by( 'id', (int)$_GET['term-id'] ) )
-			wp_die( $this->module->messages['term-error'] );
+			wp_die( $this->module->messages['status-missing'] );
 
 		$name = sanitize_text_field( trim( $_POST['name'] ) );
 		$description = stripslashes( wp_filter_nohtml_kses( trim( $_POST['description'] ) ) );

--- a/modules/custom-status/custom-status.php
+++ b/modules/custom-status/custom-status.php
@@ -808,7 +808,7 @@ class EF_Custom_Status extends EF_Module {
 			wp_die( $this->module->messages['invalid-permissions'] );
 
 		if ( !$existing_status = $this->get_custom_status_by( 'id', (int)$_GET['term-id'] ) )
-			wp_die( $this->module->message['term-error'] );
+			wp_die( $this->module->messages['term-error'] );
 
 		$name = sanitize_text_field( trim( $_POST['name'] ) );
 		$description = stripslashes( wp_filter_nohtml_kses( trim( $_POST['description'] ) ) );

--- a/modules/custom-status/custom-status.php
+++ b/modules/custom-status/custom-status.php
@@ -808,7 +808,7 @@ class EF_Custom_Status extends EF_Module {
 			wp_die( $this->module->messages['invalid-permissions'] );
 
 		if ( !$existing_status = $this->get_custom_status_by( 'id', (int)$_GET['term-id'] ) )
-			wp_die( $this->module->messsage['term-error'] );
+			wp_die( $this->module->message['term-error'] );
 
 		$name = sanitize_text_field( trim( $_POST['name'] ) );
 		$description = stripslashes( wp_filter_nohtml_kses( trim( $_POST['description'] ) ) );

--- a/modules/editorial-metadata/editorial-metadata.php
+++ b/modules/editorial-metadata/editorial-metadata.php
@@ -1089,7 +1089,7 @@ class EF_Editorial_Metadata extends EF_Module {
 			wp_die( $this->module->messages['invalid-permissions'] );			
 		
 		if ( !$existing_term = $this->get_editorial_metadata_term_by( 'id', (int)$_GET['term-id'] ) )
-			wp_die( $this->module->messages['term-error'] );			
+			wp_die( $this->module->messages['term-missing'] );			
 		
 		$new_name = sanitize_text_field( trim( $_POST['name'] ) );
 		$new_description = stripslashes( wp_filter_post_kses( strip_tags( trim( $_POST['description'] ) ) ) );
@@ -1204,7 +1204,7 @@ class EF_Editorial_Metadata extends EF_Module {
 		
 		$term_id = (int) $_POST['term_id'];
 		if ( !$existing_term = $this->get_editorial_metadata_term_by( 'id', $term_id ) )
-			die( $this->module->messages['term-error'] );
+			die( $this->module->messages['term-missing'] );
 		
 		$metadata_name = sanitize_text_field( trim( $_POST['name'] ) );
 		$metadata_description = stripslashes( wp_filter_post_kses( trim( $_POST['description'] ) ) );
@@ -1313,7 +1313,7 @@ class EF_Editorial_Metadata extends EF_Module {
 			wp_die( $this->module->messages['invalid-permissions'] );
 			
 		if ( !$existing_term = $this->get_editorial_metadata_term_by( 'id', (int)$_GET['term-id'] ) )
-			wp_die( $this->module->messages['term-error'] );			
+			wp_die( $this->module->messages['term-missing'] );			
 			
 		$result = $this->delete_editorial_metadata_term( $existing_term->term_id );
 		if ( !$result || is_wp_error( $result ) )

--- a/modules/editorial-metadata/editorial-metadata.php
+++ b/modules/editorial-metadata/editorial-metadata.php
@@ -1089,7 +1089,7 @@ class EF_Editorial_Metadata extends EF_Module {
 			wp_die( $this->module->messages['invalid-permissions'] );			
 		
 		if ( !$existing_term = $this->get_editorial_metadata_term_by( 'id', (int)$_GET['term-id'] ) )
-			wp_die( $this->module->message['term-error'] );			
+			wp_die( $this->module->messages['term-error'] );			
 		
 		$new_name = sanitize_text_field( trim( $_POST['name'] ) );
 		$new_description = stripslashes( wp_filter_post_kses( strip_tags( trim( $_POST['description'] ) ) ) );
@@ -1204,7 +1204,7 @@ class EF_Editorial_Metadata extends EF_Module {
 		
 		$term_id = (int) $_POST['term_id'];
 		if ( !$existing_term = $this->get_editorial_metadata_term_by( 'id', $term_id ) )
-			die( $this->module->message['term-error'] );
+			die( $this->module->messages['term-error'] );
 		
 		$metadata_name = sanitize_text_field( trim( $_POST['name'] ) );
 		$metadata_description = stripslashes( wp_filter_post_kses( trim( $_POST['description'] ) ) );
@@ -1313,7 +1313,7 @@ class EF_Editorial_Metadata extends EF_Module {
 			wp_die( $this->module->messages['invalid-permissions'] );
 			
 		if ( !$existing_term = $this->get_editorial_metadata_term_by( 'id', (int)$_GET['term-id'] ) )
-			wp_die( $this->module->message['term-error'] );			
+			wp_die( $this->module->messages['term-error'] );			
 			
 		$result = $this->delete_editorial_metadata_term( $existing_term->term_id );
 		if ( !$result || is_wp_error( $result ) )

--- a/modules/editorial-metadata/editorial-metadata.php
+++ b/modules/editorial-metadata/editorial-metadata.php
@@ -1089,7 +1089,7 @@ class EF_Editorial_Metadata extends EF_Module {
 			wp_die( $this->module->messages['invalid-permissions'] );			
 		
 		if ( !$existing_term = $this->get_editorial_metadata_term_by( 'id', (int)$_GET['term-id'] ) )
-			wp_die( $this->module->messsage['term-error'] );			
+			wp_die( $this->module->message['term-error'] );			
 		
 		$new_name = sanitize_text_field( trim( $_POST['name'] ) );
 		$new_description = stripslashes( wp_filter_post_kses( strip_tags( trim( $_POST['description'] ) ) ) );
@@ -1204,7 +1204,7 @@ class EF_Editorial_Metadata extends EF_Module {
 		
 		$term_id = (int) $_POST['term_id'];
 		if ( !$existing_term = $this->get_editorial_metadata_term_by( 'id', $term_id ) )
-			die( $this->module->messsage['term-error'] );
+			die( $this->module->message['term-error'] );
 		
 		$metadata_name = sanitize_text_field( trim( $_POST['name'] ) );
 		$metadata_description = stripslashes( wp_filter_post_kses( trim( $_POST['description'] ) ) );
@@ -1313,7 +1313,7 @@ class EF_Editorial_Metadata extends EF_Module {
 			wp_die( $this->module->messages['invalid-permissions'] );
 			
 		if ( !$existing_term = $this->get_editorial_metadata_term_by( 'id', (int)$_GET['term-id'] ) )
-			wp_die( $this->module->messsage['term-error'] );			
+			wp_die( $this->module->message['term-error'] );			
 			
 		$result = $this->delete_editorial_metadata_term( $existing_term->term_id );
 		if ( !$result || is_wp_error( $result ) )

--- a/modules/user-groups/user-groups.php
+++ b/modules/user-groups/user-groups.php
@@ -344,7 +344,7 @@ class EF_User_Groups extends EF_Module {
 			wp_die( $this->module->messages['invalid-permissions'] );
 			
 		if ( !$existing_usergroup = $this->get_usergroup_by( 'id', (int)$_POST['usergroup_id'] ) )
-			wp_die( $this->module->message['usergroup-error'] );			
+			wp_die( $this->module->messages['usergroup-error'] );			
 		
 		// Sanitize all of the user-entered values
 		$name = strip_tags( trim( $_POST['name'] ) );
@@ -439,7 +439,7 @@ class EF_User_Groups extends EF_Module {
 		
 		$usergroup_id = (int) $_POST['usergroup_id'];
 		if ( !$existing_term = $this->get_usergroup_by( 'id', $usergroup_id ) )
-			die( $this->module->message['usergroup-error'] );
+			die( $this->module->messages['usergroup-error'] );
 		
 		$name = strip_tags( trim( $_POST['name'] ) );
 		$description = stripslashes( strip_tags( trim( $_POST['description'] ) ) );

--- a/modules/user-groups/user-groups.php
+++ b/modules/user-groups/user-groups.php
@@ -344,7 +344,7 @@ class EF_User_Groups extends EF_Module {
 			wp_die( $this->module->messages['invalid-permissions'] );
 			
 		if ( !$existing_usergroup = $this->get_usergroup_by( 'id', (int)$_POST['usergroup_id'] ) )
-			wp_die( $this->module->messsage['usergroup-error'] );			
+			wp_die( $this->module->message['usergroup-error'] );			
 		
 		// Sanitize all of the user-entered values
 		$name = strip_tags( trim( $_POST['name'] ) );
@@ -439,7 +439,7 @@ class EF_User_Groups extends EF_Module {
 		
 		$usergroup_id = (int) $_POST['usergroup_id'];
 		if ( !$existing_term = $this->get_usergroup_by( 'id', $usergroup_id ) )
-			die( $this->module->messsage['usergroup-error'] );
+			die( $this->module->message['usergroup-error'] );
 		
 		$name = strip_tags( trim( $_POST['name'] ) );
 		$description = stripslashes( strip_tags( trim( $_POST['description'] ) ) );

--- a/modules/user-groups/user-groups.php
+++ b/modules/user-groups/user-groups.php
@@ -344,7 +344,7 @@ class EF_User_Groups extends EF_Module {
 			wp_die( $this->module->messages['invalid-permissions'] );
 			
 		if ( !$existing_usergroup = $this->get_usergroup_by( 'id', (int)$_POST['usergroup_id'] ) )
-			wp_die( $this->module->messages['usergroup-error'] );			
+			wp_die( $this->module->messages['usergroup-missing'] );			
 		
 		// Sanitize all of the user-entered values
 		$name = strip_tags( trim( $_POST['name'] ) );
@@ -439,7 +439,7 @@ class EF_User_Groups extends EF_Module {
 		
 		$usergroup_id = (int) $_POST['usergroup_id'];
 		if ( !$existing_term = $this->get_usergroup_by( 'id', $usergroup_id ) )
-			die( $this->module->messages['usergroup-error'] );
+			die( $this->module->messages['usergroup-missing'] );
 		
 		$name = strip_tags( trim( $_POST['name'] ) );
 		$description = stripslashes( strip_tags( trim( $_POST['description'] ) ) );


### PR DESCRIPTION
Fixing typo in reference to $this->module->message array, as reported in #313 