### PR TITLE
Cleanup PHP to comply with strict standards

### DIFF
--- a/common/php/class-module.php
+++ b/common/php/class-module.php
@@ -574,9 +574,10 @@ class EF_Module {
 		global $wp_roles;
 		
 		if ( $wp_roles->is_role( $role ) ) {
-			$role = &get_role( $role );
-			foreach ( $caps as $cap )
+			$role = get_role( $role );
+			foreach ( $caps as $cap ) {
 				$role->add_cap( $cap );
+			}
 		}
 	}
 

--- a/modules/custom-status/custom-status.php
+++ b/modules/custom-status/custom-status.php
@@ -637,8 +637,10 @@ class EF_Custom_Status extends EF_Module {
 	 */
 	function get_default_custom_status() {
 		$default_status = $this->get_custom_status_by( 'slug', $this->module->options->default_status );
-		if ( ! $default_status )
-			$default_status = array_shift( $this->get_custom_statuses() );
+		if ( ! $default_status ) {
+			$custom_statuses = $this->get_custom_statuses();
+			$default_status = array_shift( $custom_statuses );
+		}
 		return $default_status;
 
 	}

--- a/tests/test-class-module.php
+++ b/tests/test-class-module.php
@@ -1,0 +1,51 @@
+<?php
+
+class WP_Test_Edit_Flow_Class_Module extends WP_UnitTestCase {
+	protected static $admin_user_id;
+
+	public static function wpSetUpBeforeClass( $factory ) {
+		self::$admin_user_id = $factory->user->create( array( 'role' => 'administrator' ) );
+	}
+
+	function _flush_roles() {
+		// we want to make sure we're testing against the db, not just in-memory data
+		// this will flush everything and reload it from the db
+		unset( $GLOBALS['wp_user_roles'] );
+		global $wp_roles;
+		if ( is_object( $wp_roles ) ) {
+			$wp_roles->_init();
+		}
+	}
+
+	function setUp() {
+		parent::setUp();
+		// keep track of users we create
+		$this->_flush_roles();
+
+	}
+	
+	function test_add_caps_to_role() {
+		$EditFlowModule = new EF_Module();
+
+		$usergroup_roles = array(
+			'administrator' => array( 'edit_usergroups' ),
+		);
+
+		foreach( $usergroup_roles as $role => $caps ) {
+			$EditFlowModule->add_caps_to_role( $role, $caps );
+		}
+
+		$user = new WP_User( self::$admin_user_id );
+
+		//Verify before flush
+		$this->assertTrue( $user->has_cap( 'edit_usergroups' ), 'User did not have role edit_usergroups' );
+
+		$this->_flush_roles();
+
+		$this->assertTrue( $user->has_cap( 'edit_usergroups' ), 'User did not have role edit_usergroups' );
+	}
+	
+	public static function wpTearDownAfterClass() {
+		self::delete_user( self::$admin_user_id );
+	}
+}


### PR DESCRIPTION
Encountering the "only variables should be assigned by reference" and "only variables should be passed by reference" warnings when PHP strict standards are enabled. Cleanup instances in the code where these warnings are being triggered.

**fix for #311**
`$role = get_role( $role );`
Don't think we need the `&` if I'm reading http://php.net/manual/en/language.oop5.references.php correctly. Can someone with a bit more PHP expertise verify that?

**fix for #321**
`$default_status = array_shift( $custom_statuses );`
Looks like we need to pass a variable to `array_shift` instead of the return value of `$this->get_custom_statuses() `

**edit:** tagging issue correctly