### PR TITLE
Added check for empty author in notifications

### DIFF
--- a/modules/notifications/notifications.php
+++ b/modules/notifications/notifications.php
@@ -563,8 +563,8 @@ jQuery(document).ready(function($) {
 			
 			$body .= sprintf( __( '== %s Details ==', 'edit-flow' ), $post_type ) . "\r\n";
 			$body .= sprintf( __( 'Title: %s', 'edit-flow' ), $post_title ) . "\r\n";
-			/* translators: 1: author name, 2: author email */
 			if ( ! empty( $post_author ) ) {
+				/* translators: 1: author name, 2: author email */
 				$body .= sprintf( __( 'Author: %1$s (%2$s)', 'edit-flow' ), $post_author->display_name, $post_author->user_email ) . "\r\n";
 			}
 			

--- a/modules/notifications/notifications.php
+++ b/modules/notifications/notifications.php
@@ -564,7 +564,9 @@ jQuery(document).ready(function($) {
 			$body .= sprintf( __( '== %s Details ==', 'edit-flow' ), $post_type ) . "\r\n";
 			$body .= sprintf( __( 'Title: %s', 'edit-flow' ), $post_title ) . "\r\n";
 			/* translators: 1: author name, 2: author email */
-			$body .= sprintf( __( 'Author: %1$s (%2$s)', 'edit-flow' ), $post_author->display_name, $post_author->user_email ) . "\r\n";
+			if ( ! empty( $post_author ) ) {
+				$body .= sprintf( __( 'Author: %1$s (%2$s)', 'edit-flow' ), $post_author->display_name, $post_author->user_email ) . "\r\n";
+			}
 			
 			$edit_link = htmlspecialchars_decode( get_edit_post_link( $post_id ) );
 			if ( $new_status != 'publish' ) {


### PR DESCRIPTION
When creating a new page via WP-CLI using `wp post create` and not specifying the author, a PHP notice is occurring.

```
vagrant@vvv:/srv/www/wordpress-default/htdocs/wp-content$ wp post create post-content.html --post_type=page --post_title="New Page"
PHP Notice:  Trying to get property of non-object in /srv/www/wordpress-default/htdocs/wp-content/plugins/edit-flow/modules/notifications/notifications.php on line 567
```

This patch checks for an empty `$post_author` variable before trying to access the properties in the variable.

