### PR TITLE
Fix ef_pre_insert_editorial_comment filter

### DIFF
--- a/modules/editorial-comments/editorial-comments.php
+++ b/modules/editorial-comments/editorial-comments.php
@@ -326,7 +326,7 @@ class EF_Editorial_Comments extends EF_Module
 			    'comment_approved' => self::comment_type,
 			);
 
-			apply_filters( 'ef_pre_insert_editorial_comment', $data );
+			$data = apply_filters( 'ef_pre_insert_editorial_comment', $data );
 
 			// Insert Comment
 			$comment_id = wp_insert_comment($data);


### PR DESCRIPTION
The `apply_filters` function is getting called wrongly. (ie) The return value of the function is not getting stored anywhere, esentially rendering the filter useless.

This PR fixes that and also passes `$_POST` as an additional parameter to the filter.