### PR TITLE
Refactor for the fix_post_row_actions function

### DIFF
--- a/modules/custom-status/custom-status.php
+++ b/modules/custom-status/custom-status.php
@@ -1611,7 +1611,6 @@ class EF_Custom_Status extends EF_Module {
 		} else if ( 'post' == $post->post_type ) {
 			$args = array(
 					'p'          => $post->ID,
-					'preview'	 => 'true'
 				);
 		} else {
 			$args = array(
@@ -1620,7 +1619,7 @@ class EF_Custom_Status extends EF_Module {
 				);
 		}
 
-		$args['preview'] = $post->ID;
+		$args['preview_id'] = $post->ID;
 		return add_query_arg( $args, home_url() );
 	}
 

--- a/modules/custom-status/custom-status.php
+++ b/modules/custom-status/custom-status.php
@@ -1602,7 +1602,7 @@ class EF_Custom_Status extends EF_Module {
 	 *
 	 * @since 0.8
 	 */
-	private function get_preview_link( $post ) {
+	static function get_preview_link( $post ) {
 
 		if ( 'page' == $post->post_type ) {
 			$args = array(
@@ -1646,22 +1646,7 @@ class EF_Custom_Status extends EF_Module {
 		if ( empty( $actions['view'] ) )
 			return $actions;
 
-		if ( 'page' == $post->post_type ) {
-			$args = array(
-					'page_id'    => $post->ID,
-				);
-		} else if ( 'post' == $post->post_type ) {
-			$args = array(
-					'p'          => $post->ID,
-				);
-		} else {
-			$args = array(
-					'p'          => $post->ID,
-					'post_type'  => $post->post_type,
-				);
-		}
-		$args['preview'] = 'true';
-		$preview_link = add_query_arg( $args, home_url() );
+		$preview_link = $this->get_preview_link($post);
 
 		$actions['view'] = '<a href="' . esc_url( $preview_link ) . '" title="' . esc_attr( sprintf( __( 'Preview &#8220;%s&#8221;' ), $post->post_title ) ) . '" rel="permalink">' . __( 'Preview' ) . '</a>';
 		return $actions;

--- a/modules/custom-status/custom-status.php
+++ b/modules/custom-status/custom-status.php
@@ -1620,7 +1620,7 @@ class EF_Custom_Status extends EF_Module {
 				);
 		}
 
-		$args['preview_id'] = $post->ID;
+		$args['preview'] = $post->ID;
 		return add_query_arg( $args, home_url() );
 	}
 

--- a/modules/custom-status/custom-status.php
+++ b/modules/custom-status/custom-status.php
@@ -1602,7 +1602,7 @@ class EF_Custom_Status extends EF_Module {
 	 *
 	 * @since 0.8
 	 */
-	static function get_preview_link( $post ) {
+	public static function get_preview_link( $post ) {
 
 		if ( 'page' == $post->post_type ) {
 			$args = array(


### PR DESCRIPTION
There code from lines 1649 to 1664 on custom-status.php file is the same as the one from _get_preview_link_. That's why I replaced it with the call of the _get_preview_link_. 
Another change made in this PR is making this _get_preview_link_ method static. The purpose of this function is to change the actions of a post and it's not related to the class itself. Making it static will let us use it outside this _EF_Custom_Status_ class at any moment.