### PR TITLE
Proposed fix on Calendar module for "current_user_can" capability check

### DIFF
--- a/modules/calendar/calendar.php
+++ b/modules/calendar/calendar.php
@@ -767,7 +767,7 @@ class EF_Calendar extends EF_Module {
 						<a class="show-more" href="#"><?php printf( __( 'Show %d more', 'edit-flow' ), $this->hidden ); ?></a>
 					<?php endif; ?>
 
-					<?php if( current_user_can('publish_posts') ) : 
+					<?php if( current_user_can( $this->create_post_cap ) ) :
 						$date_formatted = date( 'D, M jS, Y', strtotime( $week_single_date ) );
 					?>
 


### PR DESCRIPTION
If a custom user role has been created for write access to the calendar via the filter on https://github.com/Automattic/Edit-Flow/blob/master/modules/calendar/calendar.php#L87 and that user doesn't have WP `publish_posts` capabilities, they won't be able to create calendar entries. Proposing changing the check from `publish_posts` to `$this->create_post_cap`