### PR TITLE
Fix #252 - Cache calendar fragments for each user

### DIFF
--- a/modules/calendar/calendar.php
+++ b/modules/calendar/calendar.php
@@ -817,7 +817,7 @@ class EF_Calendar extends EF_Module {
 	function generate_post_li_html( $post, $post_date, $num = 0 ){
 
 		$can_modify = ( $this->current_user_can_modify_post( $post ) ) ? 'can_modify' : 'read_only';
-		$cache_key = $post->ID . $can_modify;
+		$cache_key = $post->ID . $can_modify . '_' . get_current_user_id();
 		$cache_val = wp_cache_get( $cache_key, self::$post_li_html_cache_key );
 		// Because $num is pertinent to the display of the post LI, need to make sure that's what's in cache
 		if ( is_array( $cache_val ) && $cache_val['num'] == $num ) {
@@ -826,7 +826,6 @@ class EF_Calendar extends EF_Module {
 		}
 
 		ob_start();
-
 		$post_id = $post->ID;
 		$edit_post_link = get_edit_post_link( $post_id );
 		

--- a/modules/calendar/calendar.php
+++ b/modules/calendar/calendar.php
@@ -919,7 +919,6 @@ class EF_Calendar extends EF_Module {
 				<?php do_action( 'ef_calendar_item_additional_html', $post->ID ); ?>
 			</table>
 			<?php
-				$post_type_object = get_post_type_object( $post->post_type );
 				$item_actions = array();
 				if ( $this->current_user_can_modify_post( $post ) ) {
 					// Edit this post

--- a/modules/calendar/calendar.php
+++ b/modules/calendar/calendar.php
@@ -918,6 +918,7 @@ class EF_Calendar extends EF_Module {
 				<?php do_action( 'ef_calendar_item_additional_html', $post->ID ); ?>
 			</table>
 			<?php
+				$post_type_object = get_post_type_object( $post->post_type );
 				$item_actions = array();
 				if ( $this->current_user_can_modify_post( $post ) ) {
 					// Edit this post

--- a/modules/calendar/calendar.php
+++ b/modules/calendar/calendar.php
@@ -911,7 +911,7 @@ class EF_Calendar extends EF_Module {
 						<?php elseif( $values['value'] ): ?>
 							<td class="value"><?php echo esc_html( $values['value'] ); ?></td>
 						<?php else: ?>
-						<td class="value"><em class="none"><?php esc_html_e( 'None', 'edit-flow' ); ?></em></td>
+						<td class="value"><em class="none"><?php echo _e( 'None', 'edit-flow' ); ?></em></td>
 						<?php endif; ?>
 					</tr>
 				<?php endforeach; ?>

--- a/modules/calendar/calendar.php
+++ b/modules/calendar/calendar.php
@@ -912,7 +912,7 @@ class EF_Calendar extends EF_Module {
 						<?php elseif( $values['value'] ): ?>
 							<td class="value"><?php echo esc_html( $values['value'] ); ?></td>
 						<?php else: ?>
-						<td class="value"><em class="none"><?php echo _e( 'None', 'edit-flow' ); ?></em></td>
+						<td class="value"><em class="none"><?php esc_html_e( 'None', 'edit-flow' ); ?></em></td>
 						<?php endif; ?>
 					</tr>
 				<?php endforeach; ?>


### PR DESCRIPTION
Issue #252 was caused because whole chunks of HTML are cached, including nonces that are specific to the current user. This fix caches the HTML fragments to the current user. 

An alternative to this fix would be to ajaxify the delete button, but that would take more effort to implement. This fixes a bug, I think that's good enough for now.