### PR TITLE
Added a test for multisite preview page

### DIFF
--- a/tests/test-edit-flow-custom-status.php
+++ b/tests/test-edit-flow-custom-status.php
@@ -335,7 +335,8 @@ class WP_Test_Edit_Flow_Custom_Status extends WP_UnitTestCase {
 
 	public function test_home_url_slash_available_on_multisite_page_preview() {
 		if ( is_multisite() ) {
-			$blog_id = wpmu_create_blog( site_url(), 'sample', 'test', self::$admin_user_id );
+			global $pagenow;
+			$blog_id = self::factory()->blog->create( array( 'user_id' => self::$admin_user_id ) );
 			switch_to_blog( $blog_id );
 
 			$page_args = array(
@@ -344,9 +345,12 @@ class WP_Test_Edit_Flow_Custom_Status extends WP_UnitTestCase {
 				'post_status' => 'draft',
 				'post_author' => self::$admin_user_id
 			);
-			$added_page = wp_insert_post( $page_args  );
+			$added_page = wp_insert_post( $page_args );
 
+			// set $pagenow to index.php so we can make sure that the frontpage is checked, not the dashboard
+			$pagenow = 'index.php';
 			$this->assertContains( '/?page_id=', get_preview_post_link( $added_page ) );
+
 		}
 	}
 }

--- a/tests/test-edit-flow-custom-status.php
+++ b/tests/test-edit-flow-custom-status.php
@@ -332,4 +332,21 @@ class WP_Test_Edit_Flow_Custom_Status extends WP_UnitTestCase {
 		$this->assertSame( home_url() . '/publish-parent-page/%pagename%/', $actual[0] );
 		$this->assertSame( 'child-page', $actual[1] );
 	}
+
+	public function test_home_url_slash_available_on_multisite_page_preview() {
+		if ( is_multisite() ) {
+			$blog_id = wpmu_create_blog( site_url(), 'sample', 'test', self::$admin_user_id );
+			switch_to_blog( $blog_id );
+
+			$page_args = array(
+				'post_type'   => 'page',
+				'post_title'  => 'Preview Page',
+				'post_status' => 'draft',
+				'post_author' => self::$admin_user_id
+			);
+			$added_page = wp_insert_post( $page_args  );
+
+			$this->assertContains( '/?page_id=', get_preview_post_link( $added_page ) );
+		}
+	}
 }


### PR DESCRIPTION
This change is meant to test the PR #357. The problem is that when you're previewing a page on a multisite using subdirectory (not subdomain), the link is 

http://eflowmslocal.local/test1?page_id=7&preview_id=7&preview=true

instead of:

http://eflowmslocal.local/test1/?page_id=7&preview_id=7&preview=true

(it's missing the / between test1 and ?page_id).

The solution from the PR is the right one and I want to wrap this up into a test.

Basically, what I'm trying to do is:
1. check if the current installation is multisite;
2. create a new blog; 
3. move to it;
4. create a new page;
5. check its preview link. 

The problem is that the preview link seems to have a broken structure once I create the new blog. This is how the link looks:

http://httpexample.org/sample/?page_id=3&preview=true

The slash appears even though the preview link in the browser is still broken.