### PR TITLE
Adding vipgo-helper.php in order to allow developers to load the plug…

### DIFF
--- a/vipgo-helper.php
+++ b/vipgo-helper.php
@@ -11,6 +11,7 @@ add_action( 'after_setup_theme', 'EditFlow' );
 add_filter( 'after_setup_theme', 'edit_flow_wpcom_load_modules' );
 function edit_flow_wpcom_load_modules() {
 	global $edit_flow;
-	if ( method_exists( $edit_flow, 'action_ef_loaded_load_modules' ) )
+	if ( method_exists( $edit_flow, 'action_ef_loaded_load_modules' ) ) {
 		$edit_flow->action_ef_loaded_load_modules();
+	}
 }

--- a/vipgo-helper.php
+++ b/vipgo-helper.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * Ensure Edit Flow is instantiated
+ */
+add_action( 'after_setup_theme', 'EditFlow' );
+
+/**
+ * Edit Flow loads modules after plugins_loaded, which has already been fired when loading via wpcom_vip_load_plugins
+ * Let's run the method at after_setup_themes
+ */
+add_filter( 'after_setup_theme', 'edit_flow_wpcom_load_modules' );
+function edit_flow_wpcom_load_modules() {
+	global $edit_flow;
+	if ( method_exists( $edit_flow, 'action_ef_loaded_load_modules' ) )
+		$edit_flow->action_ef_loaded_load_modules();
+}


### PR DESCRIPTION
…in using the `wpcom_vip_load_plugin()` function

Since loading the plugin from within a theme's functions.php is happenning after the `plugins_loaded` hook is triggerred, we need to initiate the plugin on the `after_setup_theme` hook.

Since the plugin's default directory name does not match the .php file, when using the `wpcom_vip_load_plugin()` function following notication is necessary:

```
wpcom_vip_load_plugin( 'Edit-Flow/edit_flow.php' );
```

Fixes #368