### PR TITLE
Changed the way that the post title and status looks on calendar cells

### DIFF
--- a/modules/calendar/calendar.php
+++ b/modules/calendar/calendar.php
@@ -857,9 +857,19 @@ class EF_Calendar extends EF_Module {
 			<div style="clear:right;"></div>
 			<div class="item-static">
 				<div class="item-default-visible">
-					<div class="item-status"><span class="status-text"><?php echo esc_html__( $this->get_post_status_friendly_name( get_post_status( $post_id ) ), 'edit-flow' ); ?></span></div>
+					<div class="item-status"><span class="status-text"><?php
+								if ( strlen( esc_html__( $this->get_post_status_friendly_name( get_post_status( $post_id ) ), 'edit-flow' ) ) > 8 )
+									echo substr( esc_html__( $this->get_post_status_friendly_name( get_post_status( $post_id ) ), 'edit-flow' ), 0, 8 ) . '...';
+								else
+									echo esc_html__( $this->get_post_status_friendly_name( get_post_status( $post_id ) ), 'edit-flow' );
+								?></span></div>
 					<div class="inner">
-						<span class="item-headline post-title"><strong><?php echo esc_html( _draft_or_post_title( $post->ID ) ); ?></strong></span>
+						<span class="item-headline post-title"><strong><?php
+								if ( strlen( esc_html( _draft_or_post_title( $post->ID ) ) ) > 15 )
+									echo substr( esc_html( _draft_or_post_title( $post->ID ) ), 0, 15 ) . '...';
+								else
+									echo esc_html( _draft_or_post_title( $post->ID ) );
+								?></strong></span>
 					</div>
 				</div>
 				<div class="item-inner">


### PR DESCRIPTION
I started working on this based on the question raised on #378. I tested different post titles and statuses and I tried to look for a change that will make both elements look better inside a calendar cell.