### PR TITLE
Remove gutenberg list styles from Edit Flow metaboxes

### DIFF
--- a/common/css/edit-flow-admin.css
+++ b/common/css/edit-flow-admin.css
@@ -7,3 +7,11 @@
 #ui-datepicker-div {
 	margin-top: 30px;
 }
+
+
+/*
+	Override Gutenberg 2.0
+ */
+#ef-comments .comment-item,  #ef-post_following_box .list-filterizer-tabs {
+	list-style-type: none;
+}


### PR DESCRIPTION
A tiny fix for when Gutenberg styles break Edit Flow metabox lists.

Fixes #430 