### PR TITLE
Add local PHPUnit setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -89,18 +89,8 @@ matrix:
     - php: "5.3"
 
 before_script:
-    - export PLUGIN_SLUG=$(basename $(pwd))
-    - git clone --depth=1 --branch $WP_VERSION git://develop.git.wordpress.org/ /tmp/wordpress
-    - cd ..
-    - mv $PLUGIN_SLUG "/tmp/wordpress/src/wp-content/plugins/$PLUGIN_SLUG"
-    - cd /tmp/wordpress
-    - git checkout $WP_VERSION
-    - mysql -e "CREATE DATABASE wordpress_tests;" -uroot
-    - cp wp-tests-config-sample.php wp-tests-config.php
-    - sed -i "s/youremptytestdbnamehere/wordpress_tests/" wp-tests-config.php
-    - sed -i "s/yourusernamehere/travis/" wp-tests-config.php
-    - sed -i "s/yourpasswordhere//" wp-tests-config.php
-    - cd "/tmp/wordpress/src/wp-content/plugins/$PLUGIN_SLUG"
+    - bash bin/install-wp-tests.sh wordpress_test root '' localhost $WP_VERSION
+    - export PATH="$HOME/.composer/vendor/bin:$PATH"
     - |
         if [[ ${TRAVIS_PHP_VERSION:0:2} == "7." ]]; then
           composer global require "phpunit/phpunit=5.7.*"

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ php:
     - "7.1"
 
 env:
-    - WP_VERSION=master WP_MULTISITE=0 #Current stable release
+    - WP_VERSION=latest WP_MULTISITE=0 #Current stable release
 
 # Test WP 4.8 and on PHP 5.4, 5.5, 5.6, 7.0 and 7.1 (w and w/o multisite enabled)
 # Test WP 4.8 and on PHP 5.2 and 5.3 and allow_failures (w and w/o multisite enabled)
@@ -82,7 +82,7 @@ matrix:
     - php: "7.1"
       env: WP_VERSION=4.9 WP_MULTISITE=1
     - php: "nightly"
-      env: WP_VERSION=master WP_MULTISITE=0
+      env: WP_VERSION=latest WP_MULTISITE=0
   allow_failures:
     - php: "nightly"
     - php: "5.2"

