### PR TITLE
Scope module assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@ Contributors: batmoo, danielbachhuber, sbressler, automattic
 Donate link: http://editflow.org/contribute/
 Tags: edit flow, workflow, editorial, newsroom, management, journalism, post status, custom status, notifications, email, comments, editorial comments, usergroups, calendars, editorial calendar, story budget
 Requires at least: 4.5
-Tested up to: 4.6.1
-Stable tag: 0.8.2
+Tested up to: 4.9.6
+Stable tag: 0.8.3
 
 Redefining your editorial workflow.
 
@@ -56,6 +56,9 @@ For support questions, feedback and ideas, please use the [WordPress.org forums]
 
 ## Upgrade Notice
 
+**0.8.3**
+Improvements and bugfixes.
+
 **0.8.2**
 Minor enhancements and bug fixes, translation updates.
 
@@ -80,10 +83,10 @@ Contributors and other users without the 'publish_posts' capability can access c
 **0.7.1**
 Enhancements and bug fixes, including defaulting to the proper date in the calendar and an Italian localization.
 
-**0.7** 
+**0.7**
 Complete rewrite into a modular architecture. Lots of polish added. Important note: If upgrading from pre-v0.6, please upgrade to v0.6.5 first
 
-**0.6.5** 
+**0.6.5**
 Fixes an issue where the post timestamp would be set as soon as a custom status was used.
 
 **0.6.4**
@@ -102,6 +105,18 @@ Proper support for custom post types. We removed the option to enable/disable Cu
 New features, including story budget and editorial metadata, a completely rewritten calendar view, and many bug fixes, including one for editorial comments appearing in the admin.
 
 ## Changelog
