### PR TITLE
Fix #389 - pass custom-status variables to JavaScript on all whitelisted pages

### DIFF
--- a/modules/custom-status/custom-status.php
+++ b/modules/custom-status/custom-status.php
@@ -358,25 +358,30 @@ class EF_Custom_Status extends EF_Module {
 		wp_get_current_user() ;
 
 		// Only add the script to Edit Post and Edit Page pages -- don't want to bog down the rest of the admin with unnecessary javascript
-		if ( !empty( $post ) && $this->is_whitelisted_page() ) {
+		if ( $this->is_whitelisted_page() ) {
 
 			$custom_statuses = $this->get_custom_statuses();
 
-			// Get the status of the current post
-			if ( $post->ID == 0 || $post->post_status == 'auto-draft' || $pagenow == 'edit.php' ) {
-				// TODO: check to make sure that the default exists
-				$selected = $this->get_default_custom_status()->slug;
-
-			} else {
-				$selected = $post->post_status;
-			}
-
-			// Get the current post status name
+			// $selected can be empty, but must be set because it's used as a JS variable
+			$selected = '';
 			$selected_name = '';
 
-			foreach ($custom_statuses as $status) {
-				if ($status->slug == $selected) {
-					$selected_name = $status->name;
+			if( ! empty( $post ) ) {
+				// Get the status of the current post
+				if ( $post->ID == 0 || $post->post_status == 'auto-draft' || $pagenow == 'edit.php' ) {
+					// TODO: check to make sure that the default exists
+					$selected = $this->get_default_custom_status()->slug;
+
+				} else {
+					$selected = $post->post_status;
+				}
+
+				// Get the label of current status
+				foreach ( $custom_statuses as $status ) {
+					if ( $status->slug == $selected ) {
+						$selected_name = $status->name;
+						break; // selected name found, we can exit the loop
+					}
 				}
 			}
 

--- a/modules/custom-status/custom-status.php
+++ b/modules/custom-status/custom-status.php
@@ -380,7 +380,6 @@ class EF_Custom_Status extends EF_Module {
 				foreach ( $custom_statuses as $status ) {
 					if ( $status->slug == $selected ) {
 						$selected_name = $status->name;
-						break; // selected name found, we can exit the loop
 					}
 				}
 			}


### PR DESCRIPTION
This will ensure that variables are passed to `custom-status.js` even when `global $post` is not available (for example, in Page list). 

`$selected` and `$selected_name` variables are only used in single view, so they can be left empty if there is no `global $post` object available.

Also, a micro-optimization is included that breaks out of the `foreach` loop when the `$selected_name` is found