### PR TITLE
travis-ci: drop support for hhvm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ env:
 # Test WP master, current and previous stable releases on most popular PHP 5.5, 5.6 (w/ multisite enabled for 5.6)
 # Test WP master, current and previous stable releases on minimum PHP 5.2 (w/o multisite enabled)
 # Test WP current on PHP 5.3, 5.4 (w/o multisite enabled)
-# Test WP master on PHP hhvm, 7.0 and nightly (w/o multisite enabled)
+# Test WP master on PHP 7.0 and nightly (w/o multisite enabled)
 
 matrix:
   include:
@@ -42,12 +42,9 @@ matrix:
       env: WP_VERSION=master WP_MULTISITE=0
     - php: "7.0"
       env: WP_VERSION=4.5 WP_MULTISITE=0
-    - php: "hhvm"
-      env: WP_VERSION=master WP_MULTISITE=0
     - php: "nightly"
       env: WP_VERSION=master WP_MULTISITE=0
   allow_failures:
-    - php: "hhvm"
     - php: "nightly"
 
 before_script:


### PR DESCRIPTION
Since WordPress doesn`t support hhvm anymore, lets decrease the unit testing complexity by removing it here too