### PR TITLE
Revert "Fix #389 - Custom Statuses in Pages"

### DIFF
--- a/modules/custom-status/custom-status.php
+++ b/modules/custom-status/custom-status.php
@@ -297,15 +297,6 @@ class EF_Custom_Status extends EF_Module {
 		if ( $this->is_whitelisted_page() ) {
 			wp_enqueue_script( 'edit_flow-custom_status', $this->module_url . 'lib/custom-status.js', array( 'jquery','post' ), EDIT_FLOW_VERSION, true );
 			wp_enqueue_style( 'edit_flow-custom_status', $this->module_url . 'lib/custom-status.css', false, EDIT_FLOW_VERSION, 'all' );
-			wp_localize_script('edit_flow-custom_status', '__ef_localize_custom_status', array(
-				'no_change' => esc_html__( "&mdash; No Change &mdash;", 'edit-flow' ),
-				'published' => esc_html__( 'Published', 'edit-flow' ),
-				'save_as'   => esc_html__( 'Save as', 'edit-flow' ),
-				'save'      => esc_html__( 'Save', 'edit-flow' ),
-				'edit'      => esc_html__( 'Edit', 'edit-flow' ),
-				'ok'        => esc_html__( 'OK', 'edit-flow' ),
-				'cancel'    => esc_html__( 'Cancel', 'edit-flow' ),
-			));
 		}
 	}
 
@@ -358,7 +349,7 @@ class EF_Custom_Status extends EF_Module {
 	 * @todo Support private and future posts on edit.php view
 	 */
 	function post_admin_header() {
-		global $post, $pagenow;
+		global $post, $edit_flow, $pagenow, $current_user;
 
 		if ( $this->disable_custom_statuses_for_post_type() )
 			return;
@@ -367,7 +358,7 @@ class EF_Custom_Status extends EF_Module {
 		wp_get_current_user() ;
 
 		// Only add the script to Edit Post and Edit Page pages -- don't want to bog down the rest of the admin with unnecessary javascript
-		if ( $this->is_whitelisted_page() ) {
+		if ( !empty( $post ) && $this->is_whitelisted_page() ) {
 
 			$custom_statuses = $this->get_custom_statuses();
 
@@ -396,17 +387,17 @@ class EF_Custom_Status extends EF_Module {
 
 			// The default statuses from WordPress
 			$all_statuses[] = array(
-				'name' => esc_html__( 'Published', 'edit-flow' ),
+				'name' => __( 'Published', 'edit-flow' ),
 				'slug' => 'publish',
 				'description' => '',
 			);
 			$all_statuses[] = array(
-				'name' => esc_html__( 'Privately Published', 'edit-flow' ),
+				'name' => __( 'Privately Published', 'edit-flow' ),
 				'slug' => 'private',
 				'description' => '',
 			);
 			$all_statuses[] = array(
-				'name' => esc_html__( 'Scheduled', 'edit-flow' ),
+				'name' => __( 'Scheduled', 'edit-flow' ),
 				'slug' => 'future',
 				'description' => '',
 			);

--- a/modules/custom-status/lib/custom-status.js
+++ b/modules/custom-status/lib/custom-status.js
@@ -1,7 +1,5 @@
 jQuery(document).ready(function() {
 
-	var i18n = window.__ef_localize_custom_status;
-
 	jQuery('label[for=post_status]').show();
 	jQuery('#post-status-display').show();
 
@@ -12,13 +10,13 @@ jQuery(document).ready(function() {
 			jQuery('#publish').show();
 		} else {
 			// mimic default post status dropdown
-			jQuery('<span>&nbsp;<a href="#post_status" class="edit-post-status" tabindex=\'4\'>' + i18n.edit + '</a></span>' +
+			jQuery('<span>&nbsp;<a href="#post_status" class="edit-post-status" tabindex=\'4\'>Edit</a></span>' + 
 			' <div id="post-status-select">' +
 			' <input type="hidden" name="hidden_post_status" id="hidden_post_status" value="in-progress" />' +
 			' <select name=\'post_status\' id=\'post_status\' tabindex=\'4\'>' +
 			' </select>' +
-			'  <a href="#post_status" class="save-post-status button">' + i18n.ok + '</a>' +
-			'  <a href="#post_status" class="cancel-post-status">' + i18n.cancel + '</a>' +
+			'  <a href="#post_status" class="save-post-status button">OK</a>' +
+			'  <a href="#post_status" class="cancel-post-status">Cancel</a>' +
 			' </div>').insertAfter('#post-status-display');
 		
 			if (!status_dropdown_visible) {
@@ -49,7 +47,7 @@ jQuery(document).ready(function() {
 	if ( jQuery('select[name="post_status"]').length > 0 ) {
 		
 		// Set the Save button to generic text by default
-		ef_update_save_button(i18n.save);
+		ef_update_save_button('Save');
 		
 		// Bind event when OK button is clicked
 		jQuery('.save-post-status').bind('click', function() {	
@@ -86,13 +84,13 @@ jQuery(document).ready(function() {
 			ef_append_to_dropdown('#the-list select[name="_status"]');
 		} );
 		// Clean up the bulk edit selector because it's non-standard
-		jQuery( '#bulk-edit' ).find( 'select[name="_status"]' ).prepend( '<option value="">' + i18n.no_change + '</option>' );
+		jQuery( '#bulk-edit' ).find( 'select[name="_status"]' ).prepend( '<option value="">' + ef_text_no_change + '</option>' );
 		jQuery( '#bulk-edit' ).find( 'select[name="_status"] option' ).removeAttr('selected');
 		jQuery( '#bulk-edit' ).find( 'select[name="_status"] option[value="future"]').remove();
 	} else {
 
 		// Set the Save button to generic text by default
-		ef_update_save_button(i18n.save);
+		ef_update_save_button('Save');
 
 		// If custom status set for post, then set is as #post-status-display
 		jQuery('#post-status-display').text(ef_get_status_name(current_status));
@@ -113,7 +111,7 @@ jQuery(document).ready(function() {
 		if ( id=='select[name="_status"]' && current_user_can_publish_posts ) {
 			jQuery(id).append(jQuery('<option></option')
 				.attr('value','publish')
-				.text( i18n.published )
+				.text('Published')
 			);
 		}
 		
@@ -159,7 +157,7 @@ jQuery(document).ready(function() {
 	
 	// Update "Save" button text
 	function ef_update_save_button( text ) {
-		if(!text) text = i18n.save_as + ' ' + jQuery('select[name="post_status"] :selected').text();
+		if(!text) text = 'Save as ' + jQuery('select[name="post_status"] :selected').text();
 		jQuery(':input#save-post').attr('value', text);
 	}
 	


### PR DESCRIPTION
There was still room for improvement in #414
A cleaner solution available in pull requests #419 and #420 

This will revert Automattic/Edit-Flow#414 so that #419 and #420 can be merged in.