### PR TITLE
fix initialization of $post_int in EF_Module->get_current_post_type()

### DIFF
--- a/common/php/class-module.php
+++ b/common/php/class-module.php
@@ -253,7 +253,7 @@ class EF_Module {
 	function get_current_post_type() {
 		global $post, $typenow, $pagenow, $current_screen;
 		//get_post() needs a variable
-		$post_int;
+		$post_int = '';
 		if( isset( $_REQUEST['post'] ) )
 			$post_int = (int)$_REQUEST['post'];
 


### PR DESCRIPTION
It was a line that just said "$post_int;" which does nothing AFAIK.

In Debug Bar I was seeing this error:
 NOTICE: /class-module.php:243 - Undefined variable: post_int

The whole method could use a review but this PR is the minimum possible change to fix the notice and (I think) honor the original intention of the code. 

Thanks!