### PR TITLE
Fixes the dash between the post title and status label

### DIFF
--- a/modules/custom-status/lib/custom-status.js
+++ b/modules/custom-status/lib/custom-status.js
@@ -186,8 +186,8 @@ jQuery(document).ready(function() {
 	// Remove the " - " in between a post title and the post-state span (separately hidden via CSS).
 	// This will not affect the dash before post-state-format spans.
 	function ef_remove_post_title_trailing_dashes() {
-		jQuery('.post-title.column-title strong').each(function() {
-			jQuery(this).html(jQuery(this).html().replace(/(.*) - (<span class="post-state".*<\/span>)$/g, "$1$2"));
+		jQuery('.page-title.column-title strong').each(function() {
+			jQuery(this).html(jQuery(this).html().substr (0, jQuery(this).html().indexOf('</a>')));
 		});
 	}
 	


### PR DESCRIPTION
When the custom statuses are used, there's an option to display a column with the statuses on Posts section (on the dashboard). Right now, the dashes between the post title and status label (that are hidden) are still there. The class for post titles was wrong and I replaced the regex with a _substr_ function. This fixes #395.

I checked what happens both when the status column is displayed/hidden and the custom status is not used. Things are working very well.

The problem that this PR is fixing is the one about the dash that exists by default on WordPress between the post/page title and its status:

<img width="531" alt="screenshot at feb 02 14-35-11" src="https://user-images.githubusercontent.com/6512220/35733504-5b9ec7ee-0826-11e8-9590-49df8b8b5cd6.png">
When the custom status from Edit Flow is used, a column for statuses is displayed. That's why the status on the end of the post title is no longer needed. However, the dash between is still there:

<img width="398" alt="screenshot at feb 02 14-28-30" src="https://user-images.githubusercontent.com/6512220/35733591-a88a5474-0826-11e8-9de0-cac4b9385031.png">

According to the comment for the _ef_remove_post_title_trailing_dashes_ function, this code:
`replace(/(.*) - (<span class="post-state".*<\/span>)$/g, "$1$2"));`
should remove this dash:

<img width="398" alt="screenshot at feb 02 14-28-30" src="https://user-images.githubusercontent.com/6512220/35733258-6180e5da-0825-11e8-869d-2fbd1ec12c2c.png">

However, this is not doing any change so I used this code instead:
`substr (0, jQuery(this).html().indexOf('</a>')));`
that's looking for the end of the anchor and keeps everything before it (including the closing tag).

Also, I changed the selector from https://github.com/Automattic/Edit-Flow/pull/431/files#diff-ffa61788e8ad2e66c3f716f610e629c0L189 because the class of the post title is _page-title_, not _post-title_ and this is the one that should be targeted in order to remove the dash.