### PR TITLE
Don’t generate rewrite rules for notepad

### DIFF
--- a/modules/dashboard/widgets/dashboard-notepad.php
+++ b/modules/dashboard/widgets/dashboard-notepad.php
@@ -16,6 +16,7 @@ class EF_Dashboard_Notepad_Widget {
 	public function init() {
 
 		register_post_type( self::notepad_post_type, array(
+				'rewrite' => false,
 				'label' => __( 'Dashboard Note', 'edit-flow' )
 			) 
 		);


### PR DESCRIPTION
Fix #245 
The dashboard notepad was generating an unused WordPress rewrite. This pull removes that behavior.