### PR TITLE
Status localize

### DIFF
--- a/common/php/class-module.php
+++ b/common/php/class-module.php
@@ -219,7 +219,7 @@ class EF_Module {
 		} else if ( array_key_exists( $status, $builtin_stati ) ) {
 			$status_friendly_name = $builtin_stati[$status];
 		}
-		return $status_friendly_name;
+		return esc_html__( $status_friendly_name, 'edit-flow');
 	}
 	
 	/**

--- a/modules/custom-status/custom-status.php
+++ b/modules/custom-status/custom-status.php
@@ -405,7 +405,7 @@ class EF_Custom_Status extends EF_Module {
 			// Load the custom statuses
 			foreach( $custom_statuses as $status ) {
 				$all_statuses[] = array(
-					'name' => esc_js( $status->name ),
+					'name' => esc_js( esc_html__( $status->name, 'edit-flow') ),
 					'slug' => esc_js( $status->slug ),
 					'description' => esc_js( $status->description ),
 				);


### PR DESCRIPTION
This PR is intended to fix the issue #377 . Also, when checking this out I could see that the status dropdown from the right side of the page when adding/editing a post was not localized either. The options were all in English even if the language was set to French, for example.  