### PR TITLE
Added checks for `add_screen_options_panel()`

### DIFF
--- a/modules/calendar/calendar.php
+++ b/modules/calendar/calendar.php
@@ -86,8 +86,11 @@ class EF_Calendar extends EF_Module {
 		// Define the create-post capability
 		$this->create_post_cap = apply_filters( 'ef_calendar_create_post_cap', 'edit_posts' );
 		
-		require_once( EDIT_FLOW_ROOT . '/common/php/' . 'screen-options.php' );
-		add_screen_options_panel( self::usermeta_key_prefix . 'screen_options', __( 'Calendar Options', 'edit-flow' ), array( $this, 'generate_screen_options' ), self::screen_id, false, true );
+		if ( is_admin() ) {
+				require_once( EDIT_FLOW_ROOT . '/common/php/' . 'screen-options.php' );
+				add_screen_options_panel( self::usermeta_key_prefix . 'screen_options', __( 'Calendar Options', 'edit-flow' ), array( $this, 'generate_screen_options' ), self::screen_id, false, true );
+		}
+		
 		add_action( 'admin_init', array( $this, 'handle_save_screen_options' ) );
 		
 		add_action( 'admin_init', array( $this, 'register_settings' ) );

--- a/modules/story-budget/story-budget.php
+++ b/modules/story-budget/story-budget.php
@@ -68,9 +68,11 @@ class EF_Story_Budget extends EF_Module {
 		
 		add_action( 'admin_init', array( $this, 'handle_form_date_range_change' ) );
 		
-		include_once( EDIT_FLOW_ROOT . '/common/php/' . 'screen-options.php' );
-		if ( function_exists( 'add_screen_options_panel' ) )
-			add_screen_options_panel( self::usermeta_key_prefix . 'screen_columns', __( 'Screen Layout', 'edit-flow' ), array( $this, 'print_column_prefs' ), self::screen_id, array( $this, 'save_column_prefs' ), true );
+		if ( is_admin() ) {
+			include_once( EDIT_FLOW_ROOT . '/common/php/' . 'screen-options.php' );
+			if ( function_exists( 'add_screen_options_panel' ) )
+				add_screen_options_panel( self::usermeta_key_prefix . 'screen_columns', __( 'Screen Layout', 'edit-flow' ), array( $this, 'print_column_prefs' ), self::screen_id, array( $this, 'save_column_prefs' ), true );
+		}
 		
 		// Register the columns of data appearing on every term. This is hooked into admin_init
 		// so other Edit Flow modules can register their filters if needed


### PR DESCRIPTION
Fixes #354 

Added `is_admin() conditional` before making a call to `add_screen_options_panel()` in _calendar_ and _custom-budget_ modules since the `screen-options` is being accessed on the front-end.

 I've mentioned two other approaches for this issue on issue page. If you find those are better, let me know and I'll make the changes.