### PR TITLE
Modify custom_status_timestamp to cover more statuses.

### DIFF
--- a/modules/custom-status/custom-status.php
+++ b/modules/custom-status/custom-status.php
@@ -1331,9 +1331,10 @@ class EF_Custom_Status extends EF_Module {
 			return $data;
 		}
 
+		$status_slugs = wp_list_pluck( $this->get_custom_statuses(), 'slug' );
+
 		//Post is scheduled or published? Ignoring.
-		if ( $postarr['post_status'] == 'future' 
-		|| $postarr['post_status'] == 'publish' ) {
+		if ( !in_array( $postarr['post_status'], $status_slugs ) ) {
 			return $data;
 		}
 


### PR DESCRIPTION
Previously was just covering 'publish' and 'future'. Should also cover 'private'. Rather than trying to account for these, if the status is not in this array return early.