### PR TITLE
Check if $post_count object has property before trying to use it

### DIFF
--- a/modules/dashboard/dashboard.php
+++ b/modules/dashboard/dashboard.php
@@ -163,7 +163,7 @@ class EF_Dashboard extends EF_Module {
 								<a href="<?php echo esc_url( $filter_link ); ?>">
 									<?php
 									$slug = $status->slug;
-									echo esc_html( $post_count->$slug ); ?>
+									echo (property_exists($post_count, $slug) ? esc_html( $post_count->$slug ) : 0); ?>
 								</a>
 							</td>
 							<td>


### PR DESCRIPTION
In the dashboard, if the $post_count object has no results for a custom status (for instance, if you create a status called 'in progress', but have not yet assigned that status to a post), line 166 will generate an error:

Notice:  Undefined property: stdClass::$in-progress in /var/www/html/web/app/plugins/edit-flow/modules/dashboard/dashboard.php on line 166

Added a check to see if the object has the property before attempting to use it.