### PR TITLE
Fix broken in-post pagination when custom post statuses are used

### DIFF
--- a/common/php/util.php
+++ b/common/php/util.php
@@ -14,3 +14,54 @@ if( ! function_exists( 'ef_draft_or_post_title' ) ) :
 		return ! empty( $post->post_title ) ? $post->post_title : __( '(no title)', 'edit-flow' );
 	}
 endif;
+
+/**
+ * This function is necessary to make post preview pagination work with custom post statuses
+ * @modified WordPress 4.9.2
+ *
+ * Original Comments:
+ *
+ * Helper function for wp_link_pages()
+ *
+ * @since 3.1.0
+ * @access private
+ *
+ * @global WP_Rewrite $wp_rewrite
+ *
+ * @param int $i Page number.
+ * @return string Link.
+ */
+if ( ! function_exists( '_ef_wp_link_page' ) ) {
+	function _ef_wp_link_page( $i ) {
+		$custom_statuses= wp_list_pluck( edit_flow::instance()->custom_status->get_custom_statuses(), 'slug');
+
+		global $wp_rewrite;
+		$post = get_post();
+		$query_args = array();
+
+		if ( 1 == $i ) {
+			$url = get_permalink();
+		} else {
+			// Check for all custom post statuses, not just draft & pending
+			if ( '' == get_option('permalink_structure') || in_array($post->post_status, array_merge( $custom_statuses, array( 'pending' ) ) ) )
+				$url = add_query_arg( 'page', $i, get_permalink() );
+			elseif ( 'page' == get_option('show_on_front') && get_option('page_on_front') == $post->ID )
+				$url = trailingslashit(get_permalink()) . user_trailingslashit("$wp_rewrite->pagination_base/" . $i, 'single_paged');
+			else
+				$url = trailingslashit(get_permalink()) . user_trailingslashit($i, 'single_paged');
+		}
+
+		if ( is_preview() ) {
+
+			// Check for all custom post statuses, no just the draft
+			if ( ( ! in_array($post->post_status, $custom_statuses ) ) && isset( $_GET['preview_id'], $_GET['preview_nonce'] ) ) {
+				$query_args['preview_id'] = wp_unslash( $_GET['preview_id'] );
+				$query_args['preview_nonce'] = wp_unslash( $_GET['preview_nonce'] );
+			}
+
+			$url = get_preview_post_link( $post, $query_args, $url );
+		}
+
+		return '<a href="' . esc_url( $url ) . '">';
+	}
+}

