### PR TITLE
Add label to Dashboard Note and tests

### DIFF
--- a/modules/dashboard/widgets/dashboard-notepad.php
+++ b/modules/dashboard/widgets/dashboard-notepad.php
@@ -15,7 +15,10 @@ class EF_Dashboard_Notepad_Widget {
 
 	public function init() {
 
-		register_post_type( self::notepad_post_type );
+		register_post_type( self::notepad_post_type, array(
+				'label' => __( 'Dashboard Note', 'edit-flow' )
+			) 
+		);
 
 		$this->edit_cap = apply_filters( 'ef_dashboard_notepad_edit_cap', $this->edit_cap );
 

--- a/tests/test-edit-flow-dashboard-notepad.php
+++ b/tests/test-edit-flow-dashboard-notepad.php
@@ -1,0 +1,28 @@
+<?php
+
+class WP_Test_Edit_Flow_Dashboard_Note extends WP_UnitTestCase {
+	
+	function test_register_dashboard_note_post_type() {
+		//As part of the Edit Flow initialziation process
+		//EF_Dashboard_Notepad_Widget should have already
+		//created the dashboard-note post type
+		$pobj = get_post_type_object( 'dashboard-note' );
+		$this->assertInstanceOf( 'stdClass', $pobj );
+		$this->assertEquals( 'dashboard-note', $pobj->name );
+
+		//Testing EF_Dashboard_Notepad_Widget::init explicitly 
+		_unregister_post_type( 'dashboard-note' );
+
+		$EditFlowDashboardNote = new EF_Dashboard_Notepad_Widget();
+
+		$this->assertNull( get_post_type_object( 'dashboard-note' ) );
+
+		//Should create the post type 'dashboard-note'
+		$EditFlowDashboardNote->init();
+
+		$pobj = get_post_type_object( 'dashboard-note' );
+		$this->assertInstanceOf( 'stdClass', $pobj );
+		$this->assertEquals( 'dashboard-note', $pobj->name );
+	}
+
+}


### PR DESCRIPTION
This adds the label 'Dashboard Note' when registering the dashboard-note post type. Also adds `WP_Test_Edit_Flow_Dashboard_Note` to test EF_Dashboard_Notepad_Widget. Currently tests that EF_Dashboard_Notepad_Widget properly registers the dashboard-note post type.