### PR TITLE
Limit posts_per_page in calendar week query

### DIFF
--- a/modules/calendar/calendar.php
+++ b/modules/calendar/calendar.php
@@ -1182,7 +1182,7 @@ class EF_Calendar extends EF_Module {
 			'cat'              => null,
 			'author'           => null,
 			'post_type'        => $supported_post_types,
-			'posts_per_page'   => -1,
+			'posts_per_page'   => 200,
 		);
 						 
 		$args = array_merge( $defaults, $args );


### PR DESCRIPTION
Fixes #236 

[It's recommended](https://vip.wordpress.com/documentation/code-review-what-we-look-for/#no-limit-queries) to limit `posts_per_page` when possible. 

I think that 200 posts per week should be a reasonable upper limit for 99.99% use cases. For the remaining 0.01%, a simple filter can easily revert this back:
```
add_filter( 'ef_calendar_posts_query_args', function( $args ) {
	$args['posts_per_page'] = -1;
	return $args;
});
```