--- a/common/php/util.php
+++ b/common/php/util.php
@@ -17,6 +17,7 @@ endif;
 
 /**
  * This function is necessary to make post preview pagination work with custom post statuses
+ * @see _wp_link_page()
  * @modified WordPress 4.9.2
  *
  * Original Comments:

--- a/common/php/util.php
+++ b/common/php/util.php
@@ -32,9 +32,7 @@ endif;
  * @return string Link.
  */
 if ( ! function_exists( '_ef_wp_link_page' ) ) {
-	function _ef_wp_link_page( $i ) {
-		$custom_statuses= wp_list_pluck( edit_flow::instance()->custom_status->get_custom_statuses(), 'slug');
-
+	function _ef_wp_link_page( $i, $custom_statuses ) {
 		global $wp_rewrite;
 		$post = get_post();
 		$query_args = array();

--- a/modules/custom-status/custom-status.php
+++ b/modules/custom-status/custom-status.php
@@ -1624,17 +1624,19 @@ class EF_Custom_Status extends EF_Module {
 			return $link;
 		}
 
-		$defaults = array(
-			'link_before'      => '',
-			'link_after'       => '',
-			'pagelink'         => '%',
-		);
-
-		// Apply original link filters from core `wp_link_pages()`
-		$r = apply_filters( 'wp_link_pages_args', $defaults );
-
+		// Get an array of valid custom status slugs
 		$custom_statuses = wp_list_pluck( $this->get_custom_statuses(), 'slug');
 
+		// Apply original link filters from core `wp_link_pages()`
+		$r = apply_filters( 'wp_link_pages_args', array(
+				'link_before' => '',
+				'link_after'  => '',
+				'pagelink'    => '%',
+			)
+		);
+
+		// _wp_link_page() && _ef_wp_link_page() produces an opening link tag ( <a href=".."> )
+		// This is necessary to replicate core behavior:
 		$link = $r['link_before'] . str_replace( '%', $i, $r['pagelink'] ) . $r['link_after'];
 		$link = _ef_wp_link_page( $i, $custom_statuses ) . $link . '</a>';
 

--- a/modules/custom-status/custom-status.php
+++ b/modules/custom-status/custom-status.php
@@ -112,6 +112,9 @@ class EF_Custom_Status extends EF_Module {
 		add_filter( 'post_row_actions', array( $this, 'fix_post_row_actions' ), 10, 2 );
 		add_filter( 'page_row_actions', array( $this, 'fix_post_row_actions' ), 10, 2 );
 
+		// Pagination for custom post statuses when previewing posts
+		add_filter( 'wp_link_pages_link', array( $this, 'modify_preview_link_pagination_url' ), 10, 2 );
+
 	}
 
 	/**
@@ -1598,6 +1601,43 @@ class EF_Custom_Status extends EF_Module {
 		}
 
 		return $return;
+	}
+
+
+	/**
+	 * Fixes a bug where post-pagination doesn't work when previewing a post with a custom status
+	 * @link https://github.com/Automattic/Edit-Flow/issues/192
+	 *
+	 * This filter only modifies output if `is_preview()` is true
+	 *
+	 * Used by `wp_link_pages_link` filter
+	 *
+	 * @param $link
+	 * @param $i
+	 *
+	 * @return string
+	 */
+	function modify_preview_link_pagination_url( $link, $i ) {
+
+		// Use the original $link when not in preview mode
+		if( ! is_preview() ) {
+			return $link;
+		}
+
+		$defaults = array(
+			'link_before'      => '',
+			'link_after'       => '',
+			'pagelink'         => '%',
+		);
+
+		// Apply original link filters from core `wp_link_pages()`
+		$r = apply_filters( 'wp_link_pages_args', $defaults );
+
+		$link = $r['link_before'] . str_replace( '%', $i, $r['pagelink'] ) . $r['link_after'];
+		$link = _ef_wp_link_page( $i ) . $link . '</a>';
+
+
+		return $link;
 	}
 
 	/**

--- a/modules/custom-status/custom-status.php
+++ b/modules/custom-status/custom-status.php
@@ -1633,8 +1633,10 @@ class EF_Custom_Status extends EF_Module {
 		// Apply original link filters from core `wp_link_pages()`
 		$r = apply_filters( 'wp_link_pages_args', $defaults );
 
+		$custom_statuses = wp_list_pluck( $this->get_custom_statuses(), 'slug');
+
 		$link = $r['link_before'] . str_replace( '%', $i, $r['pagelink'] ) . $r['link_after'];
-		$link = _ef_wp_link_page( $i ) . $link . '</a>';
+		$link = _ef_wp_link_page( $i, $custom_statuses ) . $link . '</a>';
 
 
 		return $link;

--- a/modules/custom-status/custom-status.php
+++ b/modules/custom-status/custom-status.php
@@ -1635,7 +1635,7 @@ class EF_Custom_Status extends EF_Module {
 			)
 		);
 
-		// _wp_link_page() && _ef_wp_link_page() produces an opening link tag ( <a href=".."> )
+		// _wp_link_page() && _ef_wp_link_page() produce an opening link tag ( <a href=".."> )
 		// This is necessary to replicate core behavior:
 		$link = $r['link_before'] . str_replace( '%', $i, $r['pagelink'] ) . $r['link_after'];
 		$link = _ef_wp_link_page( $i, $custom_statuses ) . $link . '</a>';


### PR DESCRIPTION
Fix #192 

WordPress doesn't fully support custom post statuses, which is why there are many "hacks" inside Edit Flow. This is another one.

There is no way to tell `_wp_link_page()` function that we have other statuses besides draft that are still unpublished. That's why I copied original `_wp_link_page()` function, renamed it to `_ef_wp_link_page()` and added support for custom post statuses.

Then the `_ef_wp_link_page()` function is used to generate a new link when in preview mode using the `wp_link_pages_link` filter. 