### PR TITLE
Fix #389 - Custom Statuses in Pages

### DIFF
--- a/modules/custom-status/custom-status.php
+++ b/modules/custom-status/custom-status.php
@@ -358,7 +358,7 @@ class EF_Custom_Status extends EF_Module {
 		wp_get_current_user() ;
 
 		// Only add the script to Edit Post and Edit Page pages -- don't want to bog down the rest of the admin with unnecessary javascript
-		if ( !empty( $post ) && $this->is_whitelisted_page() ) {
+		if ( $this->is_whitelisted_page() ) {
 
 			$custom_statuses = $this->get_custom_statuses();
 

--- a/modules/custom-status/custom-status.php
+++ b/modules/custom-status/custom-status.php
@@ -349,7 +349,7 @@ class EF_Custom_Status extends EF_Module {
 	 * @todo Support private and future posts on edit.php view
 	 */
 	function post_admin_header() {
-		global $post, $edit_flow, $pagenow, $current_user;
+		global $post, $pagenow;
 
 		if ( $this->disable_custom_statuses_for_post_type() )
 			return;

--- a/modules/custom-status/custom-status.php
+++ b/modules/custom-status/custom-status.php
@@ -388,17 +388,17 @@ class EF_Custom_Status extends EF_Module {
 
 			// The default statuses from WordPress
 			$all_statuses[] = array(
-				'name' => __( 'Published', 'edit-flow' ),
+				'name' => esc_html__( 'Published', 'edit-flow' ),
 				'slug' => 'publish',
 				'description' => '',
 			);
 			$all_statuses[] = array(
-				'name' => __( 'Privately Published', 'edit-flow' ),
+				'name' => esc_html__( 'Privately Published', 'edit-flow' ),
 				'slug' => 'private',
 				'description' => '',
 			);
 			$all_statuses[] = array(
-				'name' => __( 'Scheduled', 'edit-flow' ),
+				'name' => esc_html__( 'Scheduled', 'edit-flow' ),
 				'slug' => 'future',
 				'description' => '',
 			);
@@ -417,9 +417,17 @@ class EF_Custom_Status extends EF_Module {
  			$post_type_obj = get_post_type_object( $this->get_current_post_type() );
 
 			return array(
+				'i18n'      => array(
+					'no_change' => esc_html__( "&mdash; No Change &mdash;", 'edit-flow' ),
+					'published' => esc_html__( 'Published', 'edit-flow' ),
+					'save_as'   => esc_html__( 'Save as', 'edit-flow' ),
+					'save'      => esc_html__( 'Save', 'edit-flow' ),
+					'edit'      => esc_html__( 'Edit', 'edit-flow' ),
+					'ok'        => esc_html__( 'OK', 'edit-flow' ),
+					'cancel'    => esc_html__( 'Cancel', 'edit-flow' ),
+				),
 				'variables' => array(
 					'custom_statuses'                       => $all_statuses,
-					'text_no_change'                     => esc_js( __( "&mdash; No Change &mdash;" ) ),
 					'current_status'                        => esc_js( $selected ),
 					'current_status_name'                   => esc_js( $selected_name ),
 					'status_dropdown_visible'               => esc_js( $always_show_dropdown ),

--- a/modules/custom-status/lib/custom-status.js
+++ b/modules/custom-status/lib/custom-status.js
@@ -1,11 +1,13 @@
 jQuery(document).ready(function() {
 
+	var ef = window.__ef_custom_status.variables;
+
 	jQuery('label[for=post_status]').show();
 	jQuery('#post-status-display').show();
 
 	if ( jQuery('select[name="_status"]').length == 0 ) { // not on quick edit
 		
-		if ( current_user_can_publish_posts || ( current_status == 'publish' && current_user_can_edit_published_posts ) ) {
+		if ( ef.current_user_can_publish_posts || ( ef.current_status == 'publish' && ef.current_user_can_edit_published_posts ) ) {
 			// show publish button if allowed to publish
 			jQuery('#publish').show();
 		} else {
@@ -19,7 +21,7 @@ jQuery(document).ready(function() {
 			'  <a href="#post_status" class="cancel-post-status">Cancel</a>' +
 			' </div>').insertAfter('#post-status-display');
 		
-			if (!status_dropdown_visible) {
+			if (!ef.status_dropdown_visible) {
 				jQuery('#post-status-select').hide();
 				jQuery('.edit-post-status').show();
 			}
@@ -58,24 +60,24 @@ jQuery(document).ready(function() {
 		ef_append_to_dropdown('select[name="post_status"]');
 		
 		// Make status dropdown visible on load if enabled
-		if ( status_dropdown_visible ) {
+		if ( ef.status_dropdown_visible ) {
 			jQuery('#post-status-select').show();
 			jQuery('.edit-post-status').hide();
 		}
 		
 		// Hide status dropdown if not allowed to edit
-		if ( !ef_can_change_status(current_status) ) {
+		if ( !ef_can_change_status(ef.current_status) ) {
 			jQuery('#post-status-select').hide();
 			jQuery('.edit-post-status').hide();
 			
 			// set the current status as the selected one
-			var $option = jQuery('<option></option>').text(current_status_name).attr('value', current_status).attr('selected', 'selected');
+			var $option = jQuery('<option></option>').text(ef.current_status_name).attr('value', ef.current_status).attr('selected', 'selected');
 
 			$option.appendTo('select[name="post_status"]');
 		}
 		
 		// If custom status set for post, then set is as #post-status-display
-		jQuery('#post-status-display').text(ef_get_status_name(current_status));
+		jQuery('#post-status-display').text(ef_get_status_name(ef.current_status));
 
 	} else if ( jQuery('select[name="_status"]').length > 0 ) {
 		ef_append_to_dropdown('select[name="_status"]');
@@ -84,7 +86,7 @@ jQuery(document).ready(function() {
 			ef_append_to_dropdown('#the-list select[name="_status"]');
 		} );
 		// Clean up the bulk edit selector because it's non-standard
-		jQuery( '#bulk-edit' ).find( 'select[name="_status"]' ).prepend( '<option value="">' + ef_text_no_change + '</option>' );
+		jQuery( '#bulk-edit' ).find( 'select[name="_status"]' ).prepend( '<option value="">' + ef.text_no_change + '</option>' );
 		jQuery( '#bulk-edit' ).find( 'select[name="_status"] option' ).removeAttr('selected');
 		jQuery( '#bulk-edit' ).find( 'select[name="_status"] option[value="future"]').remove();
 	} else {
@@ -93,7 +95,7 @@ jQuery(document).ready(function() {
 		ef_update_save_button('Save');
 
 		// If custom status set for post, then set is as #post-status-display
-		jQuery('#post-status-display').text(ef_get_status_name(current_status));
+		jQuery('#post-status-display').text(ef_get_status_name(ef.current_status));
 		
 	}
 		
@@ -108,7 +110,7 @@ jQuery(document).ready(function() {
 		jQuery(id + ' option').not('[value="future"]').remove();
 		
 		// Add "Published" status to quick-edit for users that can publish
-		if ( id=='select[name="_status"]' && current_user_can_publish_posts ) {
+		if ( id=='select[name="_status"]' && ef.current_user_can_publish_posts ) {
 			jQuery(id).append(jQuery('<option></option')
 				.attr('value','publish')
 				.text('Published')
@@ -116,11 +118,11 @@ jQuery(document).ready(function() {
 		}
 		
 		// Add remaining statuses to dropdown. 'private' is always handled by a checkbox, and 'future' already exists if we need it
-		jQuery.each( custom_statuses, function() {
+		jQuery.each( ef.custom_statuses, function() {
 			if ( this.slug == 'private' || this.slug == 'future' )
 				return;
 			
-			if ( current_status != 'publish' && this.slug == 'publish' )
+			if ( ef.current_status != 'publish' && this.slug == 'publish' )
 				return;
 				
 			var $option = jQuery('<option></option>')
@@ -129,7 +131,7 @@ jQuery(document).ready(function() {
 							.attr('title', (this.description) ? this.description : '')
 							;
 							
-			if( current_status == this.slug ) $option.attr('selected','selected');
+			if( ef.current_status == this.slug ) $option.attr('selected','selected');
 			
 			$option.appendTo( jQuery(id) );
 		});
@@ -138,17 +140,17 @@ jQuery(document).ready(function() {
 	function ef_can_change_status(slug) {
 		var change = false;
 
-		jQuery.each(custom_statuses, function() {
+		jQuery.each(ef.custom_statuses, function() {
 			if(this.slug==slug) change = true;
 		});
-		if (slug == 'publish' && !current_user_can_publish_posts) {
+		if (slug == 'publish' && !ef.current_user_can_publish_posts) {
 			change = false;
 		}
 		return change;
 	}
 	
 	function ef_add_tooltips_to_filter_links(selector) {	
-		jQuery.each(custom_statuses, function() {
+		jQuery.each(ef.custom_statuses, function() {
 			jQuery(selector + ':contains("'+ this.name +'")')
 				.attr('title', this.description)
 		})
@@ -164,12 +166,12 @@ jQuery(document).ready(function() {
 	// Returns the name of the status given a slug
 	function ef_get_status_name (slug) {
 		var name = '';
-		jQuery.each(custom_statuses, function() {
+		jQuery.each(ef.custom_statuses, function() {
 			if(this.slug==slug) name = this.name;
 		});
 		
 		if (!name) {
-			name = current_status_name;
+			name = ef.current_status_name;
 		}
 		
 		return name;

--- a/modules/custom-status/lib/custom-status.js
+++ b/modules/custom-status/lib/custom-status.js
@@ -1,6 +1,7 @@
 jQuery(document).ready(function() {
 
 	var ef = window.__ef_custom_status.variables;
+	var i18n = window.__ef_custom_status.i18n;
 
 	jQuery('label[for=post_status]').show();
 	jQuery('#post-status-display').show();
@@ -12,13 +13,13 @@ jQuery(document).ready(function() {
 			jQuery('#publish').show();
 		} else {
 			// mimic default post status dropdown
-			jQuery('<span>&nbsp;<a href="#post_status" class="edit-post-status" tabindex=\'4\'>Edit</a></span>' + 
+			jQuery('<span>&nbsp;<a href="#post_status" class="edit-post-status" tabindex=\'4\'>' + i18n.edit + '</a></span>' +
 			' <div id="post-status-select">' +
 			' <input type="hidden" name="hidden_post_status" id="hidden_post_status" value="in-progress" />' +
 			' <select name=\'post_status\' id=\'post_status\' tabindex=\'4\'>' +
 			' </select>' +
-			'  <a href="#post_status" class="save-post-status button">OK</a>' +
-			'  <a href="#post_status" class="cancel-post-status">Cancel</a>' +
+			'  <a href="#post_status" class="save-post-status button">' + i18n.ok + '</a>' +
+			'  <a href="#post_status" class="cancel-post-status">' + i18n.cancel + '</a>' +
 			' </div>').insertAfter('#post-status-display');
 		
 			if (!ef.status_dropdown_visible) {
@@ -49,7 +50,7 @@ jQuery(document).ready(function() {
 	if ( jQuery('select[name="post_status"]').length > 0 ) {
 		
 		// Set the Save button to generic text by default
-		ef_update_save_button('Save');
+		ef_update_save_button(i18n.save);
 		
 		// Bind event when OK button is clicked
 		jQuery('.save-post-status').bind('click', function() {	
@@ -86,13 +87,13 @@ jQuery(document).ready(function() {
 			ef_append_to_dropdown('#the-list select[name="_status"]');
 		} );
 		// Clean up the bulk edit selector because it's non-standard
-		jQuery( '#bulk-edit' ).find( 'select[name="_status"]' ).prepend( '<option value="">' + ef.text_no_change + '</option>' );
+		jQuery( '#bulk-edit' ).find( 'select[name="_status"]' ).prepend( '<option value="">' + i18n.no_change + '</option>' );
 		jQuery( '#bulk-edit' ).find( 'select[name="_status"] option' ).removeAttr('selected');
 		jQuery( '#bulk-edit' ).find( 'select[name="_status"] option[value="future"]').remove();
 	} else {
 
 		// Set the Save button to generic text by default
-		ef_update_save_button('Save');
+		ef_update_save_button(i18n.save);
 
 		// If custom status set for post, then set is as #post-status-display
 		jQuery('#post-status-display').text(ef_get_status_name(ef.current_status));
@@ -113,7 +114,7 @@ jQuery(document).ready(function() {
 		if ( id=='select[name="_status"]' && ef.current_user_can_publish_posts ) {
 			jQuery(id).append(jQuery('<option></option')
 				.attr('value','publish')
-				.text('Published')
+				.text(i18n.published)
 			);
 		}
 		
@@ -159,7 +160,7 @@ jQuery(document).ready(function() {
 	
 	// Update "Save" button text
 	function ef_update_save_button( text ) {
-		if(!text) text = 'Save as ' + jQuery('select[name="post_status"] :selected').text();
+		if(!text) text = i18n.save_as + ' ' + jQuery('select[name="post_status"] :selected').text();
 		jQuery(':input#save-post').attr('value', text);
 	}
 	


### PR DESCRIPTION
This fixes #389 and makes the `custom-status.js` translatable