### PR TITLE
Fix get_beginning_of_week

### DIFF
--- a/modules/calendar/calendar.php
+++ b/modules/calendar/calendar.php
@@ -1314,8 +1314,8 @@ class EF_Calendar extends EF_Module {
 		$end_of_week = get_option( 'start_of_week' ) - 1;
 		$day_of_week = date( 'w', $date );
 		$date += (( $end_of_week - $day_of_week + 7 ) % 7) * 60 * 60 * 24;
-		$additional = 3600 * 24 * 7 * ( $week - 1 );
-		$formatted_end_of_week = date( $format, $date + $additional );
+		$date = strtotime ( '+' . ( $week - 1 ) . ' week', $date ) ;
+		$formatted_end_of_week = date( $format, $date );
 		return $formatted_end_of_week;
 		
 	}

--- a/modules/calendar/calendar.php
+++ b/modules/calendar/calendar.php
@@ -1276,23 +1276,23 @@ class EF_Calendar extends EF_Module {
 	
 	/**
 	 * Given a day in string format, returns the day at the beginning of that week, which can be the given date.
-	 * The end of the week is determined by the blog option, 'start_of_week'.
+	 * The beginning of the week is determined by the blog option, 'start_of_week'.
 	 *
 	 * @see http://www.php.net/manual/en/datetime.formats.date.php for valid date formats
 	 *
 	 * @param string $date String representing a date
-	 * @param string $format Date format in which the end of the week should be returned
+	 * @param string $format Date format in which the beginning of the week should be returned
 	 * @param int $week Number of weeks we're offsetting the range	
-	 * @return string $formatted_start_of_week End of the week
+	 * @return string $formatted_start_of_week Beginning of the week
 	 */
 	function get_beginning_of_week( $date, $format = 'Y-m-d', $week = 1 ) {
 		
 		$date = strtotime( $date );
 		$start_of_week = get_option( 'start_of_week' );
 		$day_of_week = date( 'w', $date );
-		$date += (( $start_of_week - $day_of_week - 7 ) % 7) * 60 * 60 * 24 * $week;
-		$additional = 3600 * 24 * 7 * ( $week - 1 );
-		$formatted_start_of_week = date( $format, $date + $additional );
+		$date += (( $start_of_week - $day_of_week - 7 ) % 7) * 60 * 60 * 24 ;
+		$date = strtotime ( '+' . ( $week - 1 ) . ' week', $date ) ;
+                $formatted_start_of_week = date( $format, $date );
 		return $formatted_start_of_week;
 		
 	}


### PR DESCRIPTION
The method get_beginning_of_week has some flaws which I addressed in this commit.
1. The comments make no sense (mixing up end of week and beginning of week)
2. When the passed $date is not a start of the week and the passed number $week is greater than 1, the method will behave incorrectly, because the difference between $day_of_week and $start_of_week is then subtracted multiple times. In the current calendar implementation this seems to have no negative effect, because the passed $date will always be a start of a week. But I thought it would be proper to fix it anyway.
3. When, by means of the given offset of $week, a DST switch introducing additional time occurs during the period between $date and the final date, the method will also behave incorrectly (the same date(s) may occur multiple times in the calendar causing misalignment of weekdays and possible confusion)
