### PR TITLE
Changed the output of status on the calendar

### DIFF
--- a/modules/calendar/calendar.php
+++ b/modules/calendar/calendar.php
@@ -857,7 +857,7 @@ class EF_Calendar extends EF_Module {
 			<div style="clear:right;"></div>
 			<div class="item-static">
 				<div class="item-default-visible">
-					<div class="item-status"><span class="status-text"><?php echo esc_html( $this->get_post_status_friendly_name( get_post_status( $post_id ) ) ); ?></span></div>
+					<div class="item-status"><span class="status-text"><?php echo esc_html__( $this->get_post_status_friendly_name( get_post_status( $post_id ) ), 'edit-flow' ); ?></span></div>
 					<div class="inner">
 						<span class="item-headline post-title"><strong><?php echo esc_html( _draft_or_post_title( $post->ID ) ); ?></strong></span>
 					</div>


### PR DESCRIPTION
The missing part was the text domain for the output and that's all. This time I escaped the output later (based on this https://vip.wordpress.com/documentation/validating-sanitizing-escaping/#always-escape-late) This PR fixes #377 