### PR TITLE
Avoid direct SQL Queries by using WP Date Query

### DIFF
--- a/modules/calendar/calendar.php
+++ b/modules/calendar/calendar.php
@@ -1213,14 +1213,12 @@ class EF_Calendar extends EF_Module {
 		}
 
 		$beginning_date = $this->get_beginning_of_week( $this->start_date, 'Y-m-d', $this->current_week );
-		$ending_date = $this->get_ending_of_week( $this->start_date, 'Y-m-d', $this->current_week );
-
-		$beginning_date_offset = date( "Y-m-d", strtotime( $beginning_date  ) - DAY_IN_SECONDS );
-		$ending_date_offset = date( "Y-m-d", strtotime( $ending_date  ) + DAY_IN_SECONDS );
+		$ending_date    = date( "Y-m-d", strtotime( $beginning_date ) + WEEK_IN_SECONDS );
 
 		$args['date_query'] = array(
-			'before' => $ending_date_offset,
-			'after' => $beginning_date_offset,
+			'after'     => $beginning_date,
+			'before'    => $ending_date,
+			'inclusive' => true,
 		);
 
 		// Filter for an end user to implement any of their own query args

--- a/modules/calendar/calendar.php
+++ b/modules/calendar/calendar.php
@@ -1174,7 +1174,6 @@ class EF_Calendar extends EF_Module {
 	 * @return array $posts All of the posts as an array sorted by date
 	 */
 	function get_calendar_posts_for_week( $args = array(), $context = 'dashboard' ) {
-		global $wpdb;
 		
 		$supported_post_types = $this->get_post_types_for_module( $this->module );
 		$defaults = array(
@@ -1213,7 +1212,7 @@ class EF_Calendar extends EF_Module {
 		add_filter( 'posts_where', array( $this, 'posts_where_week_range' ) );
 		$post_results = new WP_Query( $args );
 		remove_filter( 'posts_where', array( $this, 'posts_where_week_range' ) );
-		
+
 		$posts = array();
 		while ( $post_results->have_posts() ) {
 			$post_results->the_post();
@@ -1234,7 +1233,7 @@ class EF_Calendar extends EF_Module {
 	 */
 	function posts_where_week_range( $where = '' ) {
 		global $wpdb;
-	
+
 		$beginning_date = $this->get_beginning_of_week( $this->start_date, 'Y-m-d', $this->current_week );
 		$ending_date = $this->get_ending_of_week( $this->start_date, 'Y-m-d', $this->current_week );
 		// Adjust the ending date to account for the entire day of the last day of the week

--- a/modules/calendar/calendar.php
+++ b/modules/calendar/calendar.php
@@ -1201,12 +1201,17 @@ class EF_Calendar extends EF_Module {
 		// The WP functions for printing the category and author assign a value of 0 to the default
 		// options, but passing this to the query is bad (trashed and auto-draft posts appear!), so
 		// unset those arguments.
-		if ( $args['cat'] === '0' ) unset( $args['cat'] );
-		if ( $args['author'] === '0' ) unset( $args['author'] );
+		if ( $args['cat'] === '0' ) {
+			unset( $args['cat'] );
+		}
+		if ( $args['author'] === '0' ) {
+			unset( $args['author'] );
+		}
 
-		if ( empty( $args['post_type'] ) || ! in_array( $args['post_type'], $supported_post_types ) )
+		if ( empty( $args['post_type'] ) || ! in_array( $args['post_type'], $supported_post_types ) ) {
 			$args['post_type'] = $supported_post_types;
-		
+		}
+
 		// Filter for an end user to implement any of their own query args
 		$args = apply_filters( 'ef_calendar_posts_query_args', $args, $context );
 		add_filter( 'posts_where', array( $this, 'posts_where_week_range' ) );

--- a/modules/story-budget/story-budget.php
+++ b/modules/story-budget/story-budget.php
@@ -388,9 +388,19 @@ class EF_Story_Budget extends EF_Module {
 		// Filter for an end user to implement any of their own query args
      	$args = apply_filters( 'ef_story_budget_posts_query_args', $args );
 
-		add_filter( 'posts_where', array( $this, 'posts_where_range' ) );
+		$beginning_date = date( 'Y-m-d', strtotime( $this->user_filters['start_date'] )  );
+		$end_day = $this->user_filters['number_days'];
+		$ending_date = date( "Y-m-d", strtotime( "+" . $end_day . " days", strtotime( $beginning_date ) ) );
+
+		$beginning_date_offset = date( "Y-m-d", strtotime( $beginning_date  ) - DAY_IN_SECONDS );
+		$ending_date_offset = date( "Y-m-d", strtotime( $ending_date  ) + DAY_IN_SECONDS );
+
+		$args['date_query'] = array(
+			'before' => $ending_date_offset,
+			'after' => $beginning_date_offset,
+		);
+
 		$term_posts_query_results = new WP_Query( $args );
-		remove_filter( 'posts_where', array( $this, 'posts_where_range' ) );
 		
 		$term_posts = array();
 		while ( $term_posts_query_results->have_posts() ) {
@@ -401,23 +411,7 @@ class EF_Story_Budget extends EF_Module {
 		
 		return $term_posts;
 	}
-	
-	/**
-	 * Filter the WP_Query so we can get a range of posts
-	 *
-	 * @param string $where The original WHERE SQL query string
-	 * @return string $where Our modified WHERE query string
-	 */
-	function posts_where_range( $where = '' ) {
-		global $wpdb;
-	
-		$beginning_date = date( 'Y-m-d', strtotime( $this->user_filters['start_date'] ) );
-		$end_day = $this->user_filters['number_days'];
-		$ending_date = date( "Y-m-d", strtotime( "+" . $end_day . " days", strtotime( $beginning_date ) ) );
-		$where = $where . $wpdb->prepare( " AND ($wpdb->posts.post_date >= %s AND $wpdb->posts.post_date < %s)", $beginning_date, $ending_date );
-	
-		return $where;
-	}
+
 	
 	/**
 	 * Prints the stories in a single term in the story budget.

--- a/modules/story-budget/story-budget.php
+++ b/modules/story-budget/story-budget.php
@@ -384,9 +384,6 @@ class EF_Story_Budget extends EF_Module {
 		
 		// Filter by post_author if it's set
 		if ( $args['author'] === '0' ) unset( $args['author'] );
-		
-		// Filter for an end user to implement any of their own query args
-     	$args = apply_filters( 'ef_story_budget_posts_query_args', $args );
 
 		$beginning_date = strtotime( $this->user_filters['start_date'] );
 		$days_to_show = $this->user_filters['number_days'];
@@ -397,6 +394,9 @@ class EF_Story_Budget extends EF_Module {
 			'before'    => date( "Y-m-d", $ending_date ),
 			'inclusive' => true,
 		);
+
+		// Filter for an end user to implement any of their own query args
+		$args = apply_filters( 'ef_story_budget_posts_query_args', $args );
 
 		$term_posts_query_results = new WP_Query( $args );
 		

--- a/modules/story-budget/story-budget.php
+++ b/modules/story-budget/story-budget.php
@@ -388,16 +388,14 @@ class EF_Story_Budget extends EF_Module {
 		// Filter for an end user to implement any of their own query args
      	$args = apply_filters( 'ef_story_budget_posts_query_args', $args );
 
-		$beginning_date = date( 'Y-m-d', strtotime( $this->user_filters['start_date'] )  );
-		$end_day = $this->user_filters['number_days'];
-		$ending_date = date( "Y-m-d", strtotime( "+" . $end_day . " days", strtotime( $beginning_date ) ) );
-
-		$beginning_date_offset = date( "Y-m-d", strtotime( $beginning_date  ) - DAY_IN_SECONDS );
-		$ending_date_offset = date( "Y-m-d", strtotime( $ending_date  ) + DAY_IN_SECONDS );
+		$beginning_date = strtotime( $this->user_filters['start_date'] );
+		$days_to_show = $this->user_filters['number_days'];
+		$ending_date = $beginning_date + ( $days_to_show * DAY_IN_SECONDS );
 
 		$args['date_query'] = array(
-			'before' => $ending_date_offset,
-			'after' => $beginning_date_offset,
+			'after'     => date( "Y-m-d", $beginning_date ),
+			'before'    => date( "Y-m-d", $ending_date ),
+			'inclusive' => true,
 		);
 
 		$term_posts_query_results = new WP_Query( $args );


### PR DESCRIPTION
Fixes #248 
Possibly a breaking change: Removing method `post_where_week_range` from the `posts_where` filter.