+
+**0.8.3 (June 14, 2018)**
+* UI Improvement: Made primary buttons on Settings screen consistent with WordPress UI. Props [cojennin](https://github.com/cojennin).
+* UI Improvement: Display who particularly was notified about an editorial comment. Props [goodguyry](https://github.com/goodguyry), [WPprodigy](https://github.com/WPprodigy)
+* Improvement: Updated Russian translation and documentation. Props [achumakov](https://github.com/achumakov).
+* Improvement: Eliminate a few cases of raw SQL queries in favor of `date_query`. Props [justnorris](https://github.com/justnorris).
+* Improvement: Cache calendar items for each user individually to prevent potential cache pollution. Props [justnorris](https://github.com/justnorris).
+* Improvement: various i18n updates.
+* Improvement: Move ef_story_budget_posts_query_args filter down to allow overriding the date query in Story Budget module.
+* Improvement: Limit results in Calendar to 200 per page, potentially saving from trouble on websites with large amount of content.
+* Improvement: Don’t generate rewrite rules for notepad as they're unused.
+* Improvement: Support modifying HTML output of a Calendar day via ef_pre_calendar_single_date_item_html filter. Props [cklosowski](https://github.com/cklosowski).
 
 **0.8.2 (Sept. 16, 2016)**
 * Improvement: Updated Spanish localization thanks to [moucho](https://github.com/moucho)
@@ -306,13 +321,13 @@ The following folks did some tremendous work helping with the release of Edit Fl
 * Added option to globally disable QuickPitch widget
 * Bug fix: Custom Status names cannot be longer than 20 chars
 * Bug fix: Deleted users are removed as subscribers from posts
-* Bug fix: Blank menu items should now be sorta hidden 
+* Bug fix: Blank menu items should now be sorta hidden
 
 **0.2**
 * Custom Statuses are now supported for pages
 * Editorial Comments (with threading)
 * Email Notifications (on post status change and editorial comment)
-* Additional Post metadata 
+* Additional Post metadata
 * Quick Pitch Dashboard widget
 * Bug fix: sorting issue on Manage Posts page (Mad props to David Smith from Columbia U.)
 * Other bug fixes

--- a/common/php/class-module-with-view.php
+++ b/common/php/class-module-with-view.php
@@ -1,0 +1,181 @@
+<?php
+
+
+class EF_Module_With_View extends EF_Module {
+
+
+	/**
+	 * Whether or not the current page is an Edit Flow settings view (either main or module)
+	 * Determination is based on $pagenow, $_GET['page'], and the module's $settings_slug
+	 * If there's no module name specified, it will return true against all Edit Flow settings views
+	 *
+	 * @since 0.8.3
+	 *
+	 * @param string $slug (Optional) Module name to check against
+	 * @return bool true if is module settings view
+	 */
+	public function is_module_settings_view( $slug = false ) {
+		global $pagenow, $edit_flow;
+
+		// All of the settings views are based on admin.php and a $_GET['page'] parameter
+		if ( $pagenow !== 'admin.php' || ! isset( $_GET['page'] ) )
+			return false;
+
+		$settings_view_slugs = array();
+		// Load all of the modules that have a settings slug/ callback for the settings page
+		foreach ( $edit_flow->modules as $mod_name => $mod_data ) {
+			if ( isset( $mod_data->options->enabled ) && $mod_data->options->enabled == 'on' && $mod_data->configure_page_cb )
+				$settings_view_slugs[] = $mod_data->settings_slug;
+		}
+
+		// The current page better be in the array of registered settings view slugs
+		if ( empty( $settings_view_slugs ) || ! in_array( $_GET['page'], $settings_view_slugs ) ) {
+			return false;
+		}
+
+		if ( $slug && $edit_flow->modules->{$slug}->settings_slug !== $_GET['page'] ) {
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Check whether if we're at module settings view
+	 * for the current module based on `is_module_settings_view` method
+	 *
+	 * @return bool
+	 */
+	public function is_current_module_settings_view() {
+		return $this->is_module_settings_view( $this->module->name );
+	}
+
+
+	/**
+	 * Check for admin page and whether the current post type is supported
+	 * @param array $allowed_pages
+	 *
+	 * @return bool
+	 */
+	function is_active_view( $allowed_pages = array( 'edit.php', 'post.php', 'post-new.php' ) ) {
+		return ( $this->is_admin_page( $allowed_pages ) && $this->is_supported_post_type() );
+	}
+
+
+	/**
+	 * Check whether the current post type is supported for $this module
+	 *
+	 * @return bool
+	 */
+	public function is_supported_post_type() {
+		$post_type = $this->get_current_post_type();
+
+		return (
+			$post_type
+			&&
+			in_array( $post_type, $this->get_post_types_for_module( $this->module ), true )
+		);
+	}
+
+	/**
+	 * Checks for the current post type
+	 *
+	 * @since 0.7
+	 * @return string|null $post_type The post type we've found, or null if no post type
+	 */
+	function get_current_post_type() {
+		global $post, $typenow, $pagenow, $current_screen;
+		//get_post() needs a variable
+		$post_id = isset( $_REQUEST['post'] ) ? (int) $_REQUEST['post'] : false;
+
+		if ( $post && $post->post_type ) {
+			$post_type = $post->post_type;
+		} elseif ( $typenow ) {
+			$post_type = $typenow;
+		} elseif ( $current_screen && ! empty( $current_screen->post_type ) ) {
+			$post_type = $current_screen->post_type;
+		} elseif ( isset( $_REQUEST['post_type'] ) ) {
+			$post_type = sanitize_key( $_REQUEST['post_type'] );
+		} elseif ( 'post.php' == $pagenow
+		           && $post_id
+		           && ! empty( get_post( $post_id )->post_type ) ) {
+			$post_type = get_post( $post_id )->post_type;
+		} elseif ( in_array( $pagenow, array('edit.php', 'post-new.php' ) ) && empty( $_REQUEST['post_type'] ) ) {
+			$post_type = 'post';
+		} else {
+			$post_type = null;
+		}
+
+		return $post_type;
+	}
+
+	/**
+	 * Check whether currently viewing the desired admin page
+	 *
+	 * @param array $allowed_pages
+	 *
+	 * @return bool
+	 */
+	public function is_admin_page( $allowed_pages = array( 'edit.php', 'post.php', 'post-new.php' ) ) {
+		global $pagenow;
+
+		return ( $pagenow && in_array( $pagenow, $allowed_pages, true ) );
+	}
+
+
+	/**
+	 * Shorthand for `is_active_view` to check for list type views ( list of posts pages, custom post types )
+	 *
+	 * @see is_active_view
+	 * @return bool
+	 */
+	public function is_active_list_view() {
+		return $this->is_active_view( array( 'edit.php' ) );
+	}
+
+	/**
+	 * Shorthand for `is_active_view` to check for editor mode
+	 *
+	 * @see is_active_view
+	 * @return bool
+	 */
+	public function is_active_editor_view() {
+		return $this->is_active_view( array( 'post.php', 'posts-new.php' ) );
+	}
+
+
+	/**
+	 * This method was supposed to check whether or not the current page is a user-facing Edit Flow View
+	 * But it was never implemented
+	 *
+	 * It is now deprecated in favor of `$this->is_active_view`
+	 * @see        EF_Module::is_active_view()
+	 * @since      0.7
+	 * @deprecated 0.8.3
+	 *
+	 * @param string $module_name (Optional) Module name to check against
+	 */
+	public function is_whitelisted_functional_view( $module_name = null ) {
+		_deprecated_function( __FUNCTION__, '0.8.3', 'is_active_view' );
+
+		return true;
+	}
+
+	/**
+	 * Whether or not the current page is an Edit Flow settings view (either main or module)
+	 * Determination is based on $pagenow, $_GET['page'], and the module's $settings_slug
+	 * If there's no module name specified, it will return true against all Edit Flow settings views
+	 *
+	 * @since 0.7
+	 * @deprecated 0.8.3
+	 *
+	 * @param string $module_name (Optional) Module name to check against
+	 * @return bool $is_settings_view Return true if it is
+	 */
+	public function is_whitelisted_settings_view( $module_name = null ) {
+		_deprecated_function( 'is_whitelisted_settings_view', '0.8.3', 'is_module_settings_view' );
+
+		return $this->is_module_settings_view( $module_name );
+	}
+
+}

--- a/common/php/class-module.php
+++ b/common/php/class-module.php
@@ -186,42 +186,7 @@ class EF_Module {
 			$filter_link = add_query_arg( 'post_type', $post_type, $filter_link );
 		return $filter_link;
 	}
-	
-	/**
-	 * Returns the friendly name for a given status
-	 *
-	 * @since 0.7
-	 *
-	 * @param string $status The status slug
-	 * @return string $status_friendly_name The friendly name for the status
-	 */
-	function get_post_status_friendly_name( $status ) {
-		global $edit_flow;
-		
-		$status_friendly_name = '';
-		
-		$builtin_stati = array(
-			'publish' => __( 'Published', 'edit-flow' ),
-			'draft' => __( 'Draft', 'edit-flow' ),
-			'future' => __( 'Scheduled', 'edit-flow' ),
-			'private' => __( 'Private', 'edit-flow' ),
-			'pending' => __( 'Pending Review', 'edit-flow' ),
-			'trash' => __( 'Trash', 'edit-flow' ),
-		);
-		
-		// Custom statuses only handles workflow statuses
-		if ( $this->module_enabled( 'custom_status' )
-			&& !in_array( $status, array( 'publish', 'future', 'private', 'trash' ) ) ) {
-			$status_object = $edit_flow->custom_status->get_custom_status_by( 'slug', $status );
-			if( $status_object && !is_wp_error( $status_object ) ) {
-				$status_friendly_name = $status_object->name;
-			}
-		} else if ( array_key_exists( $status, $builtin_stati ) ) {
-			$status_friendly_name = $builtin_stati[$status];
-		}
-		return $status_friendly_name;
-	}
-	
+
 	/**
 	 * Enqueue any resources (CSS or JS) associated with datepicker functionality
 	 *

--- a/common/php/class-module.php
+++ b/common/php/class-module.php
@@ -208,38 +208,7 @@ class EF_Module {
 		wp_enqueue_style( 'jquery-ui-theme', EDIT_FLOW_URL . 'common/css/jquery.ui.theme.css', false, EDIT_FLOW_VERSION, 'screen' );
 	}
 	
-	/**
-	 * Checks for the current post type
-	 *
-	 * @since 0.7
-	 * @return string|null $post_type The post type we've found, or null if no post type
-	 */
-	function get_current_post_type() {
-		global $post, $typenow, $pagenow, $current_screen;
-		//get_post() needs a variable
-		$post_id = isset( $_REQUEST['post'] ) ? (int)$_REQUEST['post'] : false;
 
-		if ( $post && $post->post_type ) {
-			$post_type = $post->post_type;
-		} elseif ( $typenow ) {
-			$post_type = $typenow;
-		} elseif ( $current_screen && !empty( $current_screen->post_type ) ) {
-			$post_type = $current_screen->post_type;
-		} elseif ( isset( $_REQUEST['post_type'] ) ) {
-			$post_type = sanitize_key( $_REQUEST['post_type'] );
-		} elseif ( 'post.php' == $pagenow
-			&& $post_id
-			&& !empty( get_post( $post_id )->post_type ) ) {
-			$post_type = get_post( $post_id )->post_type;
-		} elseif ( 'edit.php' == $pagenow && empty( $_REQUEST['post_type'] ) ) {
-			$post_type = 'post';
-		} else {
-			$post_type = null;
-		}
-
-		return $post_type;
-	}
-	
 	/**
 	 * Wrapper for the get_user_meta() function so we can replace it if we need to
 	 *
@@ -295,55 +264,6 @@ class EF_Module {
 		echo json_encode( array( 'status' => $status, 'message' => $message ) );
 		exit;
 	}
-	
-	/**
-	 * Whether or not the current page is a user-facing Edit Flow View
-	 * @todo Think of a creative way to make this work
-	 *
-	 * @since 0.7
-	 *
-	 * @param string $module_name (Optional) Module name to check against
-	 */
-	function is_whitelisted_functional_view( $module_name = null ) {
-		
-		// @todo complete this method
-		
-		return true;
-	}
-	
-	/**
-	 * Whether or not the current page is an Edit Flow settings view (either main or module)
-	 * Determination is based on $pagenow, $_GET['page'], and the module's $settings_slug
-	 * If there's no module name specified, it will return true against all Edit Flow settings views
-	 *
-	 * @since 0.7
-	 *
-	 * @param string $module_name (Optional) Module name to check against
-	 * @return bool $is_settings_view Return true if it is
-	 */
-	function is_whitelisted_settings_view( $module_name = null ) {
-		global $pagenow, $edit_flow;
-		
-		// All of the settings views are based on admin.php and a $_GET['page'] parameter
-		if ( $pagenow != 'admin.php' || !isset( $_GET['page'] ) )
-			return false;
-		
-		// Load all of the modules that have a settings slug/ callback for the settings page
-		foreach ( $edit_flow->modules as $mod_name => $mod_data ) {
-			if ( isset( $mod_data->options->enabled ) && $mod_data->options->enabled == 'on' && $mod_data->configure_page_cb )
-				$settings_view_slugs[] = $mod_data->settings_slug;
-		}
-	
-		// The current page better be in the array of registered settings view slugs
-		if ( !in_array( $_GET['page'], $settings_view_slugs ) )
-			return false;
-		
-		if ( $module_name && $edit_flow->modules->$module_name->settings_slug != $_GET['page'] )
-			return false;
-			
-		return true;
-	}
-	
 	
 	/**
 	 * This is a hack, Hack, HACK!!!
@@ -573,6 +493,7 @@ class EF_Module {
 			wp_update_term( $term->term_id, $taxonomy, array( 'description' => $new_description ) );
 		}
 	}
-	
+
+
 }
 }

--- a/common/php/class-module.php
+++ b/common/php/class-module.php
@@ -472,7 +472,11 @@ class EF_Module {
 					<?php $checked = ( in_array($user->ID, $selected) ) ? 'checked="checked"' : ''; ?>
 					<li>
 						<label for="<?php echo esc_attr( $input_id .'-'. $user->ID ) ?>">
-							<input type="checkbox" id="<?php echo esc_attr( $input_id .'-'. $user->ID ) ?>" name="<?php echo esc_attr( $input_id ) ?>[]" value="<?php echo esc_attr( $user->ID ); ?>" <?php echo $checked; ?> />
+							<div class="ef-user-subscribe-actions">
+								<?php do_action( 'ef_user_subscribe_actions', $user->ID, $checked ) ?>
+								<input type="checkbox" id="<?php echo esc_attr( $input_id .'-'. $user->ID ) ?>" name="<?php echo esc_attr( $input_id ) ?>[]" value="<?php echo esc_attr( $user->ID ); ?>" <?php echo $checked; ?> />
+							</div>
+
 							<span class="ef-user_displayname"><?php echo esc_html( $user->display_name ); ?></span>
 							<span class="ef-user_useremail"><?php echo esc_html( $user->user_email ); ?></span>
 						</label>

--- a/edit_flow.php
+++ b/edit_flow.php
@@ -4,7 +4,7 @@ Plugin Name: Edit Flow
 Plugin URI: http://editflow.org/
 Description: Remixing the WordPress admin for better editorial workflow options.
 Author: Daniel Bachhuber, Scott Bressler, Mohammad Jangda, Automattic, and others
-Version: 0.8.2
+Version: 0.8.3
 Author URI: http://editflow.org/
 
 Copyright 2009-2016 Mohammad Jangda, Daniel Bachhuber, et al.
@@ -28,7 +28,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
 // Define contants
-define( 'EDIT_FLOW_VERSION' , '0.8.3-alpha' );
+define( 'EDIT_FLOW_VERSION' , '0.8.3' );
 define( 'EDIT_FLOW_ROOT' , dirname(__FILE__) );
 define( 'EDIT_FLOW_FILE_PATH' , EDIT_FLOW_ROOT . '/' . basename(__FILE__) );
 define( 'EDIT_FLOW_URL' , plugins_url( '/', __FILE__ ) );

--- a/edit_flow.php
+++ b/edit_flow.php
@@ -93,7 +93,14 @@ class edit_flow {
 
 		// Edit Flow base module
 		require_once( EDIT_FLOW_ROOT . '/common/php/class-module.php' );
-		
+
+		/*
+		 * Include interfaces:
+		 */
+		require_once( EDIT_FLOW_ROOT . '/interfaces/EF_Script_Interface.php' );
+		require_once( EDIT_FLOW_ROOT . '/interfaces/EF_Style_Interface.php' );
+		require_once( EDIT_FLOW_ROOT . '/common/php/class-module-with-view.php' );
+
 		// Scan the modules directory and include any modules that exist there
 		$module_dirs = scandir( EDIT_FLOW_ROOT . '/modules/' );
 		$class_names = array();

--- a/edit_flow.php
+++ b/edit_flow.php
@@ -128,8 +128,12 @@ class edit_flow {
 			}
 		}
 		
-		// Supplementary plugins can hook into this, include their own modules
-		// and add them to the $edit_flow object
+		/**
+		 * Fires after edit_flow has loaded all Edit Flow internal modules. 
+		 *
+		 * Plugin authors can hook into this action, include their own modules add them to the $edit_flow object
+		 *    
+		 */
 		do_action( 'ef_modules_loaded' );
 		
 	}
@@ -147,6 +151,13 @@ class edit_flow {
 
 		add_action( 'admin_init', array( $this, 'action_admin_init' ) );
 
+		/**
+		 * Fires after setup of all edit_flow actions.
+		 *
+		 * Plugin authors can hook into this action to manipulate the edit_flow class after initial actions have been registered.
+		 * 
+		 * @param edit_flow $this The core edit flow class
+		 */
 		do_action_ref_array( 'editflow_after_setup_actions', array( &$this ) );
 	}
 
@@ -169,6 +180,12 @@ class edit_flow {
 			if ( isset( $mod_data->options->enabled ) && $mod_data->options->enabled == 'on' )
 				$this->$mod_name->init();
 		
+		/**
+		 * Fires after edit_flow has loaded all modules and module options.
+		 *
+		 * Plugin authors can hook into this action to trigger functionaltiy after all Edit Flow module's have been loaded.
+		 *    
+		 */
 		do_action( 'ef_init' );
 	}
 
@@ -248,6 +265,14 @@ class edit_flow {
 			add_action( 'load-edit-flow_page_' . $args['settings_slug'], array( &$this->$name, 'action_settings_help_menu' ) );
 		
 		$this->modules->$name = (object) $args;
+
+		/**
+		 * Fires after edit_flow has registered a module.
+		 *
+		 * Plugin authors can hook into this action to trigger functionaltiy after a module has been loaded.
+		 *
+		 * @param string $name The name of the registered module
+		 */
 		do_action( 'ef_module_registered', $name );
 		return $this->modules->$name;
 	}
@@ -268,6 +293,13 @@ class edit_flow {
 
 			$this->$mod_name->module = $this->modules->$mod_name;
 		}
+
+		/**
+		 * Fires after edit_flow has loaded all of the module options from the database.
+		 *
+		 * Plugin authors can hook into this action to read and manipulate module settings.
+		 *    	
+		 */
 		do_action( 'ef_module_options_loaded' );
 	}
 
@@ -288,6 +320,9 @@ class edit_flow {
 	
 	/**
 	 * Get a module by one of its descriptive values
+	 *
+	 * @param string $key The property to use for searching a module (ex: 'name')
+	 * @param string|int|array $value The value to compare (using ==)
 	 */
 	function get_module_by( $key, $value ) {
 		$module = false;

--- a/interfaces/EF_Script_Interface.php
+++ b/interfaces/EF_Script_Interface.php
@@ -1,0 +1,9 @@
+<?php
+
+/**
+ * Interface EF_Script_Interface
+ * A very simple interface tor equire a method `enqueue_admin_scripts()`
+ */
+interface EF_Script_Interface {
+	public function enqueue_admin_scripts();
+}

--- a/interfaces/EF_Style_Interface.php
+++ b/interfaces/EF_Style_Interface.php
@@ -1,0 +1,9 @@
+<?php
+
+/**
+ * Interface EF_Style_Interface
+ * A very simple interface tor equire a method `enqueue_admin_styles()`
+ */
+interface EF_Style_Interface {
+	public function enqueue_admin_styles();
+}

--- a/modules/calendar/calendar.php
+++ b/modules/calendar/calendar.php
@@ -782,10 +782,14 @@ class EF_Calendar extends EF_Module {
 						$this->hidden = 0;
 						if ( !empty( $week_posts[$week_single_date] ) ) {
 
-							$week_posts[$week_single_date] = apply_filters( 'ef_calendar_posts_for_week', $week_posts[$week_single_date] );
+							$week_posts[$week_single_date] = apply_filters( 'ef_calendar_posts_for_week', $week_posts[$week_single_date], $week_single_date );
 
-							foreach ( $week_posts[$week_single_date] as $num => $post ){ 
-								echo $this->generate_post_li_html( $post, $week_single_date, $num ); 
+							foreach ( $week_posts[$week_single_date] as $num => $post ) {
+								$output = apply_filters( 'ef_pre_calendar_single_date_item_html', '', $this, $num, $post, $week_single_date );
+								if ( ! $output ) {
+									$output = $this->generate_post_li_html( $post, $week_single_date, $num );
+								}
+								echo $output;
 							} 
 
 						 } 

--- a/modules/calendar/calendar.php
+++ b/modules/calendar/calendar.php
@@ -1310,23 +1310,23 @@ class EF_Calendar extends EF_Module {
 	
 	/**
 	 * Given a day in string format, returns the day at the beginning of that week, which can be the given date.
-	 * The end of the week is determined by the blog option, 'start_of_week'.
+	 * The beginning of the week is determined by the blog option, 'start_of_week'.
 	 *
 	 * @see http://www.php.net/manual/en/datetime.formats.date.php for valid date formats
 	 *
 	 * @param string $date String representing a date
-	 * @param string $format Date format in which the end of the week should be returned
+	 * @param string $format Date format in which the beginning of the week should be returned
 	 * @param int $week Number of weeks we're offsetting the range	
-	 * @return string $formatted_start_of_week End of the week
+	 * @return string $formatted_start_of_week Beginning of the week
 	 */
 	function get_beginning_of_week( $date, $format = 'Y-m-d', $week = 1 ) {
 
 		$date = strtotime( $date );
 		$start_of_week = get_option( 'start_of_week' );
 		$day_of_week = date( 'w', $date );
-		$date += (( $start_of_week - $day_of_week - 7 ) % 7) * 60 * 60 * 24 * $week;
-		$additional = 3600 * 24 * 7 * ( $week - 1 );
-		$formatted_start_of_week = date( $format, $date + $additional );
+		$date += (( $start_of_week - $day_of_week - 7 ) % 7) * 60 * 60 * 24 ;
+		$date = strtotime ( '+' . ( $week - 1 ) . ' week', $date ) ;
+                $formatted_start_of_week = date( $format, $date );
 		return $formatted_start_of_week;
 		
 	}
@@ -1348,8 +1348,8 @@ class EF_Calendar extends EF_Module {
 		$end_of_week = get_option( 'start_of_week' ) - 1;
 		$day_of_week = date( 'w', $date );
 		$date += (( $end_of_week - $day_of_week + 7 ) % 7) * 60 * 60 * 24;
-		$additional = 3600 * 24 * 7 * ( $week - 1 );
-		$formatted_end_of_week = date( $format, $date + $additional );
+		$date = strtotime ( '+' . ( $week - 1 ) . ' week', $date ) ;
+		$formatted_end_of_week = date( $format, $date );
 		return $formatted_end_of_week;
 		
 	}

--- a/modules/calendar/calendar.php
+++ b/modules/calendar/calendar.php
@@ -85,13 +85,12 @@ class EF_Calendar extends EF_Module {
 
 		// Define the create-post capability
 		$this->create_post_cap = apply_filters( 'ef_calendar_create_post_cap', 'edit_posts' );
-		
-		require_once( EDIT_FLOW_ROOT . '/common/php/' . 'screen-options.php' );
-		add_screen_options_panel( self::usermeta_key_prefix . 'screen_options', __( 'Calendar Options', 'edit-flow' ), array( $this, 'generate_screen_options' ), self::screen_id, false, true );
+
+		add_action( 'admin_init', array( $this, 'add_screen_options_panel' ) );
 		add_action( 'admin_init', array( $this, 'handle_save_screen_options' ) );
 		
 		add_action( 'admin_init', array( $this, 'register_settings' ) );
-		add_action( 'admin_menu', array( $this, 'action_admin_menu' ) );		
+		add_action( 'admin_menu', array( $this, 'action_admin_menu' ) );
 		add_action( 'admin_print_styles', array( $this, 'add_admin_styles' ) );
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_admin_scripts' ) );
 		
@@ -242,6 +241,16 @@ class EF_Calendar extends EF_Module {
 		}
 		
 		return $output;	
+	}
+	
+	/**
+	 * Add module options to the screen panel
+	 *
+	 * @since 0.8.3
+	 */
+	function add_screen_options_panel() {
+		require_once( EDIT_FLOW_ROOT . '/common/php/' . 'screen-options.php' );
+		add_screen_options_panel( self::usermeta_key_prefix . 'screen_options', __( 'Calendar Options', 'edit-flow' ), array( $this, 'generate_screen_options' ), self::screen_id, false, true );		
 	}
 	
 	/**

--- a/modules/calendar/calendar.php
+++ b/modules/calendar/calendar.php
@@ -7,7 +7,7 @@
  */
 if ( !class_exists('EF_Calendar') ) {
 
-class EF_Calendar extends EF_Module {
+class EF_Calendar extends EF_Module_With_View implements EF_Style_Interface, EF_Script_Interface {
 	
 	const usermeta_key_prefix = 'ef_calendar_';
 	const screen_id = 'dashboard_page_calendar';
@@ -91,7 +91,7 @@ class EF_Calendar extends EF_Module {
 		
 		add_action( 'admin_init', array( $this, 'register_settings' ) );
 		add_action( 'admin_menu', array( $this, 'action_admin_menu' ) );
-		add_action( 'admin_print_styles', array( $this, 'add_admin_styles' ) );
+		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_admin_styles' ) );
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_admin_scripts' ) );
 		
 		// Ajax manipulation for the calendar
@@ -173,10 +173,11 @@ class EF_Calendar extends EF_Module {
 	 *
 	 * @uses wp_enqueue_style()
 	 */
-	function add_admin_styles() {
-		global $pagenow;
-		// Only load calendar styles on the calendar page
-		if ( $pagenow == 'index.php' && isset( $_GET['page'] ) && $_GET['page'] == 'calendar' )
+	public function enqueue_admin_styles() {
+		if ( ! $this->is_calendar_view() ) {
+			return;
+		}
+
 			wp_enqueue_style( 'edit-flow-calendar-css', $this->module_url . 'lib/calendar.css', false, EDIT_FLOW_VERSION );
 	}
 	
@@ -188,9 +189,12 @@ class EF_Calendar extends EF_Module {
 	 */
 	function enqueue_admin_scripts() {
 
+		if ( ! $this->is_calendar_view() ) {
+			return;
+		}
+
 		$this->enqueue_datepicker_resources();
 		
-		if ( $this->is_whitelisted_functional_view() ) {
 			$js_libraries = array(
 				'jquery',
 				'jquery-ui-core',
@@ -198,6 +202,7 @@ class EF_Calendar extends EF_Module {
 				'jquery-ui-draggable',
 				'jquery-ui-droppable',
 			);
+
 			foreach( $js_libraries as $js_library ) {
 				wp_enqueue_script( $js_library );
 			}
@@ -205,7 +210,7 @@ class EF_Calendar extends EF_Module {
 			
 			$ef_cal_js_params = array( 'can_add_posts' => current_user_can( $this->create_post_cap ) ? 'true' : 'false' );
 			wp_localize_script( 'edit-flow-calendar-js', 'ef_calendar_params', $ef_cal_js_params );
-		}
+
 		
 	}
 	
@@ -1851,6 +1856,12 @@ class EF_Calendar extends EF_Module {
 		clean_post_cache( $post_ID );
 	}
 	
+
+	public function is_calendar_view() {
+		global $pagenow;
+
+		return ( 'index.php' === $pagenow && isset( $_GET['page'] ) && $_GET['page'] === 'calendar' );
+	}
 } // EF_Calendar
 	
 } // class_exists('EF_Calendar')

--- a/modules/custom-status/custom-status.php
+++ b/modules/custom-status/custom-status.php
@@ -1695,7 +1695,7 @@ class EF_Custom_Status extends EF_Module {
 		}
 
 		$args['preview_id'] = $post->ID;
-		return add_query_arg( $args, home_url() );
+		return add_query_arg( $args, home_url( '/' ) );
 	}
 
 	/**
@@ -1735,7 +1735,7 @@ class EF_Custom_Status extends EF_Module {
 				);
 		}
 		$args['preview'] = 'true';
-		$preview_link = add_query_arg( $args, home_url() );
+		$preview_link = add_query_arg( $args, home_url( '/' ) );
 
 		$actions['view'] = '<a href="' . esc_url( $preview_link ) . '" title="' . esc_attr( sprintf( __( 'Preview &#8220;%s&#8221;' ), $post->post_title ) ) . '" rel="permalink">' . __( 'Preview' ) . '</a>';
 		return $actions;

--- a/modules/custom-status/custom-status.php
+++ b/modules/custom-status/custom-status.php
@@ -115,6 +115,8 @@ class EF_Custom_Status extends EF_Module {
 		// Pagination for custom post statuses when previewing posts
 		add_filter( 'wp_link_pages_link', array( $this, 'modify_preview_link_pagination_url' ), 10, 2 );
 
+		// Filter through Post States and run a function to check if they are also a Status
+		add_filter( 'display_post_states', array( $this, 'check_if_post_state_is_status' ), 10, 2 );
 	}
 
 	/**
@@ -722,11 +724,26 @@ class EF_Custom_Status extends EF_Module {
 
 		if ( $column_name == 'status' ) {
 			global $post;
-			echo $this->get_post_status_friendly_name( $post->post_status );
+			$post_status_obj = get_post_status_object( get_post_status( $post->ID ) );
+			echo esc_html( $post_status_obj->label );
 		}
-
 	}
-
+	/**
+	 * Check if Post State is a Status and display if it is not.
+	 * 
+	 * @param array $post_states An array of post display states.
+	 */
+	function check_if_post_state_is_status($post_states) {
+		
+		global $post;
+		$statuses = get_post_status_object(get_post_status($post->ID));
+		foreach ( $post_states as $state ) {
+			if ( $state !== $statuses->label ) {
+				echo '<span class="show"></span>';
+			}
+		}
+			return $post_states;
+	}
 
 	/**
 	 * Determines whether the slug indicated belongs to a restricted status or not

--- a/modules/custom-status/lib/custom-status.css
+++ b/modules/custom-status/lib/custom-status.css
@@ -2,3 +2,6 @@
 span.post-state {
 	display: none;
 }
+.show + span.post-state {
+	display: inline-block;
+}

--- a/modules/dashboard/widgets/dashboard-notepad.php
+++ b/modules/dashboard/widgets/dashboard-notepad.php
@@ -80,7 +80,7 @@ class EF_Dashboard_Notepad_Widget {
 		$current_post = ( ! empty( $posts[0] ) ) ? $posts[0] : false;
 
 		if ( $current_post )
-			$last_updated = '<span id="dashboard-notepad-last-updated">' . sprintf( __( '%1$s last updated on %2$s', 'edit-flow' ), get_user_by( 'id', $current_post->post_author )->display_name, get_the_time( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), $current_post ) ) . '</span>';
+			$last_updated = '<span id="dashboard-notepad-last-updated">' . sprintf( __( '%1$s last updated on %2$s', 'edit-flow' ), get_user_by( 'id', $current_post->post_author )->display_name, get_the_modified_time( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), $current_post ) ) . '</span>';
 		else
 			$last_updated = '';
 

--- a/modules/dashboard/widgets/dashboard-notepad.php
+++ b/modules/dashboard/widgets/dashboard-notepad.php
@@ -59,9 +59,6 @@ class EF_Dashboard_Notepad_Widget {
 		} else {
 			wp_insert_post( $new_note );
 		}
-
-		wp_safe_redirect( wp_get_referer() );
-		exit;
 	}
 
 	/**
@@ -88,7 +85,7 @@ class EF_Dashboard_Notepad_Widget {
 			$last_updated = '';
 
 		if ( current_user_can( $this->edit_cap ) ) {
-			echo '<form id="dashboard-notepad">';
+			echo '<form method="post" id="dashboard-notepad">';
 			echo '<input type="hidden" name="action" value="dashboard-notepad" />';
 			echo '<input type="hidden" name="notepad-id" value="' . esc_attr( $current_id ) . '" />';
 			echo '<textarea style="width:100%" rows="10" name="note">';

--- a/modules/dashboard/widgets/dashboard-notepad.php
+++ b/modules/dashboard/widgets/dashboard-notepad.php
@@ -35,7 +35,7 @@ class EF_Dashboard_Notepad_Widget {
 		global $pagenow;
 
 		if ( 'index.php' != $pagenow
-		|| ( empty( $_REQUEST['action'] ) || 'dashboard-notepad' != $_REQUEST['action'] ) )
+		|| ( empty( $_POST['action'] ) || 'dashboard-notepad' != $_POST['action'] ) )
 			return;
 
 		check_admin_referer( 'dashboard-notepad' );
@@ -43,17 +43,17 @@ class EF_Dashboard_Notepad_Widget {
 		if ( ! current_user_can( $this->edit_cap ) )
 			wp_die( EditFlow()->dashboard->messages['invalid-permissions'] );
 
-		$current_id = (int)$_REQUEST['notepad-id'];
+		$current_id = (int) $_POST['notepad-id'];
 		$current_notepad = get_post( $current_id );
 		$new_note = array(
-				'post_content'           => wp_filter_nohtml_kses( $_REQUEST['note'] ),
+				'post_content'           => wp_filter_nohtml_kses( $_POST['note'] ),
 				'post_type'              => self::notepad_post_type,
 				'post_status'            => 'draft',
 				'post_author'            => get_current_user_id(),
 			);
 		if ( $current_notepad
 			&& self::notepad_post_type == $current_notepad->post_type
-			&& ! isset ( $_REQUEST['create-note'] ) ) {
+			&& ! isset ( $_POST['create-note'] ) ) {
 			$new_note['ID'] = $current_id;
 			wp_update_post( $new_note );
 		} else {

--- a/modules/editorial-comments/editorial-comments.php
+++ b/modules/editorial-comments/editorial-comments.php
@@ -92,11 +92,6 @@ class EF_Editorial_Comments extends EF_Module
 			return;
 
 		wp_enqueue_script( 'edit_flow-post_comment', $this->module_url . 'lib/editorial-comments.js', array( 'jquery','post' ), EDIT_FLOW_VERSION, true );
-		wp_localize_script( 'edit_flow-post_comment', '__ef_localize_post_comment', array(
-			'and'           => esc_html__( 'and', 'edit-flow' ),
-			'none_notified' => esc_html__( 'No one will be notified.', 'edit-flow' ),
-		) );
-
 		wp_enqueue_style( 'edit-flow-editorial-comments-css', $this->module_url . 'lib/editorial-comments.css', false, EDIT_FLOW_VERSION, 'all' );
 
 		$thread_comments = (int) get_option('thread_comments');
@@ -202,12 +197,6 @@ class EF_Editorial_Comments extends EF_Module
 				<textarea id="ef-replycontent" name="replycontent" cols="40" rows="5"></textarea>
 			</div>
 
-			<?php if ( $this->module_enabled( 'notifications' ) ) : ?>
-				<label for="ef-reply-notifier"><?php esc_html_e( 'The following will be notified:', 'edit-flow' ); ?>
-					<input id="ef-reply-notifier" class="ef-reply-notifier-message" readonly>
-				</label>
-			<?php endif; ?>
-
 			<p id="ef-replysubmit">
 				<a class="ef-replysave button-primary alignright" href="#comments-form">
 					<span id="ef-replybtn"><?php _e('Submit Response', 'edit-flow') ?></span>
@@ -227,28 +216,6 @@ class EF_Editorial_Comments extends EF_Module
 		</div>
 
 		<?php
-	}
-
-	/**
-	 * Maybe display who was notified underneath an editorial comment.
-	 * 
-	 * @param int $comment_id
-	 * @return void
-	 */
-	function maybe_output_comment_meta( $comment_id ) {
-		if ( ! $this->module_enabled( 'notifications' ) || ! apply_filters( 'ef_editorial_comments_show_notified_users', true ) ) {
-			return;
-		}
-
-		$notification = get_comment_meta( $comment_id, 'notification_list', true );
-
-		if ( empty( $notification ) ) {
-			$message = esc_html__( 'No users or groups were notified.', 'edit-flow' );
-		} else {
-			$message = '<strong>'. esc_html__( 'Notified', 'edit-flow' ) . ':</strong> ' . esc_html( $notification );
-		}
-
-		echo '<p class="ef-notification-meta">' . $message . '</p>';
 	}
 
 	/**
@@ -301,7 +268,6 @@ class EF_Editorial_Comments extends EF_Module
 				</h5>
 
 				<div class="comment-content"><?php comment_text(); ?></div>
-				<?php $this->maybe_output_comment_meta( $comment->comment_ID ); ?>
 				<p class="row-actions"><?php echo $actions_string; ?></p>
 
 			</div>
@@ -324,7 +290,7 @@ class EF_Editorial_Comments extends EF_Module
 
       	// Set up comment data
 		$post_id = absint( $_POST['post_id'] );
-		$parent  = absint( $_POST['parent'] );
+		$parent = absint( $_POST['parent'] );
 
       	// Only allow the comment if user can edit post
       	// @TODO: allow contributers to add comments as well (?)
@@ -365,15 +331,6 @@ class EF_Editorial_Comments extends EF_Module
 			// Insert Comment
 			$comment_id = wp_insert_comment($data);
 			$comment = get_comment($comment_id);
-
-			// Save the list of notified users/usergroups.
-			if ( $this->module_enabled( 'notifications' ) && apply_filters( 'ef_editorial_comments_show_notified_users', true ) ) {
-				$notification = isset( $_POST['notification'] ) ? sanitize_text_field( $_POST['notification'] ) : '';
-
-				if ( ! empty( $notification ) && __( 'No one will be notified.', 'edit-flow' ) !== $notification ) {
-					add_comment_meta( $comment_id, 'notification_list', $notification );
-				}
-			}
 
 			// Register actions -- will be used to set up notifications and other modules can hook into this
 			if ( $comment_id )

--- a/modules/editorial-comments/lib/editorial-comments.css
+++ b/modules/editorial-comments/lib/editorial-comments.css
@@ -24,9 +24,16 @@
 		border-bottom: 1px solid #e5e5e5;
 		background: #fff;
 	}
-	#ef-comments li:hover p.row-actions {
+
+	.row-actions {
+		margin-top: 0;
+	}
+
+	#ef-comments li:hover p.row-actions,
+	#ef-comments li:hover .ef-notification-meta {
 		visibility: visible;
 	}
+
 	#ef-comments li p.row-actions {
 		text-align: right;
 	}
@@ -111,4 +118,28 @@
 #ef-comment-rbutton {
 	margin-top: 10px;
 	margin-bottom: 10px;
+}
+
+input[readonly].ef-reply-notifier-message {
+	height: 2em;
+	width: 100%;
+	padding: 0.5em;
+	border: none;
+	font-size: 1em;
+	border-left: 4px solid #46b450;
+}
+
+label[for="ef-reply-notifier"] {
+	margin: 0.75em 0;
+	display: block;
+	cursor: default;
+}
+
+input[readonly].ef-none-selected {
+	border-left: 4px solid #dc3232;
+}
+
+.ef-notification-meta {
+	margin-bottom: 0;
+	visibility: hidden;
 }

--- a/modules/editorial-comments/lib/editorial-comments.css
+++ b/modules/editorial-comments/lib/editorial-comments.css
@@ -24,16 +24,9 @@
 		border-bottom: 1px solid #e5e5e5;
 		background: #fff;
 	}
-
-	.row-actions {
-		margin-top: 0;
-	}
-
-	#ef-comments li:hover p.row-actions,
-	#ef-comments li:hover .ef-notification-meta {
+	#ef-comments li:hover p.row-actions {
 		visibility: visible;
 	}
-
 	#ef-comments li p.row-actions {
 		text-align: right;
 	}
@@ -118,28 +111,4 @@
 #ef-comment-rbutton {
 	margin-top: 10px;
 	margin-bottom: 10px;
-}
-
-input[readonly].ef-reply-notifier-message {
-	height: 2em;
-	width: 100%;
-	padding: 0.5em;
-	border: none;
-	font-size: 1em;
-	border-left: 4px solid #46b450;
-}
-
-label[for="ef-reply-notifier"] {
-	margin: 0.75em 0;
-	display: block;
-	cursor: default;
-}
-
-input[readonly].ef-none-selected {
-	border-left: 4px solid #dc3232;
-}
-
-.ef-notification-meta {
-	margin-bottom: 0;
-	visibility: hidden;
 }

--- a/modules/editorial-comments/lib/editorial-comments.js
+++ b/modules/editorial-comments/lib/editorial-comments.js
@@ -21,11 +21,6 @@ editorialCommentReply = {
 		// Bind click events to cancel and submit buttons
 		jQuery('a.ef-replycancel', row).click(function() { return editorialCommentReply.revert(); });
 		jQuery('a.ef-replysave', row).click(function() { return editorialCommentReply.send(); });
-
-		// Watch for changes to the subscribed users.
-		$( '#ef-post_following_box' ).on( 'following_list_updated', function() {
-			editorialCommentReply.notifiedMessage();
-		} );
 	},
 
 	revert : function() {
@@ -70,9 +65,6 @@ editorialCommentReply = {
 		}
 		
 		jQuery('#ef-comment_respond').hide();
-
-		// Display who will be notified for this comment
-		this.notifiedMessage();
 		
 		// Show reply textbox
 		jQuery('#ef-replyrow')
@@ -109,8 +101,7 @@ editorialCommentReply = {
 		post.parent = (jQuery("#ef-comment_parent").val()=='') ? 0 : jQuery("#ef-comment_parent").val();
 		post._nonce = jQuery("#ef_comment_nonce").val();
 		post.post_id = jQuery("#ef-post_id").val();
-		post.notification = jQuery('#ef-reply-notifier').val();
-
+		
 		// Send the request
 		jQuery.ajax({
 			type : 'POST',
@@ -121,40 +112,6 @@ editorialCommentReply = {
 		});
 
 		return false;
-	},
-
-	/**
-	 * Display who will be notified of the new comment.
-	 */
-	notifiedMessage : function() {
-		var message_wrapper = jQuery( '#ef-reply-notifier' );
-
-		if ( ! message_wrapper[0] ) {
-			return;
-		}
-
-		var subscribed_users = jQuery( '.ef-post_following_list li input:checkbox:checked' );
-
-		// No users will be notified, so return early with a default message.
-		if ( 0 === subscribed_users.length ) {
-			message_wrapper.addClass( 'ef-none-selected' );
-			message_wrapper.val( __ef_localize_post_comment.none_notified );
-			return;
-		}
-
-		var usernames = [];
-		subscribed_users.each( function() {
-			usernames.push( $( this ).next().text() );
-		} );
-
-		// Convert array of usernames into a sentence.
-		var message = usernames.pop();
-		if ( usernames.length > 0 ) {
-			message = usernames.join( ', ' ) + ' ' + __ef_localize_post_comment.and + ' ' + message + '.';
-		}
-
-		message_wrapper.removeClass( 'ef-none-selected' );
-		message_wrapper.val( message );
 	},
 
 	show : function(xml) {

--- a/modules/editorial-comments/lib/editorial-comments.js
+++ b/modules/editorial-comments/lib/editorial-comments.js
@@ -21,6 +21,11 @@ editorialCommentReply = {
 		// Bind click events to cancel and submit buttons
 		jQuery('a.ef-replycancel', row).click(function() { return editorialCommentReply.revert(); });
 		jQuery('a.ef-replysave', row).click(function() { return editorialCommentReply.send(); });
+
+		// Watch for changes to the subscribed users.
+		$( '#ef-post_following_box' ).on( 'following_list_updated', function() {
+			editorialCommentReply.notifiedMessage();
+		} );
 	},
 
 	revert : function() {
@@ -65,6 +70,9 @@ editorialCommentReply = {
 		}
 		
 		jQuery('#ef-comment_respond').hide();
+
+		// Display who will be notified for this comment
+		this.notifiedMessage();
 		
 		// Show reply textbox
 		jQuery('#ef-replyrow')
@@ -101,7 +109,8 @@ editorialCommentReply = {
 		post.parent = (jQuery("#ef-comment_parent").val()=='') ? 0 : jQuery("#ef-comment_parent").val();
 		post._nonce = jQuery("#ef_comment_nonce").val();
 		post.post_id = jQuery("#ef-post_id").val();
-		
+		post.notification = jQuery('#ef-reply-notifier').val();
+
 		// Send the request
 		jQuery.ajax({
 			type : 'POST',
@@ -112,6 +121,40 @@ editorialCommentReply = {
 		});
 
 		return false;
+	},
+
+	/**
+	 * Display who will be notified of the new comment.
+	 */
+	notifiedMessage : function() {
+		var message_wrapper = jQuery( '#ef-reply-notifier' );
+
+		if ( ! message_wrapper[0] ) {
+			return;
+		}
+
+		var subscribed_users = jQuery( '.ef-post_following_list li input:checkbox:checked' );
+
+		// No users will be notified, so return early with a default message.
+		if ( 0 === subscribed_users.length ) {
+			message_wrapper.addClass( 'ef-none-selected' );
+			message_wrapper.val( __ef_localize_post_comment.none_notified );
+			return;
+		}
+
+		var usernames = [];
+		subscribed_users.each( function() {
+			usernames.push( $( this ).next().text() );
+		} );
+
+		// Convert array of usernames into a sentence.
+		var message = usernames.pop();
+		if ( usernames.length > 0 ) {
+			message = usernames.join( ', ' ) + ' ' + __ef_localize_post_comment.and + ' ' + message + '.';
+		}
+
+		message_wrapper.removeClass( 'ef-none-selected' );
+		message_wrapper.val( message );
 	},
 
 	show : function(xml) {

--- a/modules/editorial-metadata/editorial-metadata.php
+++ b/modules/editorial-metadata/editorial-metadata.php
@@ -20,7 +20,8 @@
  */
 if ( !class_exists('EF_Editorial_Metadata') ) {
 
-class EF_Editorial_Metadata extends EF_Module {
+class EF_Editorial_Metadata extends EF_Module_With_View implements EF_Style_Interface, EF_Script_Interface {
+
 
 	/**
 	 * The name of the taxonomy we're going to register for editorial metadata.
@@ -116,7 +117,7 @@ class EF_Editorial_Metadata extends EF_Module {
 		}		
 		
 		// Load necessary scripts and stylesheets
-		add_action( 'admin_enqueue_scripts', array( $this, 'add_admin_scripts' ) );	
+		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_admin_styles' ) );
 		
 	}
 	
@@ -229,21 +230,18 @@ class EF_Editorial_Metadata extends EF_Module {
 	/**
 	 * Enqueue relevant admin Javascript
 	 */ 
-	function add_admin_scripts() {
-		global $current_screen, $pagenow;
-		
+	function enqueue_admin_styles() {
 		// Add the metabox date picker JS and CSS
-		$current_post_type = $this->get_current_post_type();
-		$supported_post_types = $this->get_post_types_for_module( $this->module );
-		if ( in_array( $current_post_type, $supported_post_types ) ) {
+		if ( $this->is_active_editor_view() ) {
 			$this->enqueue_datepicker_resources();
 
 			// Now add the rest of the metabox CSS
 			wp_enqueue_style( 'edit_flow-editorial_metadata-styles', $this->module_url . 'lib/editorial-metadata.css', false, EDIT_FLOW_VERSION, 'all' );
 		}
 		// A bit of custom CSS for the Manage Posts view if we have viewable metadata
-		if ( $current_screen->base == 'edit' && in_array( $current_post_type, $supported_post_types ) ) {
+		if ( $this->is_active_list_view() ) {
 			$terms = $this->get_editorial_metadata_terms();
+
 			$viewable_terms = array();
 			foreach( $terms as $term ) {
 				if ( $term->viewable ) 
@@ -298,9 +296,14 @@ class EF_Editorial_Metadata extends EF_Module {
 			
 		}
 		
+
+	}
+
+
+	public function enqueue_admin_scripts() {
 		// Load Javascript specific to the editorial metadata configuration view
-		if ( $this->is_whitelisted_settings_view( $this->module->name ) ) {
-			wp_enqueue_script( 'jquery-ui-sortable' );			
+		if ( $this->is_current_module_settings_view() ) {
+			wp_enqueue_script( 'jquery-ui-sortable' );
 			wp_enqueue_script( 'edit-flow-editorial-metadata-configure', EDIT_FLOW_URL . 'modules/editorial-metadata/lib/editorial-metadata-configure.js', array( 'jquery', 'jquery-ui-sortable', 'edit-flow-settings-js' ), EDIT_FLOW_VERSION, true );
 		}
 	}
@@ -1555,7 +1558,7 @@ class EF_Editorial_Metadata extends EF_Module {
 		<?php
 		endif;
 	}
-	
+
 }
 
 }

--- a/modules/notifications/lib/notifications.css
+++ b/modules/notifications/lib/notifications.css
@@ -6,31 +6,46 @@
 	background-position: 5px 7px;
 }
 
-.ef-post_following_list {
+.ef-post_following_list li {
+	padding: 10px 5px 5px 5px;
+	margin: 0;
+	border-bottom: 1px solid #ccc;
+	min-height: 36px;
 }
 
-	.ef-post_following_list li {
-		padding: 10px 5px 5px 5px;
-		margin: 0;
-		border-bottom: 1px solid #ccc;
-	}
-		.ef-post_following_list li:hover {
-			background: #EAF2FA;
-		}
-	.ef-post_following_list li input {
-		float: right;
-	}
-	.ef-post_following_list .ef-user_displayname,
-	.ef-post_following_list .ef-usergroup_name {
-		display: block;
-		font-size: 14px;
-	}
-	.ef-post_following_list .ef-user_useremail,
-	.ef-post_following_list .ef-usergroup_description {
-		display: block;
-		color: #ccc;
-		font-size: 12px;
-	}
+.ef-post_following_list li:hover {
+	background: #EAF2FA;
+}
+
+.ef-post_following_list li input {
+	float: right;
+	margin-top: 0;
+}
+
+.ef-post_following_list .ef-user_displayname,
+.ef-post_following_list .ef-usergroup_name {
+	display: block;
+	font-size: 14px;
+}
+
+.ef-post_following_list .ef-user_useremail,
+.ef-post_following_list .ef-usergroup_description {
+	display: block;
+	color: #ccc;
+	font-size: 12px;
+}
+
+.ef-post_following_list li .ef-user-subscribe-actions {
+	float: right;
+	margin-top: 5px;
+}
+
+.ef-post_following_list li .ef-user-subscribe-actions span {
+	margin-right: 10px;
+	border: solid 2px #FFCCCC;
+	color: #FFCCCC;
+	padding: 4px;
+}
 
 #ef-post_following_box {
 	margin:10px 0;	

--- a/modules/notifications/lib/notifications.js
+++ b/modules/notifications/lib/notifications.js
@@ -28,10 +28,6 @@ jQuery(document).ready(function($) {
 			url : (ajaxurl) ? ajaxurl : wpListL10n.url,
 			data : params,
 			success : function(x) { 
-
-				// This event is used to show an updated list of who will be notified of editorial comments and status updates.
-				$( '#ef-post_following_box' ).trigger( 'following_list_updated' );
-
 				var backgroundColor = parent_this.css( 'background-color' );
 				$(parent_this.parent().parent())
 					.animate( { 'backgroundColor':'#CCEEBB' }, 200 )

--- a/modules/notifications/lib/notifications.js
+++ b/modules/notifications/lib/notifications.js
@@ -6,6 +6,16 @@ jQuery(document).ready(function($) {
 		post_id: $('#post_ID').val(),
 	};
 
+	var toggle_no_access_badge = function( container, user_has_no_access ) {
+		if ( $( container ).siblings( 'span' ).length ) {
+			$( container ).siblings( 'span' ).remove();
+		} else if ( user_has_no_access ) {
+			var span = $( '<span />' );
+			span.text( ef_notifications_localization.no_access );
+			$( container ).parent().prepend( span );
+		}
+	}
+
 	$(document).on('click','.ef-post_following_list li input:checkbox, .ef-following_usergroups li input:checkbox', function() {
 		var user_group_ids = [];
 		var parent_this = $(this);
@@ -13,9 +23,7 @@ jQuery(document).ready(function($) {
 		params._nonce = $("#ef_notifications_nonce").val();
 
 		$(this)
-			.parent()
-			.parent()
-			.parent()
+			.parents('.ef-post_following_list')
 			.find('input:checked')
 			.map(function(){
 				user_group_ids.push($(this).val());
@@ -27,15 +35,22 @@ jQuery(document).ready(function($) {
 			type : 'POST',
 			url : (ajaxurl) ? ajaxurl : wpListL10n.url,
 			data : params,
-			success : function(x) { 
+
+			success : function( response ) { 
 
 				// This event is used to show an updated list of who will be notified of editorial comments and status updates.
 				$( '#ef-post_following_box' ).trigger( 'following_list_updated' );
 
 				var backgroundColor = parent_this.css( 'background-color' );
-				$(parent_this.parent().parent())
+				$(parent_this.parents('li'))
 					.animate( { 'backgroundColor':'#CCEEBB' }, 200 )
 					.animate( { 'backgroundColor':backgroundColor }, 200 );
+
+					// Toggle the "No Access" badge if the selected user does not have access.
+					if ( undefined !== response.data ) {
+						var user_has_no_access = response.data.subscribers_with_no_access.includes( parseInt( $( parent_this ).val() ) );
+						toggle_no_access_badge( $( parent_this ), user_has_no_access );
+					}
 			},
 			error : function(r) { 
 				$('#ef-post_following_users_box').prev().append(' <p class="error">There was an error. Please reload the page.</p>');

--- a/modules/notifications/lib/notifications.js
+++ b/modules/notifications/lib/notifications.js
@@ -28,6 +28,10 @@ jQuery(document).ready(function($) {
 			url : (ajaxurl) ? ajaxurl : wpListL10n.url,
 			data : params,
 			success : function(x) { 
+
+				// This event is used to show an updated list of who will be notified of editorial comments and status updates.
+				$( '#ef-post_following_box' ).trigger( 'following_list_updated' );
+
 				var backgroundColor = parent_this.css( 'background-color' );
 				$(parent_this.parent().parent())
 					.animate( { 'backgroundColor':'#CCEEBB' }, 200 )

--- a/modules/notifications/notifications.php
+++ b/modules/notifications/notifications.php
@@ -637,7 +637,7 @@ jQuery(document).ready(function($) {
 	 * Set up and set editorial comment notification email
 	 * 
 	 * @param WP_Comment $comment
-	 * @return boolean
+	 * @return boolean|null|void
 	 */
 	function notification_comment( $comment ) {
 		

--- a/modules/notifications/notifications.php
+++ b/modules/notifications/notifications.php
@@ -769,14 +769,21 @@ jQuery(document).ready(function($) {
 				$usergroup = $edit_flow->user_groups->get_usergroup_by( 'id', $usergroup_id );
 				foreach( (array)$usergroup->user_ids as $user_id ) {
 					$usergroup_user = get_user_by( 'id', $user_id );
-					if ( $usergroup_user && is_user_member_of_blog( $user_id ) )
+					if ( $this->user_can_be_notified( $usergroup_user, $post_id ) ) {
 						$usergroup_users[] = $usergroup_user->user_email;
+					}
 				}
 			}
 		}
 		
 		$users = $this->get_following_users( $post_id, 'user_email' );
-		
+		foreach( (array) $users as $key => $user ) {
+			$user_object = get_user_by( 'email', $user );
+			if ( ! $this->user_can_be_notified( $user_object, $post_id ) ) {
+				unset( $users[ $key ] );
+			}
+		}
+
 		// Merge arrays and filter any duplicates
 		$recipients = array_merge( $authors, $admins, $users, $usergroup_users );
 		$recipients = array_unique( $recipients );
@@ -801,7 +808,27 @@ jQuery(document).ready(function($) {
 			return $recipients;
 		}
 	}
-	
+
+	/**
+	 * Check if a user can be notified.
+	 * This is based off of the ability to edit the post/page by default.
+	 * 
+	 * @since 0.8.3
+	 * @param WP_User $user
+	 * @param int $post_id
+	 * @return bool True if the user can be notified, false otherwise.
+	 */
+	function user_can_be_notified( $user, $post_id ) {
+		$can_be_notified = false;
+
+		if ( $user instanceof WP_User && is_user_member_of_blog( $user->ID ) && is_numeric( $post_id ) ) {
+			// The 'edit_post' cap check also covers the undocumented 'edit_page' cap.
+			$can_be_notified = $user->has_cap( 'edit_post', $post_id );
+		}
+
+		return apply_filters( 'ef_notification_user_can_be_notified', $can_be_notified, $user, $post_id );
+	}
+
 	/**
 	 * Set a user or users to follow a post
 	 *

--- a/modules/notifications/notifications.php
+++ b/modules/notifications/notifications.php
@@ -691,12 +691,12 @@ jQuery(document).ready(function($) {
 		}
 		*/
 		
+		
+		$body .= "\r\n--------------------\r\n";
 		// Insert the notification list from comment meta @see EF_Editorial_Comments->maybe_output_comment_meta()
 		if ($notification_list) {
 			$body .= esc_html__( 'Notified', 'edit-flow' ) . ": $notification_list\n";
 		}
-		
-		$body .= "\r\n--------------------\r\n";
 		
 		$edit_link = htmlspecialchars_decode( get_edit_post_link( $post_id ) );
 		$view_link = htmlspecialchars_decode( get_permalink( $post_id ) );

--- a/modules/notifications/notifications.php
+++ b/modules/notifications/notifications.php
@@ -872,33 +872,6 @@ jQuery(document).ready(function($) {
 	}
 
 	/**
-	 * TODO: Remove this before merge. Duplicated function originally in PR #449
-	 * 
-	 * Check if a user can be notified.
-	 * This is based off of the ability to edit the post/page by default.
-	 * 
-	 * @since 0.8.3
-	 * @param WP_User $user
-	 * @param int $post_id
-	 * @return bool True if the user can be notified, false otherwise.
-	 */
-	function user_can_be_notified( $user, $post_id ) {
-		$can_be_notified = false;
-		if ( $user instanceof WP_User && is_user_member_of_blog( $user->ID ) && is_numeric( $post_id ) ) {
-			// The 'edit_post' cap check also covers the undocumented 'edit_page' cap.
-			$can_be_notified = $user->has_cap( 'edit_post', $post_id );
-		}
-		/**
-		 * Filters if a user can be notified. Defaults to true if they can edit the post/page.
-		 *
-		 * @param bool $can_be_notified True if the user can be notified.
-		 * @param WP_User|bool $user The user object, otherwise false.
-		 * @param int $post_id The post the user will be notified about.
-		 */
-		return (bool) apply_filters( 'ef_notification_user_can_be_notified', $can_be_notified, $user, $post_id );
-	}
-
-	/**
 	 * Set a user or users to follow a post
 	 *
 	 * @param int|object         $post      Post object or ID

--- a/modules/notifications/notifications.php
+++ b/modules/notifications/notifications.php
@@ -752,9 +752,8 @@ jQuery(document).ready(function($) {
 		
 		$post_id = $post->ID;
 		if( !$post_id ) return;
-		
-		$authors = array();
-		$admins = array();
+
+		$admins     = array();
 		$recipients = array();
 
 		// Email all admins, if enabled
@@ -785,8 +784,7 @@ jQuery(document).ready(function($) {
 		}
 
 		// Merge arrays and filter any duplicates
-		$recipients = array_merge( $authors, $admins, $users, $usergroup_users );
-		$recipients = array_unique( $recipients );
+		$recipients = array_unique( array_merge( $admins, $users, $usergroup_users ) );
 
 		// Process the recipients for this email to be sent
 		foreach( $recipients as $key => $user_email ) {

--- a/modules/notifications/notifications.php
+++ b/modules/notifications/notifications.php
@@ -512,6 +512,7 @@ jQuery(document).ready(function($) {
 			// Email subject and first line of body 
 			// Set message subjects according to what action is being taken on the Post	
 			if ( $old_status == 'new' || $old_status == 'auto-draft' ) {
+				$old_status_friendly_name = "New";
 				/* translators: 1: site name, 2: post type, 3. post title */
 				$subject = sprintf( __( '[%1$s] New %2$s Created: "%3$s"', 'edit-flow' ), $blogname, $post_type, $post_title );
 				/* translators: 1: post type, 2: post id, 3. post title, 4. user name, 5. user email */
@@ -546,14 +547,16 @@ jQuery(document).ready(function($) {
 				$subject = sprintf( __( '[%1$s] %2$s Status Changed for "%3$s"', 'edit-flow' ), $blogname, $post_type, $post_title );
 				/* translators: 1: post type, 2: post id, 3. post title, 4. user name, 5. user email */
 				$body .= sprintf( __( 'Status was changed for %1$s #%2$s "%3$s" by %4$s %5$s', 'edit-flow'), $post_type, $post_id, $post_title, $current_user_display_name, $current_user_email ) . "\r\n";
+				$old_status_post_obj = get_post_status_object( $old_status );
+				$old_status_friendly_name = $old_status_post_obj->label;
 			}
 			
 			/* translators: 1: date, 2: time, 3: timezone */
 			$body .= sprintf( __( 'This action was taken on %1$s at %2$s %3$s', 'edit-flow' ), date_i18n( get_option( 'date_format' ) ), date_i18n( get_option( 'time_format' ) ), get_option( 'timezone_string' ) ) . "\r\n";
-			
-			$old_status_friendly_name = $this->get_post_status_friendly_name( $old_status );
-			$new_status_friendly_name = $this->get_post_status_friendly_name( $new_status );
-			
+
+			$new_status_post_obj = get_post_status_object( $new_status );
+			$new_status_friendly_name = $new_status_post_obj->label;
+						
 			// Email body
 			$body .= "\r\n";
 			/* translators: 1: old status, 2: new status */

--- a/modules/notifications/notifications.php
+++ b/modules/notifications/notifications.php
@@ -752,7 +752,7 @@ jQuery(document).ready(function($) {
 
 		$post_id = $post->ID;
 		if ( ! $post_id ) {
-			return;
+			return $string ? '' : array();
 		}
 
 		// Email all admins if enabled.

--- a/modules/notifications/notifications.php
+++ b/modules/notifications/notifications.php
@@ -9,8 +9,8 @@ if( ! defined( 'EF_NOTIFICATION_USE_CRON' ) )
 
 if ( !class_exists('EF_Notifications') ) {
 
-class EF_Notifications extends EF_Module {
-	
+class EF_Notifications extends EF_Module_With_View implements EF_Style_Interface, EF_Script_Interface {
+
 	// Taxonomy name used to store users following posts
 	var $following_users_taxonomy = 'following_users';
 	// Taxonomy name used to store user groups following posts
@@ -189,8 +189,7 @@ class EF_Notifications extends EF_Module {
 	 * @uses wp_enqueue_script()
 	 */
 	function enqueue_admin_scripts() {
-		
-		if ( $this->is_whitelisted_functional_view() ) {
+		if ( $this->is_active_editor_view() || $this->is_current_module_settings_view() ) {
 			wp_enqueue_script( 'jquery-listfilterizer' );
 			wp_enqueue_script( 'jquery-quicksearch' );
 			wp_enqueue_script( 'edit-flow-notifications-js', $this->module_url . 'lib/notifications.js', array( 'jquery', 'jquery-listfilterizer', 'jquery-quicksearch' ), EDIT_FLOW_VERSION, true );
@@ -212,8 +211,7 @@ class EF_Notifications extends EF_Module {
 	 * @uses wp_enqueue_style()	
 	 */
 	function enqueue_admin_styles() {
-		
-		if ( $this->is_whitelisted_functional_view() || $this->is_whitelisted_settings_view() ) {
+		if ( $this->is_active_editor_view() || $this->is_module_settings_view() ) {
 			wp_enqueue_style( 'jquery-listfilterizer' );
 			wp_enqueue_style( 'edit-flow-notifications-css', $this->module->module_url . 'lib/notifications.css', false, EDIT_FLOW_VERSION );
 		}

--- a/modules/notifications/notifications.php
+++ b/modules/notifications/notifications.php
@@ -784,16 +784,11 @@ jQuery(document).ready(function($) {
 			}
 		}
 
-		// Merge arrays and filter any duplicates.
-		$recipients = array_unique( array_merge( $admins, $users, $usergroup_users ) );
+		// Merge arrays, filter any duplicates, and remove empty entries.
+		$recipients = array_filter( array_unique( array_merge( $admins, $users, $usergroup_users ) ) );
 
 		// Process the recipients for this email to be sent.
 		foreach(  $recipients as $key => $user_email ) {
-			// Get rid of empty email entries.
-			if ( empty( $recipients[ $key ] ) ) {
-				unset( $recipients[ $key ] );
-			}
-
 			// Don't send the email to the current user unless we've explicitly indicated they should receive it.
 			if ( false === apply_filters( 'ef_notification_email_current_user', false ) && wp_get_current_user()->user_email == $user_email ) {
 				unset( $recipients[ $key ] );

--- a/modules/notifications/notifications.php
+++ b/modules/notifications/notifications.php
@@ -739,34 +739,35 @@ jQuery(document).ready(function($) {
 	function send_single_email( $to, $subject, $message, $message_headers = '' ) {
 		wp_mail( $to, $subject, $message, $message_headers );
 	}
-	
+
 	/**
-	 * Returns a list of recipients for a given post
+	 * Returns a list of recipients for a given post.
 	 *
-	 * @param $post object
-	 * @param $string bool Whether to return recipients as comma-delimited string or array 
-	 * @return string or array of recipients to receive notification 
+	 * @param WP_Post $post
+	 * @param bool $string Whether to return recipients as comma-delimited string or array.
+	 * @return string|array Recipients to receive notification.
 	 */
 	private function _get_notification_recipients( $post, $string = false ) {
 		global $edit_flow;
-		
+
 		$post_id = $post->ID;
-		if( !$post_id ) return;
+		if ( ! $post_id ) {
+			return;
+		}
 
-		$admins     = array();
-		$recipients = array();
-
-		// Email all admins, if enabled
-		if( 'on' == $this->module->options->always_notify_admin )
+		// Email all admins if enabled.
+		$admins = array();
+		if ( 'on' === $this->module->options->always_notify_admin ) {
 			$admins[] = get_option('admin_email');
-		
+		}
+
 		$usergroup_users = array();
 		if ( $this->module_enabled( 'user_groups' ) ) {
-			// Get following users and usergroups
+			// Get following users and usergroups.
 			$usergroups = $this->get_following_usergroups( $post_id, 'ids' );
-			foreach( (array)$usergroups as $usergroup_id ) {
+			foreach ( (array) $usergroups as $usergroup_id ) {
 				$usergroup = $edit_flow->user_groups->get_usergroup_by( 'id', $usergroup_id );
-				foreach( (array)$usergroup->user_ids as $user_id ) {
+				foreach ( (array) $usergroup->user_ids as $user_id ) {
 					$usergroup_user = get_user_by( 'id', $user_id );
 					if ( $this->user_can_be_notified( $usergroup_user, $post_id ) ) {
 						$usergroup_users[] = $usergroup_user->user_email;
@@ -774,7 +775,7 @@ jQuery(document).ready(function($) {
 				}
 			}
 		}
-		
+
 		$users = $this->get_following_users( $post_id, 'user_email' );
 		foreach( (array) $users as $key => $user ) {
 			$user_object = get_user_by( 'email', $user );
@@ -783,23 +784,26 @@ jQuery(document).ready(function($) {
 			}
 		}
 
-		// Merge arrays and filter any duplicates
+		// Merge arrays and filter any duplicates.
 		$recipients = array_unique( array_merge( $admins, $users, $usergroup_users ) );
 
-		// Process the recipients for this email to be sent
-		foreach( $recipients as $key => $user_email ) {
-			// Get rid of empty email entries
-			if ( empty( $recipients[$key] ) )
-				unset( $recipients[$key] );
-			// Don't send the email to the current user unless we've explicitly indicated they should receive it
-			if ( false === apply_filters( 'ef_notification_email_current_user', false ) && wp_get_current_user()->user_email == $user_email )
-				unset( $recipients[$key] );
+		// Process the recipients for this email to be sent.
+		foreach(  $recipients as $key => $user_email ) {
+			// Get rid of empty email entries.
+			if ( empty( $recipients[ $key ] ) ) {
+				unset( $recipients[ $key ] );
+			}
+
+			// Don't send the email to the current user unless we've explicitly indicated they should receive it.
+			if ( false === apply_filters( 'ef_notification_email_current_user', false ) && wp_get_current_user()->user_email == $user_email ) {
+				unset( $recipients[ $key ] );
+			}
 		}
-		
-		// Filter to allow further modification of recipients
+
+		// Filter to allow further modification of recipients.
 		$recipients = apply_filters( 'ef_notification_recipients', $recipients, $post, $string );
-		
-		// If string set to true, return comma-delimited
+
+		// If string set to true, return comma-delimited.
 		if ( $string && is_array( $recipients ) ) {
 			return implode( ',', $recipients );
 		} else {

--- a/modules/notifications/notifications.php
+++ b/modules/notifications/notifications.php
@@ -69,6 +69,9 @@ class EF_Notifications extends EF_Module {
 		
 		// Set up metabox and related actions
 		add_action( 'add_meta_boxes', array( $this, 'add_post_meta_box' ) );
+
+		// Add "access badge" to the subscribers list.
+		add_action( 'ef_user_subscribe_actions', array( $this, 'display_subscriber_access_badge' ), 10, 2 );
 	
 		// Saving post actions
 		// self::save_post_subscriptions() is hooked into transition_post_status so we can ensure usergroup data
@@ -191,6 +194,13 @@ class EF_Notifications extends EF_Module {
 			wp_enqueue_script( 'jquery-listfilterizer' );
 			wp_enqueue_script( 'jquery-quicksearch' );
 			wp_enqueue_script( 'edit-flow-notifications-js', $this->module_url . 'lib/notifications.js', array( 'jquery', 'jquery-listfilterizer', 'jquery-quicksearch' ), EDIT_FLOW_VERSION, true );
+			wp_localize_script(
+				'edit-flow-notifications-js',
+				'ef_notifications_localization',
+				array(
+					'no_access' => esc_html__( 'No Access', 'edit-flow' )
+				)
+			);
 		}
 	}
 	
@@ -354,6 +364,21 @@ jQuery(document).ready(function($) {
 		
 		<?php
 	}
+
+	/**
+	 * Show a badge next to a subscriber's name showing if they have the permissions needed to recieve notifications.
+	 *
+	 * @param int $user_id 
+	 * @param bool $checked True if the user is subscribed already, false otherwise.
+	 * @return void
+	 */	
+	function display_subscriber_access_badge( $user_id, $checked ) {
+		global $post;
+
+		if ( isset( $post ) && $checked && ! $this->user_can_be_notified( get_user_by( 'id', $user_id ), $post->ID ) ) {
+			echo '<span>' . esc_html__( 'No Access', 'edit-flow' ) . '</span>';
+		}
+	}
 	
 	/**
 	 * Called when a notification editorial metadata checkbox is checked. Handles saving of a user/usergroup to a post.
@@ -381,6 +406,14 @@ jQuery(document).ready(function($) {
 
 		if ( 'ef-selected-users[]' === $_POST['ef_notifications_name'] ) {
 			$this->save_post_following_users( $post, $user_group_ids );
+			
+			if ( defined( 'DOING_AJAX' ) && DOING_AJAX && isset( $_POST['post_id'] ) ) {
+				$subscribers_with_no_access = array_filter( $user_group_ids, function( $user_id ) {
+					return ! $this->user_can_be_notified( get_user_by( 'id', $user_id ), $_POST['post_id'] );
+				} );
+
+				wp_send_json_success( array( 'subscribers_with_no_access' => array_values( $subscribers_with_no_access ) ) );
+			}
 		}
 		
 		$groups_enabled = $this->module_enabled( 'user_groups' ) && in_array( get_post_type( $post_id ), $this->get_post_types_for_module( $edit_flow->user_groups->module ) );
@@ -828,6 +861,33 @@ jQuery(document).ready(function($) {
 			$can_be_notified = $user->has_cap( 'edit_post', $post_id );
 		}
 
+		/**
+		 * Filters if a user can be notified. Defaults to true if they can edit the post/page.
+		 *
+		 * @param bool $can_be_notified True if the user can be notified.
+		 * @param WP_User|bool $user The user object, otherwise false.
+		 * @param int $post_id The post the user will be notified about.
+		 */
+		return (bool) apply_filters( 'ef_notification_user_can_be_notified', $can_be_notified, $user, $post_id );
+	}
+
+	/**
+	 * TODO: Remove this before merge. Duplicated function originally in PR #449
+	 * 
+	 * Check if a user can be notified.
+	 * This is based off of the ability to edit the post/page by default.
+	 * 
+	 * @since 0.8.3
+	 * @param WP_User $user
+	 * @param int $post_id
+	 * @return bool True if the user can be notified, false otherwise.
+	 */
+	function user_can_be_notified( $user, $post_id ) {
+		$can_be_notified = false;
+		if ( $user instanceof WP_User && is_user_member_of_blog( $user->ID ) && is_numeric( $post_id ) ) {
+			// The 'edit_post' cap check also covers the undocumented 'edit_page' cap.
+			$can_be_notified = $user->has_cap( 'edit_post', $post_id );
+		}
 		/**
 		 * Filters if a user can be notified. Defaults to true if they can edit the post/page.
 		 *

--- a/modules/notifications/notifications.php
+++ b/modules/notifications/notifications.php
@@ -761,31 +761,30 @@ jQuery(document).ready(function($) {
 			$admins[] = get_option('admin_email');
 		}
 
-		$usergroup_users = array();
+		$usergroup_recipients = array();
 		if ( $this->module_enabled( 'user_groups' ) ) {
-			// Get following users and usergroups.
 			$usergroups = $this->get_following_usergroups( $post_id, 'ids' );
 			foreach ( (array) $usergroups as $usergroup_id ) {
 				$usergroup = $edit_flow->user_groups->get_usergroup_by( 'id', $usergroup_id );
 				foreach ( (array) $usergroup->user_ids as $user_id ) {
 					$usergroup_user = get_user_by( 'id', $user_id );
 					if ( $this->user_can_be_notified( $usergroup_user, $post_id ) ) {
-						$usergroup_users[] = $usergroup_user->user_email;
+						$usergroup_recipients[] = $usergroup_user->user_email;
 					}
 				}
 			}
 		}
 
-		$users = $this->get_following_users( $post_id, 'user_email' );
-		foreach( (array) $users as $key => $user ) {
+		$user_recipients = $this->get_following_users( $post_id, 'user_email' );
+		foreach( (array) $user_recipients as $key => $user ) {
 			$user_object = get_user_by( 'email', $user );
 			if ( ! $this->user_can_be_notified( $user_object, $post_id ) ) {
-				unset( $users[ $key ] );
+				unset( $user_recipients[ $key ] );
 			}
 		}
 
 		// Merge arrays, filter any duplicates, and remove empty entries.
-		$recipients = array_filter( array_unique( array_merge( $admins, $users, $usergroup_users ) ) );
+		$recipients = array_filter( array_unique( array_merge( $admins, $user_recipients, $usergroup_recipients ) ) );
 
 		// Process the recipients for this email to be sent.
 		foreach(  $recipients as $key => $user_email ) {

--- a/modules/notifications/notifications.php
+++ b/modules/notifications/notifications.php
@@ -695,7 +695,7 @@ jQuery(document).ready(function($) {
 		$body .= "\r\n--------------------\r\n";
 		// Insert the notification list from comment meta @see EF_Editorial_Comments->maybe_output_comment_meta()
 		if ($notification_list) {
-			$body .= esc_html__( 'Notified', 'edit-flow' ) . ": $notification_list\n";
+			$body .= esc_html__( 'Notified', 'edit-flow' ) . ": " . esc_html( $notification_list ) . "\n";
 		}
 		
 		$edit_link = htmlspecialchars_decode( get_edit_post_link( $post_id ) );

--- a/modules/notifications/notifications.php
+++ b/modules/notifications/notifications.php
@@ -635,6 +635,9 @@ jQuery(document).ready(function($) {
 	
 	/**
 	 * Set up and set editorial comment notification email
+	 * 
+	 * @param WP_Comment $comment
+	 * @return boolean
 	 */
 	function notification_comment( $comment ) {
 		
@@ -654,7 +657,10 @@ jQuery(document).ready(function($) {
 		$post_id = $post->ID;
 		$post_type = get_post_type_object( $post->post_type )->labels->singular_name;
 		$post_title = ef_draft_or_post_title( $post_id );
-	
+
+		// Fetch the text list of people who were notified from comment meta @see EF_Editorial_Comments->maybe_output_comment_meta()
+		$notification_list = get_comment_meta( $comment->comment_ID, 'notification_list', true );
+
 		// Check if this a reply
 		//$parent_ID = isset( $comment->comment_parent_ID ) ? $comment->comment_parent_ID : 0;
 		//if($parent_ID) $parent = get_comment($parent_ID);
@@ -684,6 +690,11 @@ jQuery(document).ready(function($) {
 			
 		}
 		*/
+		
+		// Insert the notification list from comment meta @see EF_Editorial_Comments->maybe_output_comment_meta()
+		if ($notification_list) {
+			$body .= esc_html__( 'Notified', 'edit-flow' ) . ": $notification_list\n";
+		}
 		
 		$body .= "\r\n--------------------\r\n";
 		

--- a/modules/notifications/notifications.php
+++ b/modules/notifications/notifications.php
@@ -360,25 +360,34 @@ jQuery(document).ready(function($) {
 	 */
 	function ajax_save_post_subscriptions() {
 		global $edit_flow;
-		
-		// Verify nonce
-		if ( !wp_verify_nonce( $_POST['_nonce'], 'save_user_usergroups') )
-			die( __( "Nonce check failed. Please ensure you can add users or user groups to a post.", 'edit-flow' ) );
 
-		$post_id = (int)$_POST['post_id'];
-		$post = get_post( $post_id );
-		$user_group_ids = is_array( $_POST['user_group_ids'] ) ? $_POST['user_group_ids'] : array();
-		$user_usergroup_ids = array_map( 'intval', $user_group_ids );
-		if( ( !wp_is_post_revision( $post_id ) && !wp_is_post_autosave( $post_id ) )  && current_user_can( $this->edit_post_subscriptions_cap ) ) {
-			if( $_POST['ef_notifications_name'] === 'ef-selected-users[]' ) {
-				$this->save_post_following_users( $post, $user_usergroup_ids );
-			}
-			else if ( $_POST['ef_notifications_name'] == 'following_usergroups[]' ) {
-				if ( $this->module_enabled( 'user_groups' ) && in_array( get_post_type( $post_id ), $this->get_post_types_for_module( $edit_flow->user_groups->module ) ) ) {
-					$this->save_post_following_usergroups( $post, $user_usergroup_ids );
-				}
-			}
+		// Verify nonce.
+		if ( ! isset( $_POST['_nonce'] ) || ! wp_verify_nonce( $_POST['_nonce'], 'save_user_usergroups' ) ) {
+			die( __( 'Nonce check failed. Please ensure you can add users or user groups to a post.', 'edit-flow' ) );
 		}
+
+		$post_id = isset( $_POST['post_id'] ) ? (int) $_POST['post_id'] : 0;
+		$post    = get_post( $post_id );
+
+		$valid_post = ! is_null( $post ) && ! wp_is_post_revision( $post_id ) && ! wp_is_post_autosave( $post_id );
+		if ( ! isset( $_POST['ef_notifications_name'] ) || ! $valid_post || ! current_user_can( $this->edit_post_subscriptions_cap ) ) {
+			die();
+		}
+
+		$user_group_ids = array();
+		if ( isset( $_POST['user_group_ids'] ) && is_array( $_POST['user_group_ids'] ) ) {
+			$user_group_ids = array_map( 'intval', $_POST['user_group_ids'] );
+		}
+
+		if ( 'ef-selected-users[]' === $_POST['ef_notifications_name'] ) {
+			$this->save_post_following_users( $post, $user_group_ids );
+		}
+		
+		$groups_enabled = $this->module_enabled( 'user_groups' ) && in_array( get_post_type( $post_id ), $this->get_post_types_for_module( $edit_flow->user_groups->module ) );
+		if ( 'following_usergroups[]' === $_POST['ef_notifications_name'] && $groups_enabled ) {
+			$this->save_post_following_usergroups( $post, $user_group_ids );
+		}
+
 		die();
 	}
 

--- a/modules/notifications/notifications.php
+++ b/modules/notifications/notifications.php
@@ -776,7 +776,7 @@ jQuery(document).ready(function($) {
 		}
 
 		$user_recipients = $this->get_following_users( $post_id, 'user_email' );
-		foreach( (array) $user_recipients as $key => $user ) {
+		foreach( $user_recipients as $key => $user ) {
 			$user_object = get_user_by( 'email', $user );
 			if ( ! $this->user_can_be_notified( $user_object, $post_id ) ) {
 				unset( $user_recipients[ $key ] );
@@ -794,7 +794,13 @@ jQuery(document).ready(function($) {
 			}
 		}
 
-		// Filter to allow further modification of recipients.
+		/**
+		 * Filters the list of notification recipients.
+		 *
+		 * @param array $recipients List of recipient email addresses.
+		 * @param WP_Post $post
+		 * @param bool $string True if the recipients list will later be returned as a string.
+		 */
 		$recipients = apply_filters( 'ef_notification_recipients', $recipients, $post, $string );
 
 		// If string set to true, return comma-delimited.
@@ -822,7 +828,14 @@ jQuery(document).ready(function($) {
 			$can_be_notified = $user->has_cap( 'edit_post', $post_id );
 		}
 
-		return apply_filters( 'ef_notification_user_can_be_notified', $can_be_notified, $user, $post_id );
+		/**
+		 * Filters if a user can be notified. Defaults to true if they can edit the post/page.
+		 *
+		 * @param bool $can_be_notified True if the user can be notified.
+		 * @param WP_User|bool $user The user object, otherwise false.
+		 * @param int $post_id The post the user will be notified about.
+		 */
+		return (bool) apply_filters( 'ef_notification_user_can_be_notified', $can_be_notified, $user, $post_id );
 	}
 
 	/**

--- a/modules/settings/lib/settings.css
+++ b/modules/settings/lib/settings.css
@@ -67,15 +67,6 @@
 	width: 210px;
 }
 
-.edit-flow-modules .edit-flow-module .button-primary {
-	color: #f1f1f1;
-	border: solid 1px #538312;
-	background: #64991e;
-	background: -webkit-gradient(linear, left top, left bottom, from(#86C67C), to(#3D8B37));
-	background: -moz-linear-gradient(top,  #86C67C,  #3D8B37);
-	filter:  progid:DXImageTransform.Microsoft.gradient(startColorstr='#86C67C', endColorstr='#3D8B37');
-}
-
 .edit-flow-modules .edit-flow-module .button-primary:hover {
 	color: #FFFFFF;
 	border-color: #3B5D0C;

--- a/modules/settings/lib/settings.css
+++ b/modules/settings/lib/settings.css
@@ -21,7 +21,6 @@
 }
 
 .edit-flow-modules {
-	min-width: 740px;
 	width: 100%;
 	overflow: hidden;
 	margin-top: 20px;

--- a/modules/settings/lib/settings.css
+++ b/modules/settings/lib/settings.css
@@ -24,6 +24,8 @@
 	width: 100%;
 	overflow: hidden;
 	margin-top: 20px;
+	display: flex;
+	flex-wrap: wrap;
 }
 
 .edit-flow-modules .edit-flow-module {
@@ -80,6 +82,11 @@
 	box-shadow: none;
 	filter:  progid:DXImageTransform.Microsoft.gradient(startColorstr='#BBB', endColorstr='#888');
 	text-shadow: none;
+	float: right;
+}
+
+.edit-flow-modules .edit-flow-module .button-primary.enable-disable-edit-flow-module {
+	float: left;
 }
 
 .edit-flow-modules .edit-flow-module .button-primary.configure-edit-flow-module:hover {

--- a/modules/settings/lib/settings.css
+++ b/modules/settings/lib/settings.css
@@ -28,7 +28,7 @@
 }
 
 .edit-flow-modules .edit-flow-module {
-	width: 210px;
+	width: 250px;
 	min-height: 150px;
 	position: relative;
 	float: left;
@@ -64,7 +64,7 @@
 	position: absolute;
 	bottom: 0px;
 	left: 10px;
-	width: 210px;
+	width: 250px;
 }
 
 .edit-flow-modules .edit-flow-module .button-primary:hover {

--- a/modules/settings/settings.php
+++ b/modules/settings/settings.php
@@ -2,8 +2,8 @@
 
 if ( !class_exists('EF_Settings') ) {
 
-class EF_Settings extends EF_Module {
-	
+class EF_Settings extends EF_Module_With_View {
+
 	var $module;
 	
 	/**
@@ -65,7 +65,7 @@ class EF_Settings extends EF_Module {
 	
 	function action_admin_enqueue_scripts() {
 		
-		if ( $this->is_whitelisted_settings_view() )
+		if ( $this->is_module_settings_view() )
 			wp_enqueue_script( 'edit-flow-settings-js', $this->module_url . 'lib/settings.js', array( 'jquery' ), EDIT_FLOW_VERSION, true );
 			
 	}
@@ -75,7 +75,7 @@ class EF_Settings extends EF_Module {
 	 */
 	function action_admin_print_styles() {		
 		
-		if ( $this->is_whitelisted_settings_view() )
+		if ( $this->is_module_settings_view() )
 			wp_enqueue_style( 'edit_flow-settings-css', $this->module_url . 'lib/settings.css', false, EDIT_FLOW_VERSION );
 		
 		

--- a/modules/story-budget/lib/story-budget.css
+++ b/modules/story-budget/lib/story-budget.css
@@ -30,17 +30,16 @@
 	font-size: 14px;
 }
 
-
-.postbox-container {
-	float: left;
-	padding-right: 0;
-}
-
 .postbox {
 	display: block;
-	margin-bottom: 10px;
-	margin-left: 10px;
-	margin-right: 10px;
+	margin: 0 auto 10px;
+	justify-content: space-between;
+}
+
+.postbox-container {
+	padding-right: 0;
+	display: flex;
+	flex-flow: row wrap;
 }
 
 .postbox .inside {

--- a/modules/story-budget/lib/story-budget.js
+++ b/modules/story-budget/lib/story-budget.js
@@ -16,27 +16,35 @@ jQuery(document).ready(function($) {
 	$("h3.hndle,div.handlediv").click(function() {
 		$(this).parent().children("div.inside").toggle();
 	});
-	
+
 	// Change number of columns when choosing a new number from Screen Options
-	$("input[name=ef_story_budget_screen_columns]").click(function() {
-		var numColumns = $(this).val();
-		
-		jQuery(".postbox-container").css('width', (100 / numColumns) + '%' );
+
+	var columnsSwitch = $("input[name=ef_story_budget_screen_columns]");
+	columnsSwitch.click(function() {
+		var numColumns = parseInt($(this).val());
+		var classPrefix = 'columns-number-';
+		$(".postbox-container").removeClass(function() {
+			for (var index = 1, c = []; index <= columnsSwitch.length; index++) {
+				c.push( classPrefix + index )
+			}
+			return c.join(' ');
+		}).addClass(classPrefix + numColumns);
 	});
+
 	
-	jQuery('h2 a.change-date').click(function(){
-		jQuery(this).hide();
-		jQuery('h2 form .form-value').hide();
-		jQuery('h2 form input').show();
-		jQuery('h2 form a.change-date-cancel').show();
+	$('h2 a.change-date').click(function(){
+		$(this).hide();
+		$('h2 form .form-value').hide();
+		$('h2 form input').show();
+		$('h2 form a.change-date-cancel').show();
 		return false;
 	});
 	
-	jQuery('h2 form a.change-date-cancel').click(function(){
-		jQuery(this).hide();
-		jQuery('h2 form .form-value').show();
-		jQuery('h2 form input').hide();
-		jQuery('h2 form a.change-date').show();
+	$('h2 form a.change-date-cancel').click(function(){
+		$(this).hide();
+		$('h2 form .form-value').show();
+		$('h2 form input').hide();
+		$('h2 form a.change-date').show();
 		return false;
 	});
 });

--- a/modules/story-budget/story-budget.php
+++ b/modules/story-budget/story-budget.php
@@ -518,8 +518,7 @@ class EF_Story_Budget extends EF_Module {
 				return $output;
 				break;
 			case 'post_modified':
-				$modified_time_gmt = strtotime( $post->post_modified_gmt . " GMT" );
-				return $this->timesince( $modified_time_gmt );
+				return sprintf( esc_html__( '%s ago', 'edit-flow' ), human_time_diff( get_the_time( 'U', $post->ID ), current_time( 'timestamp' ) ) );
 				break;
 			default:
 				break;

--- a/modules/story-budget/story-budget.php
+++ b/modules/story-budget/story-budget.php
@@ -65,13 +65,9 @@ class EF_Story_Budget extends EF_Module {
 
 		// Filter to allow users to pick a taxonomy other than 'category' for sorting their posts
 		$this->taxonomy_used = apply_filters( 'ef_story_budget_taxonomy_used', $this->taxonomy_used );
-		
+
 		add_action( 'admin_init', array( $this, 'handle_form_date_range_change' ) );
-		
-		include_once( EDIT_FLOW_ROOT . '/common/php/' . 'screen-options.php' );
-		if ( function_exists( 'add_screen_options_panel' ) )
-			add_screen_options_panel( self::usermeta_key_prefix . 'screen_columns', __( 'Screen Layout', 'edit-flow' ), array( $this, 'print_column_prefs' ), self::screen_id, array( $this, 'save_column_prefs' ), true );
-		
+		add_action( 'admin_init', array( $this, 'add_screen_options_panel' ) );
 		// Register the columns of data appearing on every term. This is hooked into admin_init
 		// so other Edit Flow modules can register their filters if needed
 		add_action( 'admin_init', array( $this, 'register_term_columns' ) );
@@ -225,6 +221,16 @@ class EF_Story_Budget extends EF_Module {
 			}
 		}
 		return $this->num_columns;
+	}
+	
+	/**
+	 * Add module options to the screen panel
+	 *
+	 * @since 0.8.3
+	 */
+	function add_screen_options_panel() {
+		require_once( EDIT_FLOW_ROOT . '/common/php/' . 'screen-options.php' );
+		add_screen_options_panel( self::usermeta_key_prefix . 'screen_columns', __( 'Screen Layout', 'edit-flow' ), array( $this, 'print_column_prefs' ), self::screen_id, array( $this, 'save_column_prefs' ), true );
 	}
 	
 	/**

--- a/modules/story-budget/story-budget.php
+++ b/modules/story-budget/story-budget.php
@@ -290,23 +290,25 @@ class EF_Story_Budget extends EF_Module {
 			<?php $this->print_messages(); ?>
 			<?php $this->table_navigation(); ?>
 			<div class="metabox-holder">
-			<?php
-				// Handle the calculation of terms to postbox-containers
-				$terms_per_container = ceil( count( $terms ) / $this->num_columns );
-				$term_index = 0;
-				// Show just one column if we've filtered to one term
-				if ( count( $this->terms ) == 1 )
-					$this->num_columns = 1;
-				for( $i = 1; $i <= $this->num_columns; $i++ ) {
-					echo '<div class="postbox-container" style="width:' . ( 100 / $this->num_columns ) . '%;">';
-					for( $j = 0; $j < $terms_per_container; $j++ ) {
-						if ( isset( $this->terms[$term_index] ) )
-							$this->print_term( $this->terms[$term_index] );
-						$term_index++;
+				<?php
+					echo '<div class="postbox-container columns-number-' . absint( $this->num_columns ) . '">';
+					foreach( (array) $this->terms as $term ) {
+						$this->print_term( $term );
 					}
+
 					echo '</div>';
-				}
-			?>
+				?>
+				<style>
+					<?php
+					  for ( $i = 1; $i <= $this->max_num_columns; ++$i ) {
+						?>
+					.columns-number-<?php echo (int) $i; ?> .postbox {
+						flex-basis: <?php echo  99 / $i ?>%;
+					}
+					<?php
+				  }
+				?>
+				</style>
 			</div>
 		</div>
 		<?php

--- a/modules/story-budget/story-budget.php
+++ b/modules/story-budget/story-budget.php
@@ -5,8 +5,8 @@
  *
  * @author sbressler
  */
-class EF_Story_Budget extends EF_Module {
-	
+class EF_Story_Budget extends EF_Module_With_View implements EF_Style_Interface, EF_Script_Interface {
+
 	var $taxonomy_used = 'category';
 	
 	var $module;
@@ -75,7 +75,7 @@ class EF_Story_Budget extends EF_Module {
 		add_action( 'admin_menu', array( $this, 'action_admin_menu' ) );
 		// Load necessary scripts and stylesheets
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_admin_scripts' ) );
-		add_action( 'admin_enqueue_scripts', array( $this, 'action_enqueue_admin_styles' ) );
+		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_admin_styles' ) );
 		
 	}
 	
@@ -129,36 +129,43 @@ class EF_Story_Budget extends EF_Module {
 	function action_admin_menu() {
 		add_submenu_page( 'index.php', __('Story Budget', 'edit-flow'), __('Story Budget', 'edit-flow'), apply_filters( 'ef_view_story_budget_cap', 'ef_view_story_budget' ), $this->module->slug, array( $this, 'story_budget') );
 	}
-	
+
 	/**
 	 * Enqueue necessary admin scripts only on the story budget page.
 	 *
 	 * @uses enqueue_admin_script()
 	 */
 	function enqueue_admin_scripts() {
-		global $current_screen;
-		
-		if ( $current_screen->id != self::screen_id )
-			return;
-		
-		$num_columns = $this->get_num_columns();
-		echo '<script type="text/javascript"> var ef_story_budget_number_of_columns="' . esc_js( $this->num_columns ) . '";</script>';
-		
-		$this->enqueue_datepicker_resources();
-		wp_enqueue_script( 'edit_flow-story_budget', $this->module_url . 'lib/story-budget.js', array( 'edit_flow-date_picker' ), EDIT_FLOW_VERSION, true );
+
+		if ( $this->is_story_board_view() ) {
+			$num_columns = $this->get_num_columns();
+			echo '<script type="text/javascript"> var ef_story_budget_number_of_columns="' . esc_js( $this->num_columns ) . '";</script>';
+
+			$this->enqueue_datepicker_resources();
+			wp_enqueue_script( 'edit_flow-story_budget', $this->module_url . 'lib/story-budget.js', array( 'edit_flow-date_picker' ), EDIT_FLOW_VERSION, true );
+		}
+
 	}
 	
 	/**
 	 * Enqueue a screen and print stylesheet for the story budget.
 	 */
-	function action_enqueue_admin_styles() {
+	function enqueue_admin_styles() {
+		if( $this->is_story_board_view() ) {
+			wp_enqueue_style( 'edit_flow-story_budget-styles', $this->module_url . 'lib/story-budget.css', false, EDIT_FLOW_VERSION, 'screen' );
+			wp_enqueue_style( 'edit_flow-story_budget-print-styles', $this->module_url . 'lib/story-budget-print.css', false, EDIT_FLOW_VERSION, 'print' );
+		}
+	}
+
+
+	/**
+	 * Check whether current view is relavant to this module
+	 *
+	 * @return bool
+	 */
+	public function is_story_board_view() {
 		global $current_screen;
-		
-		if ( $current_screen->id != self::screen_id )
-			return;
-		
-		wp_enqueue_style( 'edit_flow-story_budget-styles', $this->module_url . 'lib/story-budget.css', false, EDIT_FLOW_VERSION, 'screen' );
-		wp_enqueue_style( 'edit_flow-story_budget-print-styles', $this->module_url . 'lib/story-budget-print.css', false, EDIT_FLOW_VERSION, 'print' );
+		return ( $current_screen->id === self::screen_id );
 	}
 	
 	/**

--- a/modules/user-groups/user-groups.php
+++ b/modules/user-groups/user-groups.php
@@ -11,7 +11,7 @@
 
 if ( !class_exists( 'EF_User_Groups' ) ) {
 
-class EF_User_Groups extends EF_Module {
+class EF_User_Groups extends EF_Module_With_View implements EF_Style_Interface, EF_Script_Interface {
 	
 	var $module;
 	
@@ -223,32 +223,32 @@ class EF_User_Groups extends EF_Module {
 	 * Enqueue necessary admin scripts
 	 *
 	 * @since 0.7
+	 * @updated 0.8.3
 	 *
 	 * @uses wp_enqueue_script()
 	 */
 	function enqueue_admin_scripts() {
-		
-		if ( $this->is_whitelisted_functional_view() || $this->is_whitelisted_settings_view( $this->module->name ) ) {
+
+		if ( $this->is_current_module_settings_view() ) {
 			wp_enqueue_script( 'jquery-listfilterizer' );
 			wp_enqueue_script( 'jquery-quicksearch' );
 			wp_enqueue_script( 'edit-flow-user-groups-js', $this->module_url . 'lib/user-groups.js', array( 'jquery', 'jquery-listfilterizer', 'jquery-quicksearch' ), EDIT_FLOW_VERSION, true );
-		}
-			
-		if ( $this->is_whitelisted_settings_view( $this->module->name ) )	
 			wp_enqueue_script( 'edit-flow-user-groups-configure-js', $this->module_url . 'lib/user-groups-configure.js', array( 'jquery' ), EDIT_FLOW_VERSION, true );
+		}
+
 	}
 	
 	/**
 	 * Enqueue necessary admin styles, but only on the proper pages
 	 *
 	 * @since 0.7
+	 * @updated 0.8.3
 	 *
 	 * @uses wp_enqueue_style()	
 	 */
 	function enqueue_admin_styles() {
 
-		
-		if ( $this->is_whitelisted_functional_view() || $this->is_whitelisted_settings_view() ) {
+		if ( $this->is_current_module_settings_view() ) {
 			wp_enqueue_style( 'jquery-listfilterizer' );
 			wp_enqueue_style( 'edit-flow-user-groups-css', $this->module_url . 'lib/user-groups.css', false, EDIT_FLOW_VERSION );
 		}
@@ -1070,7 +1070,8 @@ class EF_User_Groups extends EF_Module {
 			return false;
 		}
 	}
-	
+
+
 }
 
 }

--- a/modules/user-groups/user-groups.php
+++ b/modules/user-groups/user-groups.php
@@ -844,6 +844,9 @@ class EF_User_Groups extends EF_Module {
 				$usergroup->$key = $value;
 			}
 		}
+
+		$usergroup = apply_filters( 'ef_usergroup_object', $usergroup );
+
 		return $usergroup;
 	}
 	

--- a/readme.txt
+++ b/readme.txt
@@ -3,8 +3,8 @@ Contributors: batmoo, danielbachhuber, sbressler, automattic
 Donate link: http://editflow.org/contribute/
 Tags: edit flow, workflow, editorial, newsroom, management, journalism, post status, custom status, notifications, email, comments, editorial comments, usergroups, calendars, editorial calendar, story budget
 Requires at least: 4.5
-Tested up to: 4.8
-Stable tag: 0.8.2
+Tested up to: 4.9.6
+Stable tag: 0.8.3
 
 Redefining your editorial workflow.
 
@@ -56,6 +56,9 @@ For support questions, feedback and ideas, please use the [WordPress.org forums]
 
 == Upgrade Notice ==
 
+= 0.8.3 =
+Improvements and bugfixes.
+
 = 0.8.2 =
 Minor enhancements and bug fixes, translation updates.
 
@@ -102,6 +105,29 @@ Proper support for custom post types. We removed the option to enable/disable Cu
 New features, including story budget and editorial metadata, a completely rewritten calendar view, and many bug fixes, including one for editorial comments appearing in the admin.
 
 == Changelog ==
+
+= 0.8.3 (June 14, 2018) =
+* UI Improvement: Made primary buttons on Settings screen consistent with WordPress UI. Props [cojennin](https://github.com/cojennin).
+* UI Improvement: Display who particularly was notified about an editorial comment. Props [goodguyry](https://github.com/goodguyry), [WPprodigy](https://github.com/WPprodigy)
+* Improvement: Updated Russian translation and documentation. Props [achumakov](https://github.com/achumakov).
+* Improvement: Eliminate a few cases of raw SQL queries in favor of `date_query`. Props [justnorris](https://github.com/justnorris).
+* Improvement: Cache calendar items for each user individually to prevent potential cache pollution. Props [justnorris](https://github.com/justnorris).
+* Improvement: various i18n updates.
+* Improvement: Move ef_story_budget_posts_query_args filter down to allow overriding the date query in Story Budget module.
+* Improvement: Limit results in Calendar to 200 per page, potentially saving from trouble on websites with large amount of content.
+* Improvement: Don’t generate rewrite rules for notepad as they're unused.
+* Improvement: Support modifying HTML output of a Calendar day via ef_pre_calendar_single_date_item_html filter. Props [cklosowski](https://github.com/cklosowski).
+
+* Improvement: show custom post statuses in Calendar and Story Budget. Props [mikeyarce](https://github.com/mikeyarce)
+* WordPress Coding Standards improvements and code cleanup by many unsung heroes (primarily [justnorris](https://github.com/justnorris)).
+* Bug fix: Prevent user from removing "Draft" post status, breaking the auto-draft functionality.
+* Bug fix: Fix ef_pre_insert_editorial_comment filter so that it actually has meaning. Props [sudar](https://github.com/sudar).
+* Bug fix: Fix PHP Warning: array_map(): Argument #2 should be an array. Props Michael Auteri.
+* Bug fix: Always offset post times to UTC+0 for Calendars to prevent incorrect times when adding to iCalendar/Google Calendar. Props [justnorris](https://github.com/justnorris).
+* Bug fix: Use taxonomy when checking for term existence when trying to prevent term collision. Props [shadyvb](https://github.com/shadyvb).
+* Bug fix: Correctly handle screen options update for Story Budget columns. Props [raduconst](https://github.com/raduconst)
+* Bug fix: EF_Calendar::get_beginning_of_week and EF_Calendar::get_ending_of_week should respect DST now. Props [FewKinG](https://github.com/FewKinG)
+* Bug fix: Build home_url() previews with trailing slash. Props [jeremyfelt](https://github.com/jeremyfelt)
 
 = 0.8.2 (Sept 16, 2016) =
 * Improvement: Updated Spanish localization thanks to [moucho](https://github.com/moucho)

--- a/vipgo-helper.php
+++ b/vipgo-helper.php
@@ -5,6 +5,16 @@
 add_action( 'after_setup_theme', 'EditFlow' );
 
 /**
+ * Caps don't get loaded on install on VIP Go. Instead, let's add
+ * them via filters.
+ */
+add_filter( 'ef_kill_add_caps_to_role', '__return_true' );
+add_filter( 'ef_view_calendar_cap', function() {return 'edit_posts'; } );
+add_filter( 'ef_view_story_budget_cap', function() { return 'edit_posts'; } );
+add_filter( 'ef_edit_post_subscriptions_cap', function() { return 'edit_others_posts'; } );
+add_filter( 'ef_manage_usergroups_cap', function() { return 'manage_options'; } );
+
+/**
  * Edit Flow loads modules after plugins_loaded, which has already been fired when loading via wpcom_vip_load_plugins
  * Let's run the method at after_setup_themes
  */


### PR DESCRIPTION
**Overview**
At the moment, almost all assets are loaded on every admin page (for example - `calendar.js` is loaded in "Settings -> General”). Overall there were a lot of inconsistencies in asset enqueuing. The goal of this PR is to provide a reliable and predictable way of enqueuing module assets.

**Background**
Every Edit Flow module extends the `EF_Module`  class. However, some modules have dedicated views and some modules (like Dashboard widgets module) don’t. That’s where the inconsistencies begin. 

Most EF Modules enqueue assets. Some check whether they should enqueue assets, some perform the same checks in a different way, and some don’t check at all. Most of the modules use method `EF_Module::is_whitelisted_functional_view` which simply always returns true, with a `//@todo` attached to it :) - the whole asset enqueuing process needed a refactor. 

**Introducing** `EF_Module_With_View`
The EF modules needed a few methods to make it easy to check whether the any given module is visible at the moment (and therefore, whether they should enqueue assets). In most cases this is either in the edit, list and settings views. 

At first I dumped all the necessary methods on `EF_Module` class because all of the modules already are extending it. But `EF_Module` is also instantiated directly **and** it’s also extended by a `EF_Dashboard` class that doesn’t utilize the any of the “new” methods, so it didn’t make sense to keep them there. 

`EF_Module_With_View extends EF_Module` and is meant to be extended further by modules that have views, that way they have access to necessary methods, like `is_current_module_settings_view()` and `is_active_view()`


**Adding PHP interfaces**
There was no streamlined way of dealing with assets. Even enqueuing method names varied from module to module. That’s why I decided to 2 simple interfaces: `EF_Script_Interface` and  `EF_Style_Interface` - they will ensure that asset enqueuing methods are consistent and predictable. Also, by reading the class declaration it’s immediately clear whether or not the current module is enqueuing any assets.

**Summary**
* Force predictable and consistent enqueuing methods with PHP Interfaces across EF Modules
* Add a an reusable and easy to use class `EF_Module_With_View` that provides methods to easily determine whether or not assets are needed
* Refactor most modules to extend `EF_Module_With_View` instead of  `EF_Module` and enqueue assets when they’re needed

Fixes #351 