### PR TITLE
Added a check for the tests dir

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,6 +1,10 @@
 <?php
 
-$_tests_dir = '/tmp/wordpress/tests/phpunit';
+$_tests_dir = getenv( 'WP_TESTS_DIR' );
+
+if ( !$_tests_dir ) {
+	$_tests_dir = '/tmp/wordpress/tests/phpunit';
+}
 
 require_once $_tests_dir . '/includes/functions.php';
 


### PR DESCRIPTION
When the tests folder is installed locally, the folder might be different than the one used on travis. That's why I added a check. If the path to the tests is found in the environment variables, that one is used. If not, a default path is used. I made this change because the tests were installed on a different folder on my computer and I didn't want to change the $_tests_dir (not even for a test) because I might push it to the plugin (by mistake) and I thought about this workaround.