### PR TITLE
Restyle `configure-edit-flow-module` buttons.

### DIFF
--- a/modules/settings/lib/settings.css
+++ b/modules/settings/lib/settings.css
@@ -87,7 +87,9 @@
 	background: #DDD;
 	background: -webkit-gradient(linear, left top, left bottom, from(#BBB), to(#888));
 	background: -moz-linear-gradient(top,  #BBB,  #888);
+	box-shadow: none;
 	filter:  progid:DXImageTransform.Microsoft.gradient(startColorstr='#BBB', endColorstr='#888');
+	text-shadow: none;
 }
 
 .edit-flow-modules .edit-flow-module .button-primary.configure-edit-flow-module:hover {


### PR DESCRIPTION
The `configure-edit-flow-module` buttons on the Edit Flow settings
screen had a blue-tint applied to the text and button styling by
WordPress core. Adding two style changes to bring back the previous look
and feel.