### PR TITLE
Fix #243 - Offset post times to UTC+0 for Calendars

### DIFF
--- a/modules/calendar/calendar.php
+++ b/modules/calendar/calendar.php
@@ -8,12 +8,12 @@
 if ( !class_exists('EF_Calendar') ) {
 
 class EF_Calendar extends EF_Module {
-
+	
 	const usermeta_key_prefix = 'ef_calendar_';
 	const screen_id = 'dashboard_page_calendar';
-
+	
 	var $module;
-
+	
 	var $start_date = '';
 	var $current_week = 1;
 	var $total_weeks = 6; // default number of weeks to show per screen
@@ -27,6 +27,7 @@ class EF_Calendar extends EF_Module {
 	 * Construct the EF_Calendar class
 	 */
 	function __construct() {
+	
 		$this->module_url = $this->get_module_url( __FILE__ );
 		// Register the module with Edit Flow
 		$args = array(
@@ -62,17 +63,17 @@ class EF_Calendar extends EF_Module {
 				),
 			'settings_help_sidebar' => __( '<p><strong>For more information:</strong></p><p><a href="http://editflow.org/features/calendar/">Calendar Documentation</a></p><p><a href="http://wordpress.org/tags/edit-flow?forum_id=10">Edit Flow Forum</a></p><p><a href="https://github.com/danielbachhuber/Edit-Flow">Edit Flow on Github</a></p>', 'edit-flow' ),
 		);
-		$this->module = EditFlow()->register_module( 'calendar', $args );
-
+		$this->module = EditFlow()->register_module( 'calendar', $args );		
+		
 	}
-
+	
 	/**
 	 * Initialize all of our methods and such. Only runs if the module is active
 	 *
 	 * @uses add_action()
 	 */
 	function init() {
-
+		
 		// .ics calendar subscriptions
 		add_action( 'wp_ajax_ef_calendar_ics_subscription', array( $this, 'handle_ics_subscription' ) );
 		add_action( 'wp_ajax_nopriv_ef_calendar_ics_subscription', array( $this, 'handle_ics_subscription' ) );
@@ -84,19 +85,19 @@ class EF_Calendar extends EF_Module {
 
 		// Define the create-post capability
 		$this->create_post_cap = apply_filters( 'ef_calendar_create_post_cap', 'edit_posts' );
-
+		
 		require_once( EDIT_FLOW_ROOT . '/common/php/' . 'screen-options.php' );
 		add_screen_options_panel( self::usermeta_key_prefix . 'screen_options', __( 'Calendar Options', 'edit-flow' ), array( $this, 'generate_screen_options' ), self::screen_id, false, true );
 		add_action( 'admin_init', array( $this, 'handle_save_screen_options' ) );
-
+		
 		add_action( 'admin_init', array( $this, 'register_settings' ) );
-		add_action( 'admin_menu', array( $this, 'action_admin_menu' ) );
+		add_action( 'admin_menu', array( $this, 'action_admin_menu' ) );		
 		add_action( 'admin_print_styles', array( $this, 'add_admin_styles' ) );
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_admin_scripts' ) );
-
+		
 		// Ajax manipulation for the calendar
 		add_action( 'wp_ajax_ef_calendar_drag_and_drop', array( $this, 'handle_ajax_drag_and_drop' ) );
-
+		
 		// Ajax insert post placeholder for a specific date
 		add_action( 'wp_ajax_ef_insert_post', array( $this, 'handle_ajax_insert_post' ) );
 
@@ -113,7 +114,7 @@ class EF_Calendar extends EF_Module {
 		add_action( 'pre_post_update', array( $this, 'fix_post_date_on_update_part_one' ), 10, 2 );
 		add_action( 'post_updated', array( $this, 'fix_post_date_on_update_part_two' ), 10, 3 );
 	}
-
+	
 	/**
 	 * Load the capabilities onto users the first time the module is run
 	 *
@@ -156,18 +157,18 @@ class EF_Calendar extends EF_Module {
 			// Technically we've run this code before so we don't want to auto-install new data
 			$edit_flow->update_module_option( $this->module->name, 'loaded_once', true );
 		}
-
+		
 	}
-
+	
 	/**
 	 * Add the calendar link underneath the "Dashboard"
 	 *
 	 * @uses add_submenu_page
 	 */
-	function action_admin_menu() {
+	function action_admin_menu() {	
 		add_submenu_page('index.php', __('Calendar', 'edit-flow'), __('Calendar', 'edit-flow'), apply_filters( 'ef_view_calendar_cap', 'ef_view_calendar' ), $this->module->slug, array( $this, 'view_calendar' ) );
 	}
-
+	
 	/**
 	 * Add any necessary CSS to the WordPress admin
 	 *
@@ -179,7 +180,7 @@ class EF_Calendar extends EF_Module {
 		if ( $pagenow == 'index.php' && isset( $_GET['page'] ) && $_GET['page'] == 'calendar' )
 			wp_enqueue_style( 'edit-flow-calendar-css', $this->module_url . 'lib/calendar.css', false, EDIT_FLOW_VERSION );
 	}
-
+	
 	/**
 	 * Add any necessary JS to the WordPress admin
 	 *
@@ -189,7 +190,7 @@ class EF_Calendar extends EF_Module {
 	function enqueue_admin_scripts() {
 
 		$this->enqueue_datepicker_resources();
-
+		
 		if ( $this->is_whitelisted_functional_view() ) {
 			$js_libraries = array(
 				'jquery',
@@ -202,30 +203,30 @@ class EF_Calendar extends EF_Module {
 				wp_enqueue_script( $js_library );
 			}
 			wp_enqueue_script( 'edit-flow-calendar-js', $this->module_url . 'lib/calendar.js', $js_libraries, EDIT_FLOW_VERSION, true );
-
+			
 			$ef_cal_js_params = array( 'can_add_posts' => current_user_can( $this->create_post_cap ) ? 'true' : 'false' );
 			wp_localize_script( 'edit-flow-calendar-js', 'ef_calendar_params', $ef_cal_js_params );
 		}
-
+		
 	}
-
+	
 	/**
 	 * Prepare the options that need to appear in Screen Options
 	 *
 	 * @since 0.7
-	 */
+	 */ 
 	function generate_screen_options() {
-
+		
 		$output = '';
 		$screen_options = $this->get_screen_options();
-
+		
 		$output .= __( 'Number of Weeks: ', 'edit-flow' );
 		$output .= '<select id="' . self::usermeta_key_prefix . 'num_weeks" name="' . self::usermeta_key_prefix . 'num_weeks">';
 		for( $i = 1; $i <= 12; $i++ ) {
 			$output .= '<option value="' . esc_attr( $i ) . '" ' . selected( $i, $screen_options['num_weeks'], false ) . '>' . esc_attr( $i ) . '</option>';
 		}
 		$output .= '</select>';
-
+		
 		$output .= '&nbsp;&nbsp;&nbsp;<input id="screen-options-apply" name="screen-options-apply" type="submit" value="' . __( 'Apply' ) . '" class="button-secondary" />';
 
 		if ( 'on' == $this->module->options->ics_subscription && $this->module->options->ics_secret_key ) {
@@ -239,41 +240,41 @@ class EF_Calendar extends EF_Module {
 			$output .= __( 'Subscribe in iCal or Google Calendar', 'edit-flow' );
 			$output .= ':<br /><input type="text" size="100" value="' . esc_attr( $subscription_link ) . '" />';
 		}
-
-		return $output;
+		
+		return $output;	
 	}
-
+	
 	/**
 	 * Handle the request to save the screen options
 	 *
 	 * @since 0.7
 	 */
 	function handle_save_screen_options() {
-
+		
 		// Only handle screen options submissions from the current screen
 		if ( !isset( $_POST['screen-options-apply'], $_POST['ef_calendar_num_weeks'] ) )
 			return;
-
+		
 		// Nonce check
 		if ( !wp_verify_nonce( $_POST['_wpnonce-' . self::usermeta_key_prefix . 'screen_options'], 'save_settings-' . self::usermeta_key_prefix . 'screen_options' ) )
 			wp_die( $this->module->messages['nonce-failed'] );
-
+		
 		// Get the current screen options
 		$screen_options = $this->get_screen_options();
-
+		
 		// Save the number of weeks to show
 		$screen_options['num_weeks'] = (int)$_POST['ef_calendar_num_weeks'];
-
+		
 		// Save the screen options
 		$current_user = wp_get_current_user();
 		$this->update_user_meta( $current_user->ID, self::usermeta_key_prefix . 'screen_options', $screen_options );
-
+		
 		// Redirect after we're complete
 		$redirect_to = menu_page_url( $this->module->slug, false );
 		wp_redirect( $redirect_to );
 		exit;
 	}
-
+	
 	/**
 	 * Handle an AJAX request from the calendar to update a post's timestamp.
 	 * Notes:
@@ -286,30 +287,30 @@ class EF_Calendar extends EF_Module {
 	 */
 	function handle_ajax_drag_and_drop() {
 		global $wpdb;
-
+		
 		// Nonce check!
 		if ( !wp_verify_nonce( $_POST['nonce'], 'ef-calendar-modify' ) )
 			$this->print_ajax_response( 'error', $this->module->messages['nonce-failed'] );
-
+		
 		// Check that we got a proper post
 		$post_id = (int)$_POST['post_id'];
 		$post = get_post( $post_id );
 		if ( !$post )
 			$this->print_ajax_response( 'error', $this->module->messages['missing-post'] );
-
+			
 		// Check that the user can modify the post
 		if ( !$this->current_user_can_modify_post( $post ) )
 			$this->print_ajax_response( 'error', $this->module->messages['invalid-permissions'] );
-
+			
 		// Check that it's not yet published
 		if ( in_array( $post->post_status, $this->published_statuses ) )
 			$this->print_ajax_response( 'error', sprintf( $this->module->messages['published-post-ajax'], get_edit_post_link( $post_id ) ) );
-
+		
 		// Check that the new date passed is a valid one
 		$next_date_full = strtotime( $_POST['next_date'] );
 		if ( !$next_date_full )
 			$this->print_ajax_response( 'error', __( 'Something is wrong with the format for the new date.', 'edit-flow' ) );
-
+		
 		// Persist the old hourstamp because we can't manipulate the exact time on the calendar
 		// Bump the last modified timestamps too
 		$existing_time = date( 'H:i:s', strtotime( $post->post_date ) );
@@ -319,13 +320,13 @@ class EF_Calendar extends EF_Module {
 			'post_modified' => current_time( 'mysql' ),
 			'post_modified_gmt' => current_time( 'mysql', 1 ),
 		);
-
+		
 		// By default, changing a post on the calendar won't set the timestamp.
 		// If the user desires that to be the behaviour, they can set the result of this filter to 'true'
 		// With how WordPress works internally, setting 'post_date_gmt' will set the timestamp
 		if ( apply_filters( 'ef_calendar_allow_ajax_to_set_timestamp', false ) )
 			$new_values['post_date_gmt'] = date( 'Y-m-d', $next_date_full ) . ' ' . $existing_time_gmt;
-
+		
 		// We have to do SQL unfortunately because of core bugginess
 		// Note to those reading this: bug Nacin to allow us to finish the custom status API
 		// See http://core.trac.wordpress.org/ticket/18362
@@ -333,7 +334,7 @@ class EF_Calendar extends EF_Module {
 		clean_post_cache( $post->ID );
 		if ( !$response )
 			$this->print_ajax_response( 'error', $this->module->messages['update-error'] );
-
+		
 		$this->print_ajax_response( 'success', $this->module->messages['post-date-updated'] );
 		exit;
 	}
@@ -536,7 +537,7 @@ class EF_Calendar extends EF_Module {
 		wp_safe_redirect( add_query_arg( 'message', 'key-regenerated', menu_page_url( $this->module->settings_slug, false ) ) );
 		exit;
 	}
-
+	
 	/**
 	 * Get a user's screen options
 	 *
@@ -546,17 +547,17 @@ class EF_Calendar extends EF_Module {
 	 * @return array $screen_options The screen options values
 	 */
 	function get_screen_options() {
-
+		
 		$defaults = array(
 			'num_weeks' => (int)$this->total_weeks,
 		);
 		$current_user = wp_get_current_user();
 		$screen_options = $this->get_user_meta( $current_user->ID, self::usermeta_key_prefix . 'screen_options', true );
 		$screen_options = array_merge( (array)$defaults, (array)$screen_options );
-
+		
 		return $screen_options;
 	}
-
+	
 	/**
 	 * Get the user's filters for calendar, either with $_GET or from saved
 	 *
@@ -564,7 +565,7 @@ class EF_Calendar extends EF_Module {
 	 * @return array $filters All of the set or saved calendar filters
 	 */
 	function get_filters() {
-
+				
 		$current_user = wp_get_current_user();
 		$filters = array();
 		$old_filters = $this->get_user_meta( $current_user->ID, self::usermeta_key_prefix . 'filters', true );
@@ -577,7 +578,7 @@ class EF_Calendar extends EF_Module {
 				'start_date' => date( 'Y-m-d', current_time( 'timestamp' ) ),
 			);
 		$old_filters = array_merge( $default_filters, (array)$old_filters );
-
+		
 		// Sanitize and validate any newly added filters
 		foreach( $old_filters as $key => $old_value ) {
 			if ( isset( $_GET[$key] ) && false !== ( $new_value = $this->sanitize_filter( $key, $_GET[$key] ) ) )
@@ -590,33 +591,33 @@ class EF_Calendar extends EF_Module {
 		$filters['start_date'] = $this->get_beginning_of_week( $filters['start_date'] );
 
 		$filters = apply_filters( 'ef_calendar_filter_values', $filters, $old_filters );
-
+		
 		$this->update_user_meta( $current_user->ID, self::usermeta_key_prefix . 'filters', $filters );
-
+		
 		return $filters;
 	}
-
+	
 	/**
 	 * Build all of the HTML for the calendar view
 	 */
 	function view_calendar() {
 
 		$this->dropdown_taxonomies = array();
-
+		
 		$supported_post_types = $this->get_post_types_for_module( $this->module );
-
+		
 		// Get the user's screen options for displaying the data
 		$screen_options = $this->get_screen_options();
 		// Total number of weeks to display on the calendar. Run it through a filter in case we want to override the
 		// user's standard
 		$this->total_weeks = apply_filters( 'ef_calendar_total_weeks', $screen_options['num_weeks'], 'dashboard' );
-
+		
 		$dotw = array(
 			'Sat',
 			'Sun',
 		);
 		$dotw = apply_filters( 'ef_calendar_weekend_days', $dotw );
-
+		
 		// Get filters either from $_GET or from user settings
 		$filters = $this->get_filters();
 		// For generating the WP Query objects later on
@@ -627,7 +628,7 @@ class EF_Calendar extends EF_Module {
 			'author'      => $filters['author']
 		);
 		$this->start_date = $filters['start_date'];
-
+		
 		// We use this later to label posts if they need labeling
 		if ( count( $supported_post_types ) > 1 ) {
 			$all_post_types = get_post_types( null, 'objects' );
@@ -638,7 +639,7 @@ class EF_Calendar extends EF_Module {
 			$dates[$i] = $heading_date;
 			$heading_date = date( 'Y-m-d', strtotime( "+1 day", strtotime( $heading_date ) ) );
 		}
-
+		
 		// we sort by post statuses....... eventually
 		$post_statuses = $this->get_post_statuses();
 		?>
@@ -670,7 +671,7 @@ class EF_Calendar extends EF_Module {
 			?>
 
 			<div id="ef-calendar-wrap"><!-- Calendar Wrapper -->
-
+					
 			<?php $this->print_top_navigation( $filters, $dates ); ?>
 
 			<?php
@@ -682,7 +683,7 @@ class EF_Calendar extends EF_Module {
 					$table_classes[] = 'two-weeks-showing';
 				elseif ( $this->total_weeks == 3 )
 					$table_classes[] = 'three-weeks-showing';
-
+					
 				$table_classes = apply_filters( 'ef_calendar_table_classes', $table_classes );
 			?>
 			<table id="ef-calendar-view" class="<?php echo esc_attr( implode( ' ', $table_classes ) ); ?>">
@@ -692,7 +693,7 @@ class EF_Calendar extends EF_Module {
 				</tr>
 				</thead>
 				<tbody>
-
+				
 				<?php
 				$current_month = date_i18n( 'F', strtotime( $filters['start_date'] ) );
 				for( $current_week = 1; $current_week <= $this->total_weeks; $current_week++ ):
@@ -711,7 +712,7 @@ class EF_Calendar extends EF_Module {
 							$current_month = $single_date_month;
 						}
 						$week_single_date = date( 'Y-m-d', strtotime( "+1 day", strtotime( $week_single_date ) ) );
-					}
+					}			
 				?>
 				<?php if ( $split_month ): ?>
 				<tr class="month-marker">
@@ -747,26 +748,26 @@ class EF_Calendar extends EF_Module {
 						unset( $week_posts[$week_single_date] );
 						foreach( $week_posts_by_status as $status ) {
 							foreach( $status as $num => $post ) {
-								$week_posts[$week_single_date][] = $post;
+								$week_posts[$week_single_date][] = $post; 
 							}
 						}
 					}
-
+				
 					$td_classes = array(
 						'day-unit',
 					);
 					$day_name = date( 'D', strtotime( $week_single_date ) );
-
+					
 					if ( in_array( $day_name, $dotw ) )
 						$td_classes[] = 'weekend-day';
-
+					
 					if ( $week_single_date == date( 'Y-m-d', current_time( 'timestamp' ) ) )
 						$td_classes[] = 'today';
-
+						
 					// Last day of the week
 					if ( $day_num == 6 )
 						$td_classes[] = 'last-day';
-
+						
 					$td_classes = apply_filters( 'ef_calendar_table_td_classes', $td_classes, $week_single_date );
 				?>
 				<td class="<?php echo esc_attr( implode( ' ', $td_classes ) ); ?>" id="<?php echo esc_attr( $week_single_date ); ?>">
@@ -782,11 +783,11 @@ class EF_Calendar extends EF_Module {
 
 							$week_posts[$week_single_date] = apply_filters( 'ef_calendar_posts_for_week', $week_posts[$week_single_date] );
 
-							foreach ( $week_posts[$week_single_date] as $num => $post ){
-								echo $this->generate_post_li_html( $post, $week_single_date, $num );
-							}
+							foreach ( $week_posts[$week_single_date] as $num => $post ){ 
+								echo $this->generate_post_li_html( $post, $week_single_date, $num ); 
+							} 
 
-						 }
+						 } 
 						 ?>
 					</ul>
 					<?php if ( $this->hidden ): ?>
@@ -799,14 +800,14 @@ class EF_Calendar extends EF_Module {
 
 						<form method="POST" class="post-insert-dialog">
 							<?php /* translators: %1$s = post type name, %2$s = date */ ?>
-							<h1><?php echo sprintf( __( 'Schedule a %1$s for %2$s', 'edit-flow' ), $this->get_quick_create_post_type_name(), $date_formatted ); ?></h1>
+							<h1><?php echo sprintf( __( 'Schedule a %1$s for %2$s', 'edit-flow' ), $this->get_quick_create_post_type_name(), $date_formatted ); ?></h1>	
 							<?php /* translators: %s = post type name */ ?>
 							<input type="text" class="post-insert-dialog-post-title" name="post-insert-dialog-post-title" placeholder="<?php echo esc_attr( sprintf( _x( '%s Title', 'post type name', 'edit-flow' ), $this->get_quick_create_post_type_name() ) ); ?>">
 							<input type="hidden" class="post-insert-dialog-post-date" name="post-insert-dialog-post-title" value="<?php echo esc_attr( $week_single_date ); ?>">
-							<div class="post-insert-dialog-controls">
+							<div class="post-insert-dialog-controls">		
 								<input type="submit" class="button left" value="<?php echo esc_html( sprintf( _x( 'Create %s', 'post type name', 'edit-flow' ), $this->get_quick_create_post_type_name() ) ); ?>">
 								<a class="post-insert-dialog-edit-post-link" href="#"><?php echo esc_html( sprintf( _x( 'Edit %s', 'post type name', 'edit-flow' ), $this->get_quick_create_post_type_name() ) ); ?>&nbsp;&raquo;</a>
-							</div>
+							</div>	
 							<div class="spinner">&nbsp;</div>
 						</form>
 					<?php endif; ?>
@@ -814,22 +815,22 @@ class EF_Calendar extends EF_Module {
 					</td>
 					<?php endforeach; ?>
 					</tr>
-
+					
 					<?php endfor; ?>
-
-					</tbody>
+					
+					</tbody>		
 					</table><!-- /Week Wrapper -->
 					<?php
 					// Nonce field for AJAX actions
 					wp_nonce_field( 'ef-calendar-modify', 'ef-calendar-modify' ); ?>
-
+					
 					<div class="clear"></div>
 				</div><!-- /Calendar Wrapper -->
 
 			  </div>
 
-		<?php
-
+		<?php 
+		
 	}
 
 	/**
@@ -855,7 +856,7 @@ class EF_Calendar extends EF_Module {
 
 		$post_id = $post->ID;
 		$edit_post_link = get_edit_post_link( $post_id );
-
+		
 		$post_classes = array(
 			'day-item',
 			'custom-status-' . $post->post_status,
@@ -865,10 +866,10 @@ class EF_Calendar extends EF_Module {
 		// This is checked on the ajax request too.
 		if ( $this->current_user_can_modify_post( $post ) && !in_array( $post->post_status, $this->published_statuses ) )
 			$post_classes[] = 'sortable';
-
+		
 		if ( in_array( $post->post_status, $this->published_statuses ) )
 			$post_classes[] = 'is-published';
-
+		
 		// Hide posts over a certain number to prevent clutter, unless user is only viewing 1 or 2 weeks
 		$max_visible_posts = apply_filters( 'ef_calendar_max_visible_posts_per_date', $this->max_visible_posts_per_date);
 
@@ -877,7 +878,7 @@ class EF_Calendar extends EF_Module {
 			$this->hidden++;
 		}
 		$post_classes = apply_filters( 'ef_calendar_table_td_li_classes', $post_classes, $post_date, $post->ID );
-
+		
 		?>
 		<li class="<?php echo esc_attr( implode( ' ', $post_classes ) ); ?>" id="post-<?php echo esc_attr( $post->ID ); ?>">
 			<div style="clear:right;"></div>
@@ -915,9 +916,9 @@ class EF_Calendar extends EF_Module {
 	 * has been separated out so various ajax functions can reload certain
 	 * parts of an inner html element.
 	 * @param  array $ef_calendar_item_information_fields
-	 * @param  WP_Post $post
-	 * @param  array $published_statuses
-	 *
+	 * @param  WP_Post $post                               
+	 * @param  array $published_statuses                 
+	 * 
 	 * @since 0.8
 	 */
 	function get_inner_information( $ef_calendar_item_information_fields, $post ) {
@@ -994,12 +995,12 @@ class EF_Calendar extends EF_Module {
 			break;
 			case 'checkbox':
 				$output = '<select class="metadata-edit">';
-
+				
 				if( $value == 'No' )
 					$output .= '<option value="0">No</option><option value="1">Yes</option>';
 				else
 					$output .= '<option value="1">Yes</option><option value="0">No</option>';
-
+				
 				$output .= '</select>';
 
 				return $output;
@@ -1104,7 +1105,7 @@ class EF_Calendar extends EF_Module {
 			if( current_user_can( $ed_cap, $post->ID ) )
 				$information_fields[$key]['editable'] = true;
 		}
-
+		
 		$information_fields = apply_filters( 'ef_calendar_item_information_fields', $information_fields, $post->ID );
 		foreach( $information_fields as $field => $values ) {
 			// Allow filters to hide empty fields or to hide any given individual field. Hide empty fields by default.
@@ -1114,7 +1115,7 @@ class EF_Calendar extends EF_Module {
 		}
 		return $information_fields;
 	}
-
+	
 	/**
 	 * Generates the filtering and navigation options for the top of the calendar
 	 *
@@ -1129,10 +1130,10 @@ class EF_Calendar extends EF_Module {
 					<input type="hidden" name="page" value="calendar" />
 					<input type="hidden" name="start_date" value="<?php echo esc_attr( $filters['start_date'] ); ?>"/>
 					<!-- Filter by status -->
-					<?php
+					<?php 
 						foreach( $this->calendar_filters() as $select_id => $select_name ) {
 							echo $this->calendar_filter_options( $select_id, $select_name, $filters );
-						}
+						} 
 					?>
 					<input type="submit" id="post-query-submit" class="button-primary button" value="<?php _e( 'Filter', 'edit-flow' ); ?>"/>
 				</form>
@@ -1142,7 +1143,7 @@ class EF_Calendar extends EF_Module {
 				<form method="GET">
 					<input type="hidden" name="page" value="calendar" />
 					<input type="hidden" name="start_date" value="<?php echo esc_attr( $filters['start_date'] ); ?>"/>
-					<?php
+					<?php 
 					foreach( $this->calendar_filters() as $select_id => $select_name )
 						echo '<input type="hidden" name="'.$select_name.'" value="" />';
 					?>
@@ -1153,7 +1154,7 @@ class EF_Calendar extends EF_Module {
 			<?php /** Previous and next navigation items (translatable so they can be increased if needed )**/ ?>
 			<li class="date-change next-week">
 				<a title="<?php printf( __( 'Forward 1 week', 'edit-flow' ) ); ?>" href="<?php echo esc_url( $this->get_pagination_link( 'next', $filters, 1 ) ); ?>"><?php _e( '&rsaquo;', 'edit-flow' ); ?></a>
-				<?php if ( $this->total_weeks > 1): ?>
+				<?php if ( $this->total_weeks > 1): ?>			
 				<a title="<?php printf( __( 'Forward %d weeks', 'edit-flow' ), $this->total_weeks ); ?>" href="<?php echo esc_url( $this->get_pagination_link( 'next', $filters ) ); ?>"><?php _e( '&raquo;', 'edit-flow' ); ?></a>
 				<?php endif; ?>
 			</li>
@@ -1161,18 +1162,18 @@ class EF_Calendar extends EF_Module {
 				<a title="<?php printf( __( 'Today is %s', 'edit-flow' ), date( get_option( 'date_format' ), current_time( 'timestamp' ) ) ); ?>" href="<?php echo esc_url( $this->get_pagination_link( 'next', $filters, 0 ) ); ?>"><?php _e( 'Today', 'edit-flow' ); ?></a>
 			</li>
 			<li class="date-change previous-week">
-				<?php if ( $this->total_weeks > 1): ?>
+				<?php if ( $this->total_weeks > 1): ?>				
 				<a title="<?php printf( __( 'Back %d weeks', 'edit-flow' ), $this->total_weeks ); ?>"  href="<?php echo esc_url( $this->get_pagination_link( 'previous', $filters ) ); ?>"><?php _e( '&laquo;', 'edit-flow' ); ?></a>
 				<?php endif; ?>
 				<a title="<?php printf( __( 'Back 1 week', 'edit-flow' ) ); ?>" href="<?php echo esc_url( $this->get_pagination_link( 'previous', $filters, 1 ) ); ?>"><?php _e( '&lsaquo;', 'edit-flow' ); ?></a>
 			</li>
 			<li class="ajax-actions">
 				<img class="waiting" style="display:none;" src="<?php echo esc_url( admin_url( 'images/wpspin_light.gif' ) ); ?>" alt="" />
-			</li>
+			</li>			
 		</ul>
 	<?php
 	}
-
+	
 	/**
 	 * Generate the calendar header for a given range of dates
 	 *
@@ -1180,18 +1181,18 @@ class EF_Calendar extends EF_Module {
 	 * @return string $html Generated HTML for the header
 	 */
 	function get_time_period_header( $dates ) {
-
+		
 		$html = '';
 		foreach( $dates as $date ) {
 			$html .= '<th class="column-heading" >';
 			$html .= esc_html( date_i18n('l', strtotime( $date ) ) );
 			$html .= '</th>';
 		}
-
+		
 		return $html;
-
+		
 	}
-
+		
 	/**
 	 * Query to get all of the calendar posts for a given day
 	 *
@@ -1201,7 +1202,7 @@ class EF_Calendar extends EF_Module {
 	 */
 	function get_calendar_posts_for_week( $args = array(), $context = 'dashboard' ) {
 		global $wpdb;
-
+		
 		$supported_post_types = $this->get_post_types_for_module( $this->module );
 		$defaults = array(
 			'post_status'      => null,
@@ -1210,9 +1211,9 @@ class EF_Calendar extends EF_Module {
 			'post_type'        => $supported_post_types,
 			'posts_per_page'   => -1,
 		);
-
+						 
 		$args = array_merge( $defaults, $args );
-
+		
 		// Unpublished as a status is just an array of everything but 'publish'
 		if ( $args['post_status'] == 'unpublish' ) {
 			$args['post_status'] = '';
@@ -1233,13 +1234,13 @@ class EF_Calendar extends EF_Module {
 
 		if ( empty( $args['post_type'] ) || ! in_array( $args['post_type'], $supported_post_types ) )
 			$args['post_type'] = $supported_post_types;
-
+		
 		// Filter for an end user to implement any of their own query args
 		$args = apply_filters( 'ef_calendar_posts_query_args', $args, $context );
 		add_filter( 'posts_where', array( $this, 'posts_where_week_range' ) );
 		$post_results = new WP_Query( $args );
 		remove_filter( 'posts_where', array( $this, 'posts_where_week_range' ) );
-
+		
 		$posts = array();
 		while ( $post_results->have_posts() ) {
 			$post_results->the_post();
@@ -1247,11 +1248,11 @@ class EF_Calendar extends EF_Module {
 			$key_date = date( 'Y-m-d', strtotime( $post->post_date ) );
 			$posts[$key_date][] = $post;
 		}
-
+		
 		return $posts;
-
+		
 	}
-
+	
 	/**
 	 * Filter the WP_Query so we can get a week range of posts
 	 *
@@ -1260,46 +1261,46 @@ class EF_Calendar extends EF_Module {
 	 */
 	function posts_where_week_range( $where = '' ) {
 		global $wpdb;
-
+	
 		$beginning_date = $this->get_beginning_of_week( $this->start_date, 'Y-m-d', $this->current_week );
 		$ending_date = $this->get_ending_of_week( $this->start_date, 'Y-m-d', $this->current_week );
 		// Adjust the ending date to account for the entire day of the last day of the week
 		$ending_date = date( "Y-m-d", strtotime( "+1 day", strtotime( $ending_date ) ) );
 		$where = $where . $wpdb->prepare( " AND ($wpdb->posts.post_date >= %s AND $wpdb->posts.post_date < %s)", $beginning_date, $ending_date );
-
+	
 		return $where;
-	}
-
+	} 
+	
 	/**
 	 * Gets the link for the next time period
 	 *
 	 * @param string $direction 'previous' or 'next', direction to go in time
 	 * @param array $filters Any filters that need to be applied
-	 * @param int $weeks_offset Number of weeks we're offsetting the range
+	 * @param int $weeks_offset Number of weeks we're offsetting the range	
 	 * @return string $url The URL for the next page
 	 */
 	function get_pagination_link( $direction = 'next', $filters = array(), $weeks_offset = null ) {
 
 		$supported_post_types = $this->get_post_types_for_module( $this->module );
-
+		
 		if ( !isset( $weeks_offset ) )
 			$weeks_offset = $this->total_weeks;
 		else if ( $weeks_offset == 0 )
 			$filters['start_date'] = $this->get_beginning_of_week( date( 'Y-m-d', current_time( 'timestamp' ) ) );
-
+			
 		if ( $direction == 'previous' )
 			$weeks_offset = '-' . $weeks_offset;
-
+		
 		$filters['start_date'] = date( 'Y-m-d', strtotime( $weeks_offset . " weeks", strtotime( $filters['start_date'] ) ) );
 		$url = add_query_arg( $filters, menu_page_url( $this->module->slug, false ) );
 
 		if ( count( $supported_post_types ) > 1 )
 			$url = add_query_arg( 'cpt', $filters['cpt'] , $url );
-
+		
 		return $url;
-
+		
 	}
-
+	
 	/**
 	 * Given a day in string format, returns the day at the beginning of that week, which can be the given date.
 	 * The end of the week is determined by the blog option, 'start_of_week'.
@@ -1308,11 +1309,11 @@ class EF_Calendar extends EF_Module {
 	 *
 	 * @param string $date String representing a date
 	 * @param string $format Date format in which the end of the week should be returned
-	 * @param int $week Number of weeks we're offsetting the range
+	 * @param int $week Number of weeks we're offsetting the range	
 	 * @return string $formatted_start_of_week End of the week
 	 */
 	function get_beginning_of_week( $date, $format = 'Y-m-d', $week = 1 ) {
-
+		
 		$date = strtotime( $date );
 		$start_of_week = get_option( 'start_of_week' );
 		$day_of_week = date( 'w', $date );
@@ -1320,22 +1321,22 @@ class EF_Calendar extends EF_Module {
 		$additional = 3600 * 24 * 7 * ( $week - 1 );
 		$formatted_start_of_week = date( $format, $date + $additional );
 		return $formatted_start_of_week;
-
+		
 	}
-
+	
 	/**
 	 * Given a day in string format, returns the day at the end of that week, which can be the given date.
 	 * The end of the week is determined by the blog option, 'start_of_week'.
 	 *
-	 * @see http://www.php.net/manual/en/datetime.formats.date.php for valid date formats
+	 * @see http://www.php.net/manual/en/datetime.formats.date.php for valid date formats	
 	 *
 	 * @param string $date String representing a date
 	 * @param string $format Date format in which the end of the week should be returned
-	 * @param int $week Number of weeks we're offsetting the range
+	 * @param int $week Number of weeks we're offsetting the range		
 	 * @return string $formatted_end_of_week End of the week
 	 */
 	function get_ending_of_week( $date, $format = 'Y-m-d', $week = 1  ) {
-
+		
 		$date = strtotime( $date );
 		$end_of_week = get_option( 'start_of_week' ) - 1;
 		$day_of_week = date( 'w', $date );
@@ -1343,9 +1344,9 @@ class EF_Calendar extends EF_Module {
 		$additional = 3600 * 24 * 7 * ( $week - 1 );
 		$formatted_end_of_week = date( $format, $date + $additional );
 		return $formatted_end_of_week;
-
+		
 	}
-
+	
 	/**
 	 * Human-readable time range for the calendar
 	 * Shows something like "for October 30th through November 26th" for a four-week period
@@ -1353,7 +1354,7 @@ class EF_Calendar extends EF_Module {
 	 * @since 0.7
 	 */
 	function calendar_time_range() {
-
+		
 		$first_datetime = strtotime( $this->start_date );
 		$first_date = date_i18n( get_option( 'date_format' ), $first_datetime );
 		$total_days = ( $this->total_weeks * 7 ) - 1;
@@ -1361,7 +1362,7 @@ class EF_Calendar extends EF_Module {
 		$last_date = date_i18n( get_option( 'date_format' ), $last_datetime );
 		echo sprintf( __( 'for %1$s through %2$s', 'edit-flow' ), $first_date, $last_date );
 	}
-
+	
 	/**
 	 * Check whether the current user should have the ability to modify the post
 	 *
@@ -1371,10 +1372,10 @@ class EF_Calendar extends EF_Module {
 	 * @return bool $can Whether or not the current user can modify the post
 	 */
 	function current_user_can_modify_post( $post ) {
-
+		
 		if ( !$post )
 			return false;
-
+			
 		$post_type_object = get_post_type_object( $post->post_type );
 
 		// Editors and admins are fine
@@ -1386,19 +1387,19 @@ class EF_Calendar extends EF_Module {
 		// Those who can publish posts can move any of their own stuff
 		if ( current_user_can( $post_type_object->cap->publish_posts, $post->ID ) && wp_get_current_user()->ID == $post->post_author )
 			return true;
-
+		
 		return false;
 	}
-
+	
 	/**
 	 * Register settings for notifications so we can partially use the Settings API
 	 * We use the Settings API for form generation, but not saving because we have our
 	 * own way of handling the data.
-	 *
+	 * 
 	 * @since 0.7
 	 */
 	function register_settings() {
-
+		
 			add_settings_section( $this->module->options_group_name . '_general', false, '__return_false', $this->module->options_group_name );
 			add_settings_field( 'number_of_weeks', __( 'Number of weeks to show', 'edit-flow' ), array( $this, 'settings_number_weeks_option' ), $this->module->options_group_name, $this->module->options_group_name . '_general' );
 			add_settings_field( 'post_types', __( 'Post types to show', 'edit-flow' ), array( $this, 'settings_post_types_option' ), $this->module->options_group_name, $this->module->options_group_name . '_general' );
@@ -1406,7 +1407,7 @@ class EF_Calendar extends EF_Module {
 			add_settings_field( 'ics_subscription', __( 'Subscription in iCal or Google Calendar', 'edit-flow' ), array( $this, 'settings_ics_subscription_option' ), $this->module->options_group_name, $this->module->options_group_name . '_general' );
 
 	}
-
+	
 	/**
 	 * Choose the post types that should be displayed on the calendar
 	 *
@@ -1423,11 +1424,11 @@ class EF_Calendar extends EF_Module {
 	 * @since 0.8
 	 */
 	function settings_quick_create_post_type_option() {
-
+		
 		$allowed_post_types = $this->get_all_post_types();
 
 		echo "<select name='" . $this->module->options_group_name . "[quick_create_post_type]'>";
-		foreach( $allowed_post_types as $post_type => $title )
+		foreach( $allowed_post_types as $post_type => $title ) 
 			echo "<option value='" . esc_attr( $post_type ) . "' " . selected( $post_type, $this->module->options->quick_create_post_type, false ) . ">".esc_html( $title )."</option>";
 		echo "</select>";
 
@@ -1492,7 +1493,7 @@ class EF_Calendar extends EF_Module {
 
 		return $options;
 	}
-
+	
 	/**
 	 * Settings page for calendar
 	 */
@@ -1501,8 +1502,8 @@ class EF_Calendar extends EF_Module {
 		?>
 		<form class="basic-settings" action="<?php echo esc_url( menu_page_url( $this->module->settings_slug, false ) ); ?>" method="post">
 			<?php settings_fields( $this->module->options_group_name ); ?>
-			<?php do_settings_sections( $this->module->options_group_name ); ?>
-			<?php
+			<?php do_settings_sections( $this->module->options_group_name ); ?>	
+			<?php				
 				echo '<input id="edit_flow_module_name" name="edit_flow_module_name" type="hidden" value="' . esc_attr( $this->module->name ) . '" />';
 			?>
 			<p class="submit"><?php submit_button( null, 'primary', 'submit', false ); ?><a class="cancel-settings-link" href="<?php echo esc_url( EDIT_FLOW_SETTINGS_PAGE ); ?>"><?php _e( 'Back to Edit Flow', 'edit-flow' ); ?></a></p>
@@ -1541,7 +1542,7 @@ class EF_Calendar extends EF_Module {
 		$post_date = sanitize_text_field( $_POST['ef_insert_date'] );
 
 		$post_status = $this->get_default_post_status();
-
+		
 		// Set new post parameters
 		$post_placeholder = array(
 			'post_title' => $post_title,
@@ -1577,7 +1578,7 @@ class EF_Calendar extends EF_Module {
 	/**
 	 * Returns the singular label for the posts that are
 	 * quick-created on the calendar
-	 *
+	 * 
 	 * @return str Singular label for a post-type
 	 */
 	function get_quick_create_post_type_name(){
@@ -1600,7 +1601,7 @@ class EF_Calendar extends EF_Module {
 
 		if ( ! wp_verify_nonce( $_POST['nonce'], 'ef-calendar-modify' ) )
 			$this->print_ajax_response( 'error', $this->module->messages['nonce-failed'] );
-
+		
 		// Check that we got a proper post
 		$post_id = ( int )$_POST['post_id'];
 		$post = get_post( $post_id );
@@ -1615,8 +1616,8 @@ class EF_Calendar extends EF_Module {
 			$edit_check = 'edit_post';
 
 		if ( !current_user_can( $edit_check, $post->ID ) )
-			$this->print_ajax_response( 'error', $this->module->messages['invalid-permissions'] );
-
+			$this->print_ajax_response( 'error', $this->module->messages['invalid-permissions'] );	
+			
 		// Check that the user can modify the post
 		if ( ! $this->current_user_can_modify_post( $post ) )
 			$this->print_ajax_response( 'error', $this->module->messages['invalid-permissions'] );
@@ -1629,8 +1630,8 @@ class EF_Calendar extends EF_Module {
 		$metadata_types = array();
 
 		if ( !$this->module_enabled( 'editorial_metadata' ) )
-			$this->print_ajax_response( 'error', $this->module->messages['update-error'] );
-
+			$this->print_ajax_response( 'error', $this->module->messages['update-error'] );	
+		
 		$metadata_types = array_keys( EditFlow()->editorial_metadata->get_supported_metadata_types() );
 
 		// Update an editorial metadata field
@@ -1664,7 +1665,7 @@ class EF_Calendar extends EF_Module {
 			$this->print_ajax_response( 'error', __( 'Metadata could not be updated.', 'edit-flow' ) );
 	}
 
-	function calendar_filters() {
+	function calendar_filters() {		
 		$select_filter_names = array();
 
 		$select_filter_names['post_status'] = 'post_status';
@@ -1682,7 +1683,7 @@ class EF_Calendar extends EF_Module {
 	 *
 	 * @param string $key Filter being sanitized
 	 * @param string $dirty_value Value to be sanitized
-	 * @return string $sanitized_value Safe to use value
+	 * @return string $sanitized_value Safe to use value 
 	 */
 	function sanitize_filter( $key, $dirty_value ) {
 
@@ -1720,14 +1721,14 @@ class EF_Calendar extends EF_Module {
 	}
 
 	function calendar_filter_options( $select_id, $select_name, $filters ) {
-		switch( $select_id ){
+		switch( $select_id ){ 
 			case 'post_status':
 				$post_statuses = $this->get_post_statuses();
 			?>
 				<select id="<?php echo $select_id; ?>" name="<?php echo $select_name; ?>" >
 					<option value=""><?php _e( 'View all statuses', 'edit-flow' ); ?></option>
-					<?php
-						foreach ( $post_statuses as $post_status ) {
+					<?php 
+						foreach ( $post_statuses as $post_status ) { 
 							echo "<option value='" . esc_attr( $post_status->slug ) . "' " . selected( $post_status->slug, $filters['post_status'] ) . ">" . esc_html( $post_status->name ) . "</option>";
 						}
 					?>
@@ -1794,14 +1795,14 @@ class EF_Calendar extends EF_Module {
 
 	/**
 	 * This is a hack! hack! hack! until core is fixed
-	 *
+	 * 
 	 * The calendar uses 'post_date' field to store the position on the calendar
 	 * If a post has a core post status assigned (e.g. 'draft' or 'pending'), the `post_date`
 	 * field will be reset when `wp_update_post()`
 	 * is used: http://core.trac.wordpress.org/browser/tags/3.7.1/src/wp-includes/post.php#L2998
-	 *
+	 * 
 	 * This method temporarily caches the `post_date` field if it needs to be restored.
-	 *
+	 * 
 	 * @uses fix_post_date_on_update_part_two()
 	 */
 	public function fix_post_date_on_update_part_one( $post_ID, $data ) {
@@ -1821,14 +1822,14 @@ class EF_Calendar extends EF_Module {
 
 	/**
 	 * This is a hack! hack! hack! until core is fixed
-	 *
+	 * 
 	 * The calendar uses 'post_date' field to store the position on the calendar
 	 * If a post has a core post status assigned (e.g. 'draft' or 'pending'), the `post_date`
 	 * field will be reset when `wp_update_post()`
 	 * is used: http://core.trac.wordpress.org/browser/tags/3.7.1/src/wp-includes/post.php#L2998
-	 *
+	 * 
 	 * This method restores the `post_date` field if it needs to be restored.
-	 *
+	 * 
 	 * @uses fix_post_date_on_update_part_one()
 	 */
 	public function fix_post_date_on_update_part_two( $post_ID, $post_after, $post_before ) {
@@ -1842,7 +1843,7 @@ class EF_Calendar extends EF_Module {
 		$wpdb->update( $wpdb->posts, array( 'post_date' => $post_date ), array( 'ID' => $post_ID ) );
 		clean_post_cache( $post_ID );
 	}
-
+	
 } // EF_Calendar
-
+	
 } // class_exists('EF_Calendar')

--- a/modules/calendar/calendar.php
+++ b/modules/calendar/calendar.php
@@ -381,9 +381,9 @@ class EF_Calendar extends EF_Module {
 			foreach( $week_posts as $date => $day_posts ) {
 				foreach( $day_posts as $num => $post ) {
 
-					$start_date = date( 'Ymd', strtotime( $post->post_date ) ) . 'T' . date( 'His', strtotime( $post->post_date ) ) . 'Z';
-					$end_date = date( 'Ymd', strtotime( $post->post_date ) + (5 * 60) ) . 'T' . date( 'His', strtotime( $post->post_date ) + (5 * 60) ) . 'Z';
-					$last_modified = date( 'Ymd', strtotime( $post->post_modified_gmt ) ) . 'T' . date( 'His', strtotime( $post->post_modified_gmt ) ) . 'Z';
+					$start_date    = self::ics_format_time( $post->post_date );
+					$end_date      = self::ics_format_time( $post->post_date, 5 * MINUTE_IN_SECONDS );
+					$last_modified = self::ics_format_time( $post->post_modified );
 
 					// Remove the convert chars and wptexturize filters from the title
 					remove_filter( 'the_title', 'convert_chars' );
@@ -486,6 +486,33 @@ class EF_Calendar extends EF_Module {
 		$text = str_replace( ";", "\:", $text );
 		$text = str_replace( "\\", "\\\\", $text );
 		return $text;
+	}
+
+	/**
+	 * Convert a time string into a timestamp with the proper GMT offset
+	 * @param     $time_string
+	 * @param int $offset_in_seconds
+	 *
+	 * @return string|false
+	 */
+	public static function ics_format_time( $time_string, $offset_in_seconds = 0) {
+
+		// Timestamp it
+		$timestamp = strtotime( $time_string );
+
+		if( ! $timestamp ) {
+			return false;
+		}
+
+		// Add GMT Offset
+		$timestamp += -1 * get_option('gmt_offset') * HOUR_IN_SECONDS;
+
+		// Add manual offset
+		$timestamp += $offset_in_seconds;
+
+		// \T and \Z are escaped for literal T and Z characters
+		return date( 'Ymd\THis\Z', $timestamp );
+
 	}
 
 	/**

--- a/modules/calendar/calendar.php
+++ b/modules/calendar/calendar.php
@@ -506,8 +506,8 @@ class EF_Calendar extends EF_Module {
 			return false;
 		}
 
-		// Add GMT Offset
-		$timestamp += -1 * get_option('gmt_offset') * HOUR_IN_SECONDS;
+		// Subtract GMT Offset to return to UTC+0
+		$timestamp -= get_option('gmt_offset') * HOUR_IN_SECONDS;
 
 		// Add manual offset
 		$timestamp += $offset_in_seconds;

--- a/modules/calendar/calendar.php
+++ b/modules/calendar/calendar.php
@@ -490,9 +490,10 @@ class EF_Calendar extends EF_Module {
 	}
 
 	/**
-	 * Convert a time string into a timestamp with the proper GMT offset
-	 * @param     $time_string
-	 * @param int $offset_in_seconds
+	 * Convert a time string into a `.ics` formatted time string with the proper GMT offset
+	 *
+	 * @param     $time_string       - Any time string that `strtotime()` can understand
+	 * @param int $offset_in_seconds - Allows to offset the timestamp generated from $time_string
 	 *
 	 * @return string|false
 	 */

--- a/modules/calendar/calendar.php
+++ b/modules/calendar/calendar.php
@@ -8,12 +8,12 @@
 if ( !class_exists('EF_Calendar') ) {
 
 class EF_Calendar extends EF_Module {
-	
+
 	const usermeta_key_prefix = 'ef_calendar_';
 	const screen_id = 'dashboard_page_calendar';
-	
+
 	var $module;
-	
+
 	var $start_date = '';
 	var $current_week = 1;
 	var $total_weeks = 6; // default number of weeks to show per screen
@@ -27,7 +27,6 @@ class EF_Calendar extends EF_Module {
 	 * Construct the EF_Calendar class
 	 */
 	function __construct() {
-	
 		$this->module_url = $this->get_module_url( __FILE__ );
 		// Register the module with Edit Flow
 		$args = array(
@@ -63,17 +62,17 @@ class EF_Calendar extends EF_Module {
 				),
 			'settings_help_sidebar' => __( '<p><strong>For more information:</strong></p><p><a href="http://editflow.org/features/calendar/">Calendar Documentation</a></p><p><a href="http://wordpress.org/tags/edit-flow?forum_id=10">Edit Flow Forum</a></p><p><a href="https://github.com/danielbachhuber/Edit-Flow">Edit Flow on Github</a></p>', 'edit-flow' ),
 		);
-		$this->module = EditFlow()->register_module( 'calendar', $args );		
-		
+		$this->module = EditFlow()->register_module( 'calendar', $args );
+
 	}
-	
+
 	/**
 	 * Initialize all of our methods and such. Only runs if the module is active
 	 *
 	 * @uses add_action()
 	 */
 	function init() {
-		
+
 		// .ics calendar subscriptions
 		add_action( 'wp_ajax_ef_calendar_ics_subscription', array( $this, 'handle_ics_subscription' ) );
 		add_action( 'wp_ajax_nopriv_ef_calendar_ics_subscription', array( $this, 'handle_ics_subscription' ) );
@@ -85,19 +84,19 @@ class EF_Calendar extends EF_Module {
 
 		// Define the create-post capability
 		$this->create_post_cap = apply_filters( 'ef_calendar_create_post_cap', 'edit_posts' );
-		
+
 		require_once( EDIT_FLOW_ROOT . '/common/php/' . 'screen-options.php' );
 		add_screen_options_panel( self::usermeta_key_prefix . 'screen_options', __( 'Calendar Options', 'edit-flow' ), array( $this, 'generate_screen_options' ), self::screen_id, false, true );
 		add_action( 'admin_init', array( $this, 'handle_save_screen_options' ) );
-		
+
 		add_action( 'admin_init', array( $this, 'register_settings' ) );
-		add_action( 'admin_menu', array( $this, 'action_admin_menu' ) );		
+		add_action( 'admin_menu', array( $this, 'action_admin_menu' ) );
 		add_action( 'admin_print_styles', array( $this, 'add_admin_styles' ) );
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_admin_scripts' ) );
-		
+
 		// Ajax manipulation for the calendar
 		add_action( 'wp_ajax_ef_calendar_drag_and_drop', array( $this, 'handle_ajax_drag_and_drop' ) );
-		
+
 		// Ajax insert post placeholder for a specific date
 		add_action( 'wp_ajax_ef_insert_post', array( $this, 'handle_ajax_insert_post' ) );
 
@@ -114,7 +113,7 @@ class EF_Calendar extends EF_Module {
 		add_action( 'pre_post_update', array( $this, 'fix_post_date_on_update_part_one' ), 10, 2 );
 		add_action( 'post_updated', array( $this, 'fix_post_date_on_update_part_two' ), 10, 3 );
 	}
-	
+
 	/**
 	 * Load the capabilities onto users the first time the module is run
 	 *
@@ -157,18 +156,18 @@ class EF_Calendar extends EF_Module {
 			// Technically we've run this code before so we don't want to auto-install new data
 			$edit_flow->update_module_option( $this->module->name, 'loaded_once', true );
 		}
-		
+
 	}
-	
+
 	/**
 	 * Add the calendar link underneath the "Dashboard"
 	 *
 	 * @uses add_submenu_page
 	 */
-	function action_admin_menu() {	
+	function action_admin_menu() {
 		add_submenu_page('index.php', __('Calendar', 'edit-flow'), __('Calendar', 'edit-flow'), apply_filters( 'ef_view_calendar_cap', 'ef_view_calendar' ), $this->module->slug, array( $this, 'view_calendar' ) );
 	}
-	
+
 	/**
 	 * Add any necessary CSS to the WordPress admin
 	 *
@@ -180,7 +179,7 @@ class EF_Calendar extends EF_Module {
 		if ( $pagenow == 'index.php' && isset( $_GET['page'] ) && $_GET['page'] == 'calendar' )
 			wp_enqueue_style( 'edit-flow-calendar-css', $this->module_url . 'lib/calendar.css', false, EDIT_FLOW_VERSION );
 	}
-	
+
 	/**
 	 * Add any necessary JS to the WordPress admin
 	 *
@@ -190,7 +189,7 @@ class EF_Calendar extends EF_Module {
 	function enqueue_admin_scripts() {
 
 		$this->enqueue_datepicker_resources();
-		
+
 		if ( $this->is_whitelisted_functional_view() ) {
 			$js_libraries = array(
 				'jquery',
@@ -203,30 +202,30 @@ class EF_Calendar extends EF_Module {
 				wp_enqueue_script( $js_library );
 			}
 			wp_enqueue_script( 'edit-flow-calendar-js', $this->module_url . 'lib/calendar.js', $js_libraries, EDIT_FLOW_VERSION, true );
-			
+
 			$ef_cal_js_params = array( 'can_add_posts' => current_user_can( $this->create_post_cap ) ? 'true' : 'false' );
 			wp_localize_script( 'edit-flow-calendar-js', 'ef_calendar_params', $ef_cal_js_params );
 		}
-		
+
 	}
-	
+
 	/**
 	 * Prepare the options that need to appear in Screen Options
 	 *
 	 * @since 0.7
-	 */ 
+	 */
 	function generate_screen_options() {
-		
+
 		$output = '';
 		$screen_options = $this->get_screen_options();
-		
+
 		$output .= __( 'Number of Weeks: ', 'edit-flow' );
 		$output .= '<select id="' . self::usermeta_key_prefix . 'num_weeks" name="' . self::usermeta_key_prefix . 'num_weeks">';
 		for( $i = 1; $i <= 12; $i++ ) {
 			$output .= '<option value="' . esc_attr( $i ) . '" ' . selected( $i, $screen_options['num_weeks'], false ) . '>' . esc_attr( $i ) . '</option>';
 		}
 		$output .= '</select>';
-		
+
 		$output .= '&nbsp;&nbsp;&nbsp;<input id="screen-options-apply" name="screen-options-apply" type="submit" value="' . __( 'Apply' ) . '" class="button-secondary" />';
 
 		if ( 'on' == $this->module->options->ics_subscription && $this->module->options->ics_secret_key ) {
@@ -240,41 +239,41 @@ class EF_Calendar extends EF_Module {
 			$output .= __( 'Subscribe in iCal or Google Calendar', 'edit-flow' );
 			$output .= ':<br /><input type="text" size="100" value="' . esc_attr( $subscription_link ) . '" />';
 		}
-		
-		return $output;	
+
+		return $output;
 	}
-	
+
 	/**
 	 * Handle the request to save the screen options
 	 *
 	 * @since 0.7
 	 */
 	function handle_save_screen_options() {
-		
+
 		// Only handle screen options submissions from the current screen
 		if ( !isset( $_POST['screen-options-apply'], $_POST['ef_calendar_num_weeks'] ) )
 			return;
-		
+
 		// Nonce check
 		if ( !wp_verify_nonce( $_POST['_wpnonce-' . self::usermeta_key_prefix . 'screen_options'], 'save_settings-' . self::usermeta_key_prefix . 'screen_options' ) )
 			wp_die( $this->module->messages['nonce-failed'] );
-		
+
 		// Get the current screen options
 		$screen_options = $this->get_screen_options();
-		
+
 		// Save the number of weeks to show
 		$screen_options['num_weeks'] = (int)$_POST['ef_calendar_num_weeks'];
-		
+
 		// Save the screen options
 		$current_user = wp_get_current_user();
 		$this->update_user_meta( $current_user->ID, self::usermeta_key_prefix . 'screen_options', $screen_options );
-		
+
 		// Redirect after we're complete
 		$redirect_to = menu_page_url( $this->module->slug, false );
 		wp_redirect( $redirect_to );
 		exit;
 	}
-	
+
 	/**
 	 * Handle an AJAX request from the calendar to update a post's timestamp.
 	 * Notes:
@@ -287,30 +286,30 @@ class EF_Calendar extends EF_Module {
 	 */
 	function handle_ajax_drag_and_drop() {
 		global $wpdb;
-		
+
 		// Nonce check!
 		if ( !wp_verify_nonce( $_POST['nonce'], 'ef-calendar-modify' ) )
 			$this->print_ajax_response( 'error', $this->module->messages['nonce-failed'] );
-		
+
 		// Check that we got a proper post
 		$post_id = (int)$_POST['post_id'];
 		$post = get_post( $post_id );
 		if ( !$post )
 			$this->print_ajax_response( 'error', $this->module->messages['missing-post'] );
-			
+
 		// Check that the user can modify the post
 		if ( !$this->current_user_can_modify_post( $post ) )
 			$this->print_ajax_response( 'error', $this->module->messages['invalid-permissions'] );
-			
+
 		// Check that it's not yet published
 		if ( in_array( $post->post_status, $this->published_statuses ) )
 			$this->print_ajax_response( 'error', sprintf( $this->module->messages['published-post-ajax'], get_edit_post_link( $post_id ) ) );
-		
+
 		// Check that the new date passed is a valid one
 		$next_date_full = strtotime( $_POST['next_date'] );
 		if ( !$next_date_full )
 			$this->print_ajax_response( 'error', __( 'Something is wrong with the format for the new date.', 'edit-flow' ) );
-		
+
 		// Persist the old hourstamp because we can't manipulate the exact time on the calendar
 		// Bump the last modified timestamps too
 		$existing_time = date( 'H:i:s', strtotime( $post->post_date ) );
@@ -320,13 +319,13 @@ class EF_Calendar extends EF_Module {
 			'post_modified' => current_time( 'mysql' ),
 			'post_modified_gmt' => current_time( 'mysql', 1 ),
 		);
-		
+
 		// By default, changing a post on the calendar won't set the timestamp.
 		// If the user desires that to be the behaviour, they can set the result of this filter to 'true'
 		// With how WordPress works internally, setting 'post_date_gmt' will set the timestamp
 		if ( apply_filters( 'ef_calendar_allow_ajax_to_set_timestamp', false ) )
 			$new_values['post_date_gmt'] = date( 'Y-m-d', $next_date_full ) . ' ' . $existing_time_gmt;
-		
+
 		// We have to do SQL unfortunately because of core bugginess
 		// Note to those reading this: bug Nacin to allow us to finish the custom status API
 		// See http://core.trac.wordpress.org/ticket/18362
@@ -334,7 +333,7 @@ class EF_Calendar extends EF_Module {
 		clean_post_cache( $post->ID );
 		if ( !$response )
 			$this->print_ajax_response( 'error', $this->module->messages['update-error'] );
-		
+
 		$this->print_ajax_response( 'success', $this->module->messages['post-date-updated'] );
 		exit;
 	}
@@ -510,7 +509,7 @@ class EF_Calendar extends EF_Module {
 		wp_safe_redirect( add_query_arg( 'message', 'key-regenerated', menu_page_url( $this->module->settings_slug, false ) ) );
 		exit;
 	}
-	
+
 	/**
 	 * Get a user's screen options
 	 *
@@ -520,17 +519,17 @@ class EF_Calendar extends EF_Module {
 	 * @return array $screen_options The screen options values
 	 */
 	function get_screen_options() {
-		
+
 		$defaults = array(
 			'num_weeks' => (int)$this->total_weeks,
 		);
 		$current_user = wp_get_current_user();
 		$screen_options = $this->get_user_meta( $current_user->ID, self::usermeta_key_prefix . 'screen_options', true );
 		$screen_options = array_merge( (array)$defaults, (array)$screen_options );
-		
+
 		return $screen_options;
 	}
-	
+
 	/**
 	 * Get the user's filters for calendar, either with $_GET or from saved
 	 *
@@ -538,7 +537,7 @@ class EF_Calendar extends EF_Module {
 	 * @return array $filters All of the set or saved calendar filters
 	 */
 	function get_filters() {
-				
+
 		$current_user = wp_get_current_user();
 		$filters = array();
 		$old_filters = $this->get_user_meta( $current_user->ID, self::usermeta_key_prefix . 'filters', true );
@@ -551,7 +550,7 @@ class EF_Calendar extends EF_Module {
 				'start_date' => date( 'Y-m-d', current_time( 'timestamp' ) ),
 			);
 		$old_filters = array_merge( $default_filters, (array)$old_filters );
-		
+
 		// Sanitize and validate any newly added filters
 		foreach( $old_filters as $key => $old_value ) {
 			if ( isset( $_GET[$key] ) && false !== ( $new_value = $this->sanitize_filter( $key, $_GET[$key] ) ) )
@@ -564,33 +563,33 @@ class EF_Calendar extends EF_Module {
 		$filters['start_date'] = $this->get_beginning_of_week( $filters['start_date'] );
 
 		$filters = apply_filters( 'ef_calendar_filter_values', $filters, $old_filters );
-		
+
 		$this->update_user_meta( $current_user->ID, self::usermeta_key_prefix . 'filters', $filters );
-		
+
 		return $filters;
 	}
-	
+
 	/**
 	 * Build all of the HTML for the calendar view
 	 */
 	function view_calendar() {
 
 		$this->dropdown_taxonomies = array();
-		
+
 		$supported_post_types = $this->get_post_types_for_module( $this->module );
-		
+
 		// Get the user's screen options for displaying the data
 		$screen_options = $this->get_screen_options();
 		// Total number of weeks to display on the calendar. Run it through a filter in case we want to override the
 		// user's standard
 		$this->total_weeks = apply_filters( 'ef_calendar_total_weeks', $screen_options['num_weeks'], 'dashboard' );
-		
+
 		$dotw = array(
 			'Sat',
 			'Sun',
 		);
 		$dotw = apply_filters( 'ef_calendar_weekend_days', $dotw );
-		
+
 		// Get filters either from $_GET or from user settings
 		$filters = $this->get_filters();
 		// For generating the WP Query objects later on
@@ -601,7 +600,7 @@ class EF_Calendar extends EF_Module {
 			'author'      => $filters['author']
 		);
 		$this->start_date = $filters['start_date'];
-		
+
 		// We use this later to label posts if they need labeling
 		if ( count( $supported_post_types ) > 1 ) {
 			$all_post_types = get_post_types( null, 'objects' );
@@ -612,7 +611,7 @@ class EF_Calendar extends EF_Module {
 			$dates[$i] = $heading_date;
 			$heading_date = date( 'Y-m-d', strtotime( "+1 day", strtotime( $heading_date ) ) );
 		}
-		
+
 		// we sort by post statuses....... eventually
 		$post_statuses = $this->get_post_statuses();
 		?>
@@ -644,7 +643,7 @@ class EF_Calendar extends EF_Module {
 			?>
 
 			<div id="ef-calendar-wrap"><!-- Calendar Wrapper -->
-					
+
 			<?php $this->print_top_navigation( $filters, $dates ); ?>
 
 			<?php
@@ -656,7 +655,7 @@ class EF_Calendar extends EF_Module {
 					$table_classes[] = 'two-weeks-showing';
 				elseif ( $this->total_weeks == 3 )
 					$table_classes[] = 'three-weeks-showing';
-					
+
 				$table_classes = apply_filters( 'ef_calendar_table_classes', $table_classes );
 			?>
 			<table id="ef-calendar-view" class="<?php echo esc_attr( implode( ' ', $table_classes ) ); ?>">
@@ -666,7 +665,7 @@ class EF_Calendar extends EF_Module {
 				</tr>
 				</thead>
 				<tbody>
-				
+
 				<?php
 				$current_month = date_i18n( 'F', strtotime( $filters['start_date'] ) );
 				for( $current_week = 1; $current_week <= $this->total_weeks; $current_week++ ):
@@ -685,7 +684,7 @@ class EF_Calendar extends EF_Module {
 							$current_month = $single_date_month;
 						}
 						$week_single_date = date( 'Y-m-d', strtotime( "+1 day", strtotime( $week_single_date ) ) );
-					}			
+					}
 				?>
 				<?php if ( $split_month ): ?>
 				<tr class="month-marker">
@@ -721,26 +720,26 @@ class EF_Calendar extends EF_Module {
 						unset( $week_posts[$week_single_date] );
 						foreach( $week_posts_by_status as $status ) {
 							foreach( $status as $num => $post ) {
-								$week_posts[$week_single_date][] = $post; 
+								$week_posts[$week_single_date][] = $post;
 							}
 						}
 					}
-				
+
 					$td_classes = array(
 						'day-unit',
 					);
 					$day_name = date( 'D', strtotime( $week_single_date ) );
-					
+
 					if ( in_array( $day_name, $dotw ) )
 						$td_classes[] = 'weekend-day';
-					
+
 					if ( $week_single_date == date( 'Y-m-d', current_time( 'timestamp' ) ) )
 						$td_classes[] = 'today';
-						
+
 					// Last day of the week
 					if ( $day_num == 6 )
 						$td_classes[] = 'last-day';
-						
+
 					$td_classes = apply_filters( 'ef_calendar_table_td_classes', $td_classes, $week_single_date );
 				?>
 				<td class="<?php echo esc_attr( implode( ' ', $td_classes ) ); ?>" id="<?php echo esc_attr( $week_single_date ); ?>">
@@ -756,11 +755,11 @@ class EF_Calendar extends EF_Module {
 
 							$week_posts[$week_single_date] = apply_filters( 'ef_calendar_posts_for_week', $week_posts[$week_single_date] );
 
-							foreach ( $week_posts[$week_single_date] as $num => $post ){ 
-								echo $this->generate_post_li_html( $post, $week_single_date, $num ); 
-							} 
+							foreach ( $week_posts[$week_single_date] as $num => $post ){
+								echo $this->generate_post_li_html( $post, $week_single_date, $num );
+							}
 
-						 } 
+						 }
 						 ?>
 					</ul>
 					<?php if ( $this->hidden ): ?>
@@ -773,14 +772,14 @@ class EF_Calendar extends EF_Module {
 
 						<form method="POST" class="post-insert-dialog">
 							<?php /* translators: %1$s = post type name, %2$s = date */ ?>
-							<h1><?php echo sprintf( __( 'Schedule a %1$s for %2$s', 'edit-flow' ), $this->get_quick_create_post_type_name(), $date_formatted ); ?></h1>	
+							<h1><?php echo sprintf( __( 'Schedule a %1$s for %2$s', 'edit-flow' ), $this->get_quick_create_post_type_name(), $date_formatted ); ?></h1>
 							<?php /* translators: %s = post type name */ ?>
 							<input type="text" class="post-insert-dialog-post-title" name="post-insert-dialog-post-title" placeholder="<?php echo esc_attr( sprintf( _x( '%s Title', 'post type name', 'edit-flow' ), $this->get_quick_create_post_type_name() ) ); ?>">
 							<input type="hidden" class="post-insert-dialog-post-date" name="post-insert-dialog-post-title" value="<?php echo esc_attr( $week_single_date ); ?>">
-							<div class="post-insert-dialog-controls">		
+							<div class="post-insert-dialog-controls">
 								<input type="submit" class="button left" value="<?php echo esc_html( sprintf( _x( 'Create %s', 'post type name', 'edit-flow' ), $this->get_quick_create_post_type_name() ) ); ?>">
 								<a class="post-insert-dialog-edit-post-link" href="#"><?php echo esc_html( sprintf( _x( 'Edit %s', 'post type name', 'edit-flow' ), $this->get_quick_create_post_type_name() ) ); ?>&nbsp;&raquo;</a>
-							</div>	
+							</div>
 							<div class="spinner">&nbsp;</div>
 						</form>
 					<?php endif; ?>
@@ -788,22 +787,22 @@ class EF_Calendar extends EF_Module {
 					</td>
 					<?php endforeach; ?>
 					</tr>
-					
+
 					<?php endfor; ?>
-					
-					</tbody>		
+
+					</tbody>
 					</table><!-- /Week Wrapper -->
 					<?php
 					// Nonce field for AJAX actions
 					wp_nonce_field( 'ef-calendar-modify', 'ef-calendar-modify' ); ?>
-					
+
 					<div class="clear"></div>
 				</div><!-- /Calendar Wrapper -->
 
 			  </div>
 
-		<?php 
-		
+		<?php
+
 	}
 
 	/**
@@ -829,7 +828,7 @@ class EF_Calendar extends EF_Module {
 
 		$post_id = $post->ID;
 		$edit_post_link = get_edit_post_link( $post_id );
-		
+
 		$post_classes = array(
 			'day-item',
 			'custom-status-' . $post->post_status,
@@ -839,10 +838,10 @@ class EF_Calendar extends EF_Module {
 		// This is checked on the ajax request too.
 		if ( $this->current_user_can_modify_post( $post ) && !in_array( $post->post_status, $this->published_statuses ) )
 			$post_classes[] = 'sortable';
-		
+
 		if ( in_array( $post->post_status, $this->published_statuses ) )
 			$post_classes[] = 'is-published';
-		
+
 		// Hide posts over a certain number to prevent clutter, unless user is only viewing 1 or 2 weeks
 		$max_visible_posts = apply_filters( 'ef_calendar_max_visible_posts_per_date', $this->max_visible_posts_per_date);
 
@@ -851,7 +850,7 @@ class EF_Calendar extends EF_Module {
 			$this->hidden++;
 		}
 		$post_classes = apply_filters( 'ef_calendar_table_td_li_classes', $post_classes, $post_date, $post->ID );
-		
+
 		?>
 		<li class="<?php echo esc_attr( implode( ' ', $post_classes ) ); ?>" id="post-<?php echo esc_attr( $post->ID ); ?>">
 			<div style="clear:right;"></div>
@@ -889,9 +888,9 @@ class EF_Calendar extends EF_Module {
 	 * has been separated out so various ajax functions can reload certain
 	 * parts of an inner html element.
 	 * @param  array $ef_calendar_item_information_fields
-	 * @param  WP_Post $post                               
-	 * @param  array $published_statuses                 
-	 * 
+	 * @param  WP_Post $post
+	 * @param  array $published_statuses
+	 *
 	 * @since 0.8
 	 */
 	function get_inner_information( $ef_calendar_item_information_fields, $post ) {
@@ -968,12 +967,12 @@ class EF_Calendar extends EF_Module {
 			break;
 			case 'checkbox':
 				$output = '<select class="metadata-edit">';
-				
+
 				if( $value == 'No' )
 					$output .= '<option value="0">No</option><option value="1">Yes</option>';
 				else
 					$output .= '<option value="1">Yes</option><option value="0">No</option>';
-				
+
 				$output .= '</select>';
 
 				return $output;
@@ -1078,7 +1077,7 @@ class EF_Calendar extends EF_Module {
 			if( current_user_can( $ed_cap, $post->ID ) )
 				$information_fields[$key]['editable'] = true;
 		}
-		
+
 		$information_fields = apply_filters( 'ef_calendar_item_information_fields', $information_fields, $post->ID );
 		foreach( $information_fields as $field => $values ) {
 			// Allow filters to hide empty fields or to hide any given individual field. Hide empty fields by default.
@@ -1088,7 +1087,7 @@ class EF_Calendar extends EF_Module {
 		}
 		return $information_fields;
 	}
-	
+
 	/**
 	 * Generates the filtering and navigation options for the top of the calendar
 	 *
@@ -1103,10 +1102,10 @@ class EF_Calendar extends EF_Module {
 					<input type="hidden" name="page" value="calendar" />
 					<input type="hidden" name="start_date" value="<?php echo esc_attr( $filters['start_date'] ); ?>"/>
 					<!-- Filter by status -->
-					<?php 
+					<?php
 						foreach( $this->calendar_filters() as $select_id => $select_name ) {
 							echo $this->calendar_filter_options( $select_id, $select_name, $filters );
-						} 
+						}
 					?>
 					<input type="submit" id="post-query-submit" class="button-primary button" value="<?php _e( 'Filter', 'edit-flow' ); ?>"/>
 				</form>
@@ -1116,7 +1115,7 @@ class EF_Calendar extends EF_Module {
 				<form method="GET">
 					<input type="hidden" name="page" value="calendar" />
 					<input type="hidden" name="start_date" value="<?php echo esc_attr( $filters['start_date'] ); ?>"/>
-					<?php 
+					<?php
 					foreach( $this->calendar_filters() as $select_id => $select_name )
 						echo '<input type="hidden" name="'.$select_name.'" value="" />';
 					?>
@@ -1127,7 +1126,7 @@ class EF_Calendar extends EF_Module {
 			<?php /** Previous and next navigation items (translatable so they can be increased if needed )**/ ?>
 			<li class="date-change next-week">
 				<a title="<?php printf( __( 'Forward 1 week', 'edit-flow' ) ); ?>" href="<?php echo esc_url( $this->get_pagination_link( 'next', $filters, 1 ) ); ?>"><?php _e( '&rsaquo;', 'edit-flow' ); ?></a>
-				<?php if ( $this->total_weeks > 1): ?>			
+				<?php if ( $this->total_weeks > 1): ?>
 				<a title="<?php printf( __( 'Forward %d weeks', 'edit-flow' ), $this->total_weeks ); ?>" href="<?php echo esc_url( $this->get_pagination_link( 'next', $filters ) ); ?>"><?php _e( '&raquo;', 'edit-flow' ); ?></a>
 				<?php endif; ?>
 			</li>
@@ -1135,18 +1134,18 @@ class EF_Calendar extends EF_Module {
 				<a title="<?php printf( __( 'Today is %s', 'edit-flow' ), date( get_option( 'date_format' ), current_time( 'timestamp' ) ) ); ?>" href="<?php echo esc_url( $this->get_pagination_link( 'next', $filters, 0 ) ); ?>"><?php _e( 'Today', 'edit-flow' ); ?></a>
 			</li>
 			<li class="date-change previous-week">
-				<?php if ( $this->total_weeks > 1): ?>				
+				<?php if ( $this->total_weeks > 1): ?>
 				<a title="<?php printf( __( 'Back %d weeks', 'edit-flow' ), $this->total_weeks ); ?>"  href="<?php echo esc_url( $this->get_pagination_link( 'previous', $filters ) ); ?>"><?php _e( '&laquo;', 'edit-flow' ); ?></a>
 				<?php endif; ?>
 				<a title="<?php printf( __( 'Back 1 week', 'edit-flow' ) ); ?>" href="<?php echo esc_url( $this->get_pagination_link( 'previous', $filters, 1 ) ); ?>"><?php _e( '&lsaquo;', 'edit-flow' ); ?></a>
 			</li>
 			<li class="ajax-actions">
 				<img class="waiting" style="display:none;" src="<?php echo esc_url( admin_url( 'images/wpspin_light.gif' ) ); ?>" alt="" />
-			</li>			
+			</li>
 		</ul>
 	<?php
 	}
-	
+
 	/**
 	 * Generate the calendar header for a given range of dates
 	 *
@@ -1154,18 +1153,18 @@ class EF_Calendar extends EF_Module {
 	 * @return string $html Generated HTML for the header
 	 */
 	function get_time_period_header( $dates ) {
-		
+
 		$html = '';
 		foreach( $dates as $date ) {
 			$html .= '<th class="column-heading" >';
 			$html .= esc_html( date_i18n('l', strtotime( $date ) ) );
 			$html .= '</th>';
 		}
-		
+
 		return $html;
-		
+
 	}
-		
+
 	/**
 	 * Query to get all of the calendar posts for a given day
 	 *
@@ -1175,7 +1174,7 @@ class EF_Calendar extends EF_Module {
 	 */
 	function get_calendar_posts_for_week( $args = array(), $context = 'dashboard' ) {
 		global $wpdb;
-		
+
 		$supported_post_types = $this->get_post_types_for_module( $this->module );
 		$defaults = array(
 			'post_status'      => null,
@@ -1184,9 +1183,9 @@ class EF_Calendar extends EF_Module {
 			'post_type'        => $supported_post_types,
 			'posts_per_page'   => -1,
 		);
-						 
+
 		$args = array_merge( $defaults, $args );
-		
+
 		// Unpublished as a status is just an array of everything but 'publish'
 		if ( $args['post_status'] == 'unpublish' ) {
 			$args['post_status'] = '';
@@ -1207,13 +1206,13 @@ class EF_Calendar extends EF_Module {
 
 		if ( empty( $args['post_type'] ) || ! in_array( $args['post_type'], $supported_post_types ) )
 			$args['post_type'] = $supported_post_types;
-		
+
 		// Filter for an end user to implement any of their own query args
 		$args = apply_filters( 'ef_calendar_posts_query_args', $args, $context );
 		add_filter( 'posts_where', array( $this, 'posts_where_week_range' ) );
 		$post_results = new WP_Query( $args );
 		remove_filter( 'posts_where', array( $this, 'posts_where_week_range' ) );
-		
+
 		$posts = array();
 		while ( $post_results->have_posts() ) {
 			$post_results->the_post();
@@ -1221,11 +1220,11 @@ class EF_Calendar extends EF_Module {
 			$key_date = date( 'Y-m-d', strtotime( $post->post_date ) );
 			$posts[$key_date][] = $post;
 		}
-		
+
 		return $posts;
-		
+
 	}
-	
+
 	/**
 	 * Filter the WP_Query so we can get a week range of posts
 	 *
@@ -1234,46 +1233,46 @@ class EF_Calendar extends EF_Module {
 	 */
 	function posts_where_week_range( $where = '' ) {
 		global $wpdb;
-	
+
 		$beginning_date = $this->get_beginning_of_week( $this->start_date, 'Y-m-d', $this->current_week );
 		$ending_date = $this->get_ending_of_week( $this->start_date, 'Y-m-d', $this->current_week );
 		// Adjust the ending date to account for the entire day of the last day of the week
 		$ending_date = date( "Y-m-d", strtotime( "+1 day", strtotime( $ending_date ) ) );
 		$where = $where . $wpdb->prepare( " AND ($wpdb->posts.post_date >= %s AND $wpdb->posts.post_date < %s)", $beginning_date, $ending_date );
-	
+
 		return $where;
-	} 
-	
+	}
+
 	/**
 	 * Gets the link for the next time period
 	 *
 	 * @param string $direction 'previous' or 'next', direction to go in time
 	 * @param array $filters Any filters that need to be applied
-	 * @param int $weeks_offset Number of weeks we're offsetting the range	
+	 * @param int $weeks_offset Number of weeks we're offsetting the range
 	 * @return string $url The URL for the next page
 	 */
 	function get_pagination_link( $direction = 'next', $filters = array(), $weeks_offset = null ) {
 
 		$supported_post_types = $this->get_post_types_for_module( $this->module );
-		
+
 		if ( !isset( $weeks_offset ) )
 			$weeks_offset = $this->total_weeks;
 		else if ( $weeks_offset == 0 )
 			$filters['start_date'] = $this->get_beginning_of_week( date( 'Y-m-d', current_time( 'timestamp' ) ) );
-			
+
 		if ( $direction == 'previous' )
 			$weeks_offset = '-' . $weeks_offset;
-		
+
 		$filters['start_date'] = date( 'Y-m-d', strtotime( $weeks_offset . " weeks", strtotime( $filters['start_date'] ) ) );
 		$url = add_query_arg( $filters, menu_page_url( $this->module->slug, false ) );
 
 		if ( count( $supported_post_types ) > 1 )
 			$url = add_query_arg( 'cpt', $filters['cpt'] , $url );
-		
+
 		return $url;
-		
+
 	}
-	
+
 	/**
 	 * Given a day in string format, returns the day at the beginning of that week, which can be the given date.
 	 * The end of the week is determined by the blog option, 'start_of_week'.
@@ -1282,11 +1281,11 @@ class EF_Calendar extends EF_Module {
 	 *
 	 * @param string $date String representing a date
 	 * @param string $format Date format in which the end of the week should be returned
-	 * @param int $week Number of weeks we're offsetting the range	
+	 * @param int $week Number of weeks we're offsetting the range
 	 * @return string $formatted_start_of_week End of the week
 	 */
 	function get_beginning_of_week( $date, $format = 'Y-m-d', $week = 1 ) {
-		
+
 		$date = strtotime( $date );
 		$start_of_week = get_option( 'start_of_week' );
 		$day_of_week = date( 'w', $date );
@@ -1294,22 +1293,22 @@ class EF_Calendar extends EF_Module {
 		$additional = 3600 * 24 * 7 * ( $week - 1 );
 		$formatted_start_of_week = date( $format, $date + $additional );
 		return $formatted_start_of_week;
-		
+
 	}
-	
+
 	/**
 	 * Given a day in string format, returns the day at the end of that week, which can be the given date.
 	 * The end of the week is determined by the blog option, 'start_of_week'.
 	 *
-	 * @see http://www.php.net/manual/en/datetime.formats.date.php for valid date formats	
+	 * @see http://www.php.net/manual/en/datetime.formats.date.php for valid date formats
 	 *
 	 * @param string $date String representing a date
 	 * @param string $format Date format in which the end of the week should be returned
-	 * @param int $week Number of weeks we're offsetting the range		
+	 * @param int $week Number of weeks we're offsetting the range
 	 * @return string $formatted_end_of_week End of the week
 	 */
 	function get_ending_of_week( $date, $format = 'Y-m-d', $week = 1  ) {
-		
+
 		$date = strtotime( $date );
 		$end_of_week = get_option( 'start_of_week' ) - 1;
 		$day_of_week = date( 'w', $date );
@@ -1317,9 +1316,9 @@ class EF_Calendar extends EF_Module {
 		$additional = 3600 * 24 * 7 * ( $week - 1 );
 		$formatted_end_of_week = date( $format, $date + $additional );
 		return $formatted_end_of_week;
-		
+
 	}
-	
+
 	/**
 	 * Human-readable time range for the calendar
 	 * Shows something like "for October 30th through November 26th" for a four-week period
@@ -1327,7 +1326,7 @@ class EF_Calendar extends EF_Module {
 	 * @since 0.7
 	 */
 	function calendar_time_range() {
-		
+
 		$first_datetime = strtotime( $this->start_date );
 		$first_date = date_i18n( get_option( 'date_format' ), $first_datetime );
 		$total_days = ( $this->total_weeks * 7 ) - 1;
@@ -1335,7 +1334,7 @@ class EF_Calendar extends EF_Module {
 		$last_date = date_i18n( get_option( 'date_format' ), $last_datetime );
 		echo sprintf( __( 'for %1$s through %2$s', 'edit-flow' ), $first_date, $last_date );
 	}
-	
+
 	/**
 	 * Check whether the current user should have the ability to modify the post
 	 *
@@ -1345,10 +1344,10 @@ class EF_Calendar extends EF_Module {
 	 * @return bool $can Whether or not the current user can modify the post
 	 */
 	function current_user_can_modify_post( $post ) {
-		
+
 		if ( !$post )
 			return false;
-			
+
 		$post_type_object = get_post_type_object( $post->post_type );
 
 		// Editors and admins are fine
@@ -1360,19 +1359,19 @@ class EF_Calendar extends EF_Module {
 		// Those who can publish posts can move any of their own stuff
 		if ( current_user_can( $post_type_object->cap->publish_posts, $post->ID ) && wp_get_current_user()->ID == $post->post_author )
 			return true;
-		
+
 		return false;
 	}
-	
+
 	/**
 	 * Register settings for notifications so we can partially use the Settings API
 	 * We use the Settings API for form generation, but not saving because we have our
 	 * own way of handling the data.
-	 * 
+	 *
 	 * @since 0.7
 	 */
 	function register_settings() {
-		
+
 			add_settings_section( $this->module->options_group_name . '_general', false, '__return_false', $this->module->options_group_name );
 			add_settings_field( 'number_of_weeks', __( 'Number of weeks to show', 'edit-flow' ), array( $this, 'settings_number_weeks_option' ), $this->module->options_group_name, $this->module->options_group_name . '_general' );
 			add_settings_field( 'post_types', __( 'Post types to show', 'edit-flow' ), array( $this, 'settings_post_types_option' ), $this->module->options_group_name, $this->module->options_group_name . '_general' );
@@ -1380,7 +1379,7 @@ class EF_Calendar extends EF_Module {
 			add_settings_field( 'ics_subscription', __( 'Subscription in iCal or Google Calendar', 'edit-flow' ), array( $this, 'settings_ics_subscription_option' ), $this->module->options_group_name, $this->module->options_group_name . '_general' );
 
 	}
-	
+
 	/**
 	 * Choose the post types that should be displayed on the calendar
 	 *
@@ -1397,11 +1396,11 @@ class EF_Calendar extends EF_Module {
 	 * @since 0.8
 	 */
 	function settings_quick_create_post_type_option() {
-		
+
 		$allowed_post_types = $this->get_all_post_types();
 
 		echo "<select name='" . $this->module->options_group_name . "[quick_create_post_type]'>";
-		foreach( $allowed_post_types as $post_type => $title ) 
+		foreach( $allowed_post_types as $post_type => $title )
 			echo "<option value='" . esc_attr( $post_type ) . "' " . selected( $post_type, $this->module->options->quick_create_post_type, false ) . ">".esc_html( $title )."</option>";
 		echo "</select>";
 
@@ -1466,7 +1465,7 @@ class EF_Calendar extends EF_Module {
 
 		return $options;
 	}
-	
+
 	/**
 	 * Settings page for calendar
 	 */
@@ -1475,8 +1474,8 @@ class EF_Calendar extends EF_Module {
 		?>
 		<form class="basic-settings" action="<?php echo esc_url( menu_page_url( $this->module->settings_slug, false ) ); ?>" method="post">
 			<?php settings_fields( $this->module->options_group_name ); ?>
-			<?php do_settings_sections( $this->module->options_group_name ); ?>	
-			<?php				
+			<?php do_settings_sections( $this->module->options_group_name ); ?>
+			<?php
 				echo '<input id="edit_flow_module_name" name="edit_flow_module_name" type="hidden" value="' . esc_attr( $this->module->name ) . '" />';
 			?>
 			<p class="submit"><?php submit_button( null, 'primary', 'submit', false ); ?><a class="cancel-settings-link" href="<?php echo esc_url( EDIT_FLOW_SETTINGS_PAGE ); ?>"><?php _e( 'Back to Edit Flow', 'edit-flow' ); ?></a></p>
@@ -1515,7 +1514,7 @@ class EF_Calendar extends EF_Module {
 		$post_date = sanitize_text_field( $_POST['ef_insert_date'] );
 
 		$post_status = $this->get_default_post_status();
-		
+
 		// Set new post parameters
 		$post_placeholder = array(
 			'post_title' => $post_title,
@@ -1551,7 +1550,7 @@ class EF_Calendar extends EF_Module {
 	/**
 	 * Returns the singular label for the posts that are
 	 * quick-created on the calendar
-	 * 
+	 *
 	 * @return str Singular label for a post-type
 	 */
 	function get_quick_create_post_type_name(){
@@ -1574,7 +1573,7 @@ class EF_Calendar extends EF_Module {
 
 		if ( ! wp_verify_nonce( $_POST['nonce'], 'ef-calendar-modify' ) )
 			$this->print_ajax_response( 'error', $this->module->messages['nonce-failed'] );
-		
+
 		// Check that we got a proper post
 		$post_id = ( int )$_POST['post_id'];
 		$post = get_post( $post_id );
@@ -1589,8 +1588,8 @@ class EF_Calendar extends EF_Module {
 			$edit_check = 'edit_post';
 
 		if ( !current_user_can( $edit_check, $post->ID ) )
-			$this->print_ajax_response( 'error', $this->module->messages['invalid-permissions'] );	
-			
+			$this->print_ajax_response( 'error', $this->module->messages['invalid-permissions'] );
+
 		// Check that the user can modify the post
 		if ( ! $this->current_user_can_modify_post( $post ) )
 			$this->print_ajax_response( 'error', $this->module->messages['invalid-permissions'] );
@@ -1603,8 +1602,8 @@ class EF_Calendar extends EF_Module {
 		$metadata_types = array();
 
 		if ( !$this->module_enabled( 'editorial_metadata' ) )
-			$this->print_ajax_response( 'error', $this->module->messages['update-error'] );	
-		
+			$this->print_ajax_response( 'error', $this->module->messages['update-error'] );
+
 		$metadata_types = array_keys( EditFlow()->editorial_metadata->get_supported_metadata_types() );
 
 		// Update an editorial metadata field
@@ -1638,7 +1637,7 @@ class EF_Calendar extends EF_Module {
 			$this->print_ajax_response( 'error', __( 'Metadata could not be updated.', 'edit-flow' ) );
 	}
 
-	function calendar_filters() {		
+	function calendar_filters() {
 		$select_filter_names = array();
 
 		$select_filter_names['post_status'] = 'post_status';
@@ -1656,7 +1655,7 @@ class EF_Calendar extends EF_Module {
 	 *
 	 * @param string $key Filter being sanitized
 	 * @param string $dirty_value Value to be sanitized
-	 * @return string $sanitized_value Safe to use value 
+	 * @return string $sanitized_value Safe to use value
 	 */
 	function sanitize_filter( $key, $dirty_value ) {
 
@@ -1694,14 +1693,14 @@ class EF_Calendar extends EF_Module {
 	}
 
 	function calendar_filter_options( $select_id, $select_name, $filters ) {
-		switch( $select_id ){ 
+		switch( $select_id ){
 			case 'post_status':
 				$post_statuses = $this->get_post_statuses();
 			?>
 				<select id="<?php echo $select_id; ?>" name="<?php echo $select_name; ?>" >
 					<option value=""><?php _e( 'View all statuses', 'edit-flow' ); ?></option>
-					<?php 
-						foreach ( $post_statuses as $post_status ) { 
+					<?php
+						foreach ( $post_statuses as $post_status ) {
 							echo "<option value='" . esc_attr( $post_status->slug ) . "' " . selected( $post_status->slug, $filters['post_status'] ) . ">" . esc_html( $post_status->name ) . "</option>";
 						}
 					?>
@@ -1768,14 +1767,14 @@ class EF_Calendar extends EF_Module {
 
 	/**
 	 * This is a hack! hack! hack! until core is fixed
-	 * 
+	 *
 	 * The calendar uses 'post_date' field to store the position on the calendar
 	 * If a post has a core post status assigned (e.g. 'draft' or 'pending'), the `post_date`
 	 * field will be reset when `wp_update_post()`
 	 * is used: http://core.trac.wordpress.org/browser/tags/3.7.1/src/wp-includes/post.php#L2998
-	 * 
+	 *
 	 * This method temporarily caches the `post_date` field if it needs to be restored.
-	 * 
+	 *
 	 * @uses fix_post_date_on_update_part_two()
 	 */
 	public function fix_post_date_on_update_part_one( $post_ID, $data ) {
@@ -1795,14 +1794,14 @@ class EF_Calendar extends EF_Module {
 
 	/**
 	 * This is a hack! hack! hack! until core is fixed
-	 * 
+	 *
 	 * The calendar uses 'post_date' field to store the position on the calendar
 	 * If a post has a core post status assigned (e.g. 'draft' or 'pending'), the `post_date`
 	 * field will be reset when `wp_update_post()`
 	 * is used: http://core.trac.wordpress.org/browser/tags/3.7.1/src/wp-includes/post.php#L2998
-	 * 
+	 *
 	 * This method restores the `post_date` field if it needs to be restored.
-	 * 
+	 *
 	 * @uses fix_post_date_on_update_part_one()
 	 */
 	public function fix_post_date_on_update_part_two( $post_ID, $post_after, $post_before ) {
@@ -1816,7 +1815,7 @@ class EF_Calendar extends EF_Module {
 		$wpdb->update( $wpdb->posts, array( 'post_date' => $post_date ), array( 'ID' => $post_ID ) );
 		clean_post_cache( $post_ID );
 	}
-	
+
 } // EF_Calendar
-	
+
 } // class_exists('EF_Calendar')


### PR DESCRIPTION
This fixes a problem where incorrect times were added to calendars because calendars expect a times to be in UTC+0 time zone. The problem described in #243 

Introduced `ics_format_time` static method that is formatting the time properly.