--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+
+if [ $# -lt 3 ]; then
+	echo "usage: $0 <db-name> <db-user> <db-pass> [db-host] [wp-version] [skip-database-creation]"
+	exit 1
+fi
+
+DB_NAME=$1
+DB_USER=$2
+DB_PASS=$3
+DB_HOST=${4-localhost}
+WP_VERSION=${5-latest}
+SKIP_DB_CREATE=${6-false}
+
+WP_TESTS_DIR=${WP_TESTS_DIR-/tmp/wordpress-tests-lib}
+WP_CORE_DIR=${WP_CORE_DIR-/tmp/wordpress/}
+
+download() {
+    if [ `which curl` ]; then
+        curl -s "$1" > "$2";
+    elif [ `which wget` ]; then
+        wget -nv -O "$2" "$1"
+    fi
+}
+
+if [[ $WP_VERSION =~ [0-9]+\.[0-9]+(\.[0-9]+)? ]]; then
+	WP_TESTS_TAG="tags/$WP_VERSION"
+elif [[ $WP_VERSION == 'nightly' || $WP_VERSION == 'trunk' ]]; then
+	WP_TESTS_TAG="trunk"
+else
+	# http serves a single offer, whereas https serves multiple. we only want one
+	download http://api.wordpress.org/core/version-check/1.7/ /tmp/wp-latest.json
+	grep '[0-9]+\.[0-9]+(\.[0-9]+)?' /tmp/wp-latest.json
+	LATEST_VERSION=$(grep -o '"version":"[^"]*' /tmp/wp-latest.json | sed 's/"version":"//')
+	if [[ -z "$LATEST_VERSION" ]]; then
+		echo "Latest WordPress version could not be found"
+		exit 1
+	fi
+	WP_TESTS_TAG="tags/$LATEST_VERSION"
+fi
+
+set -ex
+
+install_wp() {
+
+	if [ -d $WP_CORE_DIR ]; then
+		return;
+	fi
+
+	mkdir -p $WP_CORE_DIR
+
+	if [[ $WP_VERSION == 'nightly' || $WP_VERSION == 'trunk' ]]; then
+		mkdir -p /tmp/wordpress-nightly
+		download https://wordpress.org/nightly-builds/wordpress-latest.zip  /tmp/wordpress-nightly/wordpress-nightly.zip
+		unzip -q /tmp/wordpress-nightly/wordpress-nightly.zip -d /tmp/wordpress-nightly/
+		mv /tmp/wordpress-nightly/wordpress/* $WP_CORE_DIR
+	else
+		if [ $WP_VERSION == 'latest' ]; then
+			local ARCHIVE_NAME='latest'
+		else
+			local ARCHIVE_NAME="wordpress-$WP_VERSION"
+		fi
+		download https://wordpress.org/${ARCHIVE_NAME}.tar.gz  /tmp/wordpress.tar.gz
+		tar --strip-components=1 -zxmf /tmp/wordpress.tar.gz -C $WP_CORE_DIR
+	fi
+
+	download https://raw.github.com/markoheijnen/wp-mysqli/master/db.php $WP_CORE_DIR/wp-content/db.php
+}
+
+install_test_suite() {
+	# portable in-place argument for both GNU sed and Mac OSX sed
+	if [[ $(uname -s) == 'Darwin' ]]; then
+		local ioption='-i .bak'
+	else
+		local ioption='-i'
+	fi
+
+	# set up testing suite if it doesn't yet exist
+	if [ ! -d $WP_TESTS_DIR ]; then
+		# set up testing suite
+		mkdir -p $WP_TESTS_DIR
+		svn co --quiet https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/includes/ $WP_TESTS_DIR/includes
+		svn co --quiet https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/data/ $WP_TESTS_DIR/data
+	fi
+
+	if [ ! -f wp-tests-config.php ]; then
+		download https://develop.svn.wordpress.org/${WP_TESTS_TAG}/wp-tests-config-sample.php "$WP_TESTS_DIR"/wp-tests-config.php
+		# remove all forward slashes in the end
+		WP_CORE_DIR=$(echo $WP_CORE_DIR | sed "s:/\+$::")
+		sed $ioption "s:dirname( __FILE__ ) . '/src/':'$WP_CORE_DIR/':" "$WP_TESTS_DIR"/wp-tests-config.php
+		sed $ioption "s/youremptytestdbnamehere/$DB_NAME/" "$WP_TESTS_DIR"/wp-tests-config.php
+		sed $ioption "s/yourusernamehere/$DB_USER/" "$WP_TESTS_DIR"/wp-tests-config.php
+		sed $ioption "s/yourpasswordhere/$DB_PASS/" "$WP_TESTS_DIR"/wp-tests-config.php
+		sed $ioption "s|localhost|${DB_HOST}|" "$WP_TESTS_DIR"/wp-tests-config.php
+	fi
+
+}
+
+install_db() {
+
+	if [ ${SKIP_DB_CREATE} = "true" ]; then
+		return 0
+	fi
+
+	# parse DB_HOST for port or socket references
+	local PARTS=(${DB_HOST//\:/ })
+	local DB_HOSTNAME=${PARTS[0]};
+	local DB_SOCK_OR_PORT=${PARTS[1]};
+	local EXTRA=""
+
+	if ! [ -z $DB_HOSTNAME ] ; then
+		if [ $(echo $DB_SOCK_OR_PORT | grep -e '^[0-9]\{1,\}$') ]; then
+			EXTRA=" --host=$DB_HOSTNAME --port=$DB_SOCK_OR_PORT --protocol=tcp"
+		elif ! [ -z $DB_SOCK_OR_PORT ] ; then
+			EXTRA=" --socket=$DB_SOCK_OR_PORT"
+		elif ! [ -z $DB_HOSTNAME ] ; then
+			EXTRA=" --host=$DB_HOSTNAME --protocol=tcp"
+		fi
+	fi
+
+	# create database
+	mysqladmin create $DB_NAME --user="$DB_USER" --password="$DB_PASS"$EXTRA
+}
+
+install_wp
+install_test_suite
+install_db

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,18 +1,28 @@
 <?php
+/**
+ * PHPUnit bootstrap file
+ *
+ * @package Edit_Flow
+ */
 
 $_tests_dir = getenv( 'WP_TESTS_DIR' );
-
-if ( !$_tests_dir ) {
-	$_tests_dir = '/tmp/wordpress/tests/phpunit';
+if ( ! $_tests_dir ) {
+	$_tests_dir = '/tmp/wordpress-tests-lib';
 }
 
+// Give access to tests_add_filter() function.
 require_once $_tests_dir . '/includes/functions.php';
 
+/**
+ * Manually load the plugin being tested.
+ */
 function _manually_load_plugin() {
-	require dirname( __FILE__ ) . '/../edit_flow.php';
+	require dirname( dirname( __FILE__ ) ) . '/edit_flow.php';
 }
 tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );
 
+// Start up the WP testing environment.
 require $_tests_dir . '/includes/bootstrap.php';
 
+// Load the abstract class for testing AJAX calls of the plugin.
 require dirname( __FILE__ ) . '/testcase-edit-flow-ajax.php';

--- a/tests/phpunit/multisite.xml
+++ b/tests/phpunit/multisite.xml
@@ -1,0 +1,17 @@
+<phpunit
+	bootstrap="../../tests/bootstrap.php"
+	backupGlobals="false"
+	colors="true"
+	convertErrorsToExceptions="true"
+	convertNoticesToExceptions="true"
+	convertWarningsToExceptions="true"
+	>
+	<php>
+		<const name="WP_TESTS_MULTISITE" value="1" />
+	</php>
+	<testsuites>
+		<testsuite>
+			<directory prefix="test-" suffix=".php">../../tests/</directory>
+		</testsuite>
+	</testsuites>
+</phpunit>


### PR DESCRIPTION
This PR adds standard PHPUnit setup files, as they are generated by the `wp scaffold plugin-tests` command of the [WP CLI project](https://developer.wordpress.org/cli/commands/scaffold/plugin-tests/).

Primarily, this adds the `bin/install-wp-tests.sh` file, which installs the WordPress and test suite to common location. The location is then used in the test/bootstrap.php file.

Further, a multisite.xml config is added to the location which is being mentioned by WordPress PHPUnit test suite for running in MS mode:

```
Running as single site... To run multisite, use -c tests/phpunit/multisite.xml
```

Which `multisite.xml` in that location, following command works like a charm for the phpunit command run from within the plugin:

```
phpunit -c tests/phpunit/multisite.xml
```