### PR TITLE
Fix status list, calendar, and story budget to show custom post statuses and show post states in post list.

### DIFF
--- a/common/php/class-module.php
+++ b/common/php/class-module.php
@@ -197,31 +197,17 @@ class EF_Module {
 	 */
 	function get_post_status_friendly_name( $status ) {
 		global $edit_flow;
-		
+
 		$status_friendly_name = '';
-		
-		$builtin_stati = array(
-			'publish' => __( 'Published', 'edit-flow' ),
-			'draft' => __( 'Draft', 'edit-flow' ),
-			'future' => __( 'Scheduled', 'edit-flow' ),
-			'private' => __( 'Private', 'edit-flow' ),
-			'pending' => __( 'Pending Review', 'edit-flow' ),
-			'trash' => __( 'Trash', 'edit-flow' ),
-		);
-		
-		// Custom statuses only handles workflow statuses
-		if ( $this->module_enabled( 'custom_status' )
-			&& !in_array( $status, array( 'publish', 'future', 'private', 'trash' ) ) ) {
-			$status_object = $edit_flow->custom_status->get_custom_status_by( 'slug', $status );
-			if( $status_object && !is_wp_error( $status_object ) ) {
-				$status_friendly_name = $status_object->name;
-			}
-		} else if ( array_key_exists( $status, $builtin_stati ) ) {
-			$status_friendly_name = $builtin_stati[$status];
+		$status_object = get_post_status_object( get_post_status() );
+
+		if ( $status_object && ! is_wp_error( $status_object ) ) {
+			$status_friendly_name = $status_object->label;
 		}
+
 		return $status_friendly_name;
 	}
-	
+
 	/**
 	 * Enqueue any resources (CSS or JS) associated with datepicker functionality
 	 *

--- a/common/php/class-module.php
+++ b/common/php/class-module.php
@@ -195,14 +195,13 @@ class EF_Module {
 	 * @param string $status The status slug
 	 * @return string $status_friendly_name The friendly name for the status
 	 */
-	function get_post_status_friendly_name( $status ) {
-		global $edit_flow;
+	function get_post_status_friendly_name() {
 
 		$status_friendly_name = '';
-		$status_object = get_post_status_object( get_post_status() );
+		$status_object = get_post_status_object( get_post_status() )->label;
 
 		if ( $status_object && ! is_wp_error( $status_object ) ) {
-			$status_friendly_name = $status_object->label;
+			$status_friendly_name = $status_object;
 		}
 
 		return $status_friendly_name;

--- a/common/php/class-module.php
+++ b/common/php/class-module.php
@@ -195,15 +195,30 @@ class EF_Module {
 	 * @param string $status The status slug
 	 * @return string $status_friendly_name The friendly name for the status
 	 */
-	function get_post_status_friendly_name() {
-
+	function get_post_status_friendly_name( $status ) {
+		global $edit_flow;
+		
 		$status_friendly_name = '';
-		$status_object = get_post_status_object( get_post_status() )->label;
-
-		if ( $status_object && ! is_wp_error( $status_object ) ) {
-			$status_friendly_name = $status_object;
+		
+		$builtin_stati = array(
+			'publish' => __( 'Published', 'edit-flow' ),
+			'draft' => __( 'Draft', 'edit-flow' ),
+			'future' => __( 'Scheduled', 'edit-flow' ),
+			'private' => __( 'Private', 'edit-flow' ),
+			'pending' => __( 'Pending Review', 'edit-flow' ),
+			'trash' => __( 'Trash', 'edit-flow' ),
+		);
+		
+		// Custom statuses only handles workflow statuses
+		if ( $this->module_enabled( 'custom_status' )
+			&& !in_array( $status, array( 'publish', 'future', 'private', 'trash' ) ) ) {
+			$status_object = $edit_flow->custom_status->get_custom_status_by( 'slug', $status );
+			if( $status_object && !is_wp_error( $status_object ) ) {
+				$status_friendly_name = $status_object->name;
+			}
+		} else if ( array_key_exists( $status, $builtin_stati ) ) {
+			$status_friendly_name = $builtin_stati[$status];
 		}
-
 		return $status_friendly_name;
 	}
 

--- a/common/php/class-module.php
+++ b/common/php/class-module.php
@@ -186,41 +186,6 @@ class EF_Module {
 			$filter_link = add_query_arg( 'post_type', $post_type, $filter_link );
 		return $filter_link;
 	}
-	
-	/**
-	 * Returns the friendly name for a given status
-	 *
-	 * @since 0.7
-	 *
-	 * @param string $status The status slug
-	 * @return string $status_friendly_name The friendly name for the status
-	 */
-	function get_post_status_friendly_name( $status ) {
-		global $edit_flow;
-		
-		$status_friendly_name = '';
-		
-		$builtin_stati = array(
-			'publish' => __( 'Published', 'edit-flow' ),
-			'draft' => __( 'Draft', 'edit-flow' ),
-			'future' => __( 'Scheduled', 'edit-flow' ),
-			'private' => __( 'Private', 'edit-flow' ),
-			'pending' => __( 'Pending Review', 'edit-flow' ),
-			'trash' => __( 'Trash', 'edit-flow' ),
-		);
-		
-		// Custom statuses only handles workflow statuses
-		if ( $this->module_enabled( 'custom_status' )
-			&& !in_array( $status, array( 'publish', 'future', 'private', 'trash' ) ) ) {
-			$status_object = $edit_flow->custom_status->get_custom_status_by( 'slug', $status );
-			if( $status_object && !is_wp_error( $status_object ) ) {
-				$status_friendly_name = $status_object->name;
-			}
-		} else if ( array_key_exists( $status, $builtin_stati ) ) {
-			$status_friendly_name = $builtin_stati[$status];
-		}
-		return $status_friendly_name;
-	}
 
 	/**
 	 * Enqueue any resources (CSS or JS) associated with datepicker functionality

--- a/modules/calendar/calendar.php
+++ b/modules/calendar/calendar.php
@@ -885,7 +885,7 @@ class EF_Calendar extends EF_Module {
 			<div style="clear:right;"></div>
 			<div class="item-static">
 				<div class="item-default-visible">
-					<div class="item-status"><span class="status-text"><?php echo esc_html__( $status_object ); ?></span></div>
+					<div class="item-status"><span class="status-text"><?php echo esc_html( $status_object ); ?></span></div>
 					<div class="inner">
 						<span class="item-headline post-title"><strong><?php echo esc_html( _draft_or_post_title( $post->ID ) ); ?></strong></span>
 					</div>

--- a/modules/calendar/calendar.php
+++ b/modules/calendar/calendar.php
@@ -1217,14 +1217,14 @@ class EF_Calendar extends EF_Module {
 		// Unpublished as a status is just an array of everything but 'publish'
 		if ( $args['post_status'] == 'unpublish' ) {
 			$args['post_status'] = '';
-			$post_statuses = $this->get_post_statuses();
-			foreach ( $post_statuses as $post_status ) {
-				$args['post_status'] .= $post_status->slug . ', ';
+			$post_stati = get_post_stati();
+			unset($post_stati['inherit'], $post_stati['auto-draft'], $post_stati['trash'], $post_stati['publish'] );
+			if ( ! apply_filters( 'ef_show_scheduled_as_unpublished', false ) ) {
+				unset( $post_stati['future'] );
 			}
-			$args['post_status'] = rtrim( $args['post_status'], ', ' );
-			// Optional filter to include scheduled content as unpublished
-			if ( apply_filters( 'ef_show_scheduled_as_unpublished', false ) )
-				$args['post_status'] .= ', future';
+			foreach ( $post_stati as $post_status ) {
+				$args['post_status'] .= $post_status . ', ';
+			}
 		}
 		// The WP functions for printing the category and author assign a value of 0 to the default
 		// options, but passing this to the query is bad (trashed and auto-draft posts appear!), so
@@ -1684,10 +1684,9 @@ class EF_Calendar extends EF_Module {
 		switch( $key ) {
 			case 'post_status':
 				// Whitelist-based validation for this parameter
-				$valid_statuses = wp_list_pluck( $this->get_post_statuses(), 'slug' );
-				$valid_statuses[] = 'future';
+				$valid_statuses = get_post_stati();
 				$valid_statuses[] = 'unpublish';
-				$valid_statuses[] = 'publish';
+				unset($valid_statuses['inherit'], $valid_statuses['auto-draft'], $valid_statuses['trash']);
 				if ( in_array( $dirty_value, $valid_statuses ) )
 					return $dirty_value;
 				else
@@ -1717,18 +1716,19 @@ class EF_Calendar extends EF_Module {
 	function calendar_filter_options( $select_id, $select_name, $filters ) {
 		switch( $select_id ){ 
 			case 'post_status':
-				$post_statuses = $this->get_post_statuses();
+				$post_stati = get_post_stati();
+				unset($post_stati['inherit'], $post_stati['auto-draft'], $post_stati['trash']);
 			?>
 				<select id="<?php echo $select_id; ?>" name="<?php echo $select_name; ?>" >
 					<option value=""><?php _e( 'View all statuses', 'edit-flow' ); ?></option>
 					<?php 
-						foreach ( $post_statuses as $post_status ) { 
-							echo "<option value='" . esc_attr( $post_status->slug ) . "' " . selected( $post_status->slug, $filters['post_status'] ) . ">" . esc_html( $post_status->name ) . "</option>";
+						foreach ( $post_stati as $post_status ) { 
+							$value = $post_status;
+							$status = get_post_status_object($post_status)->label;
+							echo "<option value='" . esc_attr( $value ) . "' " . selected( $value, $filters['post_status'] ) . ">" . esc_html( $status ) . "</option>";
 						}
 					?>
-					<option value="future" <?php selected( 'future', $filters['post_status'] ) ?> > <?php echo __( 'Scheduled', 'edit-flow' ) ?> </option>
 					<option value="unpublish" <?php selected( 'unpublish', $filters['post_status'] ) ?> > <?php echo __( 'Unpublished', 'edit-flow' ) ?> </option>
-					<option value="publish" <?php selected( 'publish', $filters['post_status'] ) ?> > <?php echo __( 'Published', 'edit-flow' ) ?> </option>
 				</select>
 				<?php
 			break;

--- a/modules/calendar/calendar.php
+++ b/modules/calendar/calendar.php
@@ -393,7 +393,7 @@ class EF_Calendar extends EF_Module {
 					$formatted_post = array(
 						'BEGIN'           => 'VEVENT',
 						'UID'             => $post->guid,
-						'SUMMARY'         => $this->do_ics_escaping( apply_filters( 'the_title', $post->post_title ) ) . ' - ' . $this->get_post_status_friendly_name( get_post_status( $post->ID ) ),
+						'SUMMARY'         => $this->do_ics_escaping( apply_filters( 'the_title', $post->post_title ) ) . ' - ' . get_post_status_object( get_post_status( $post->ID ) )->label,
 						'DTSTART'         => $start_date,
 						'DTEND'           => $end_date,
 						'LAST-MODIFIED'   => $last_modified,
@@ -856,6 +856,7 @@ class EF_Calendar extends EF_Module {
 		ob_start();
 		$post_id = $post->ID;
 		$edit_post_link = get_edit_post_link( $post_id );
+		$status_object = get_post_status_object( get_post_status( $post_id ) )->label;
 		
 		$post_classes = array(
 			'day-item',
@@ -884,7 +885,7 @@ class EF_Calendar extends EF_Module {
 			<div style="clear:right;"></div>
 			<div class="item-static">
 				<div class="item-default-visible">
-					<div class="item-status"><span class="status-text"><?php echo esc_html__( $this->get_post_status_friendly_name( get_post_status( $post_id ) ), 'edit-flow' ); ?></span></div>
+					<div class="item-status"><span class="status-text"><?php echo esc_html__( $status_object ); ?></span></div>
 					<div class="inner">
 						<span class="item-headline post-title"><strong><?php echo esc_html( _draft_or_post_title( $post->ID ) ); ?></strong></span>
 					</div>

--- a/modules/calendar/calendar.php
+++ b/modules/calendar/calendar.php
@@ -385,7 +385,7 @@ class EF_Calendar extends EF_Module {
 					$start_date    = self::ics_format_time( $post->post_date );
 					$end_date      = self::ics_format_time( $post->post_date, 5 * MINUTE_IN_SECONDS );
 					$last_modified = self::ics_format_time( $post->post_modified );
-
+					$post_status_obj = get_post_status_object( get_post_status( $post->ID ) );
 					// Remove the convert chars and wptexturize filters from the title
 					remove_filter( 'the_title', 'convert_chars' );
 					remove_filter( 'the_title', 'wptexturize' );
@@ -393,7 +393,7 @@ class EF_Calendar extends EF_Module {
 					$formatted_post = array(
 						'BEGIN'           => 'VEVENT',
 						'UID'             => $post->guid,
-						'SUMMARY'         => $this->do_ics_escaping( apply_filters( 'the_title', $post->post_title ) ) . ' - ' . get_post_status_object( get_post_status( $post->ID ) )->label,
+						'SUMMARY'         => $this->do_ics_escaping( apply_filters( 'the_title', $post->post_title ) ) . ' - ' . $post_status_obj->label,
 						'DTSTART'         => $start_date,
 						'DTEND'           => $end_date,
 						'LAST-MODIFIED'   => $last_modified,
@@ -856,7 +856,7 @@ class EF_Calendar extends EF_Module {
 		ob_start();
 		$post_id = $post->ID;
 		$edit_post_link = get_edit_post_link( $post_id );
-		$status_object = get_post_status_object( get_post_status( $post_id ) )->label;
+		$status_object = get_post_status_object( get_post_status( $post_id ) );
 		
 		$post_classes = array(
 			'day-item',
@@ -885,7 +885,7 @@ class EF_Calendar extends EF_Module {
 			<div style="clear:right;"></div>
 			<div class="item-static">
 				<div class="item-default-visible">
-					<div class="item-status"><span class="status-text"><?php echo esc_html( $status_object ); ?></span></div>
+					<div class="item-status"><span class="status-text"><?php echo esc_html( $status_object->label ); ?></span></div>
 					<div class="inner">
 						<span class="item-headline post-title"><strong><?php echo esc_html( _draft_or_post_title( $post->ID ) ); ?></strong></span>
 					</div>
@@ -1724,8 +1724,8 @@ class EF_Calendar extends EF_Module {
 					<?php 
 						foreach ( $post_stati as $post_status ) { 
 							$value = $post_status;
-							$status = get_post_status_object($post_status)->label;
-							echo "<option value='" . esc_attr( $value ) . "' " . selected( $value, $filters['post_status'] ) . ">" . esc_html( $status ) . "</option>";
+							$status = get_post_status_object($post_status);
+							echo "<option value='" . esc_attr( $value ) . "' " . selected( $value, $filters['post_status'] ) . ">" . esc_html( $status->label ) . "</option>";
 						}
 					?>
 					<option value="unpublish" <?php selected( 'unpublish', $filters['post_status'] ) ?> > <?php echo __( 'Unpublished', 'edit-flow' ) ?> </option>

--- a/modules/calendar/calendar.php
+++ b/modules/calendar/calendar.php
@@ -1214,8 +1214,8 @@ class EF_Calendar extends EF_Module {
 						 
 		$args = array_merge( $defaults, $args );
 		
-		// Unpublished as a status is just an array of everything but 'publish'
-		if ( $args['post_status'] == 'unpublish' ) {
+		// Unpublished as a status is just an array of everything but 'publish'.
+		if ( 'unpublish' == $args['post_status'] ) {
 			$args['post_status'] = '';
 			$post_stati = get_post_stati();
 			unset($post_stati['inherit'], $post_stati['auto-draft'], $post_stati['trash'], $post_stati['publish'] );

--- a/modules/calendar/calendar.php
+++ b/modules/calendar/calendar.php
@@ -1686,7 +1686,7 @@ class EF_Calendar extends EF_Module {
 				// Whitelist-based validation for this parameter
 				$valid_statuses = get_post_stati();
 				$valid_statuses[] = 'unpublish';
-				unset($valid_statuses['inherit'], $valid_statuses['auto-draft'], $valid_statuses['trash']);
+				unset( $valid_statuses['inherit'], $valid_statuses['auto-draft'], $valid_statuses['trash'] );
 				if ( in_array( $dirty_value, $valid_statuses ) )
 					return $dirty_value;
 				else
@@ -1717,7 +1717,7 @@ class EF_Calendar extends EF_Module {
 		switch( $select_id ){ 
 			case 'post_status':
 				$post_stati = get_post_stati();
-				unset($post_stati['inherit'], $post_stati['auto-draft'], $post_stati['trash']);
+				unset( $post_stati['inherit'], $post_stati['auto-draft'], $post_stati['trash'] );
 			?>
 				<select id="<?php echo $select_id; ?>" name="<?php echo $select_name; ?>" >
 					<option value=""><?php _e( 'View all statuses', 'edit-flow' ); ?></option>

--- a/modules/custom-status/custom-status.php
+++ b/modules/custom-status/custom-status.php
@@ -724,7 +724,7 @@ class EF_Custom_Status extends EF_Module {
 
 		if ( $column_name == 'status' ) {
 			global $post;
-			echo get_post_status_object( get_post_status( $post->ID ) )->label;
+			echo esc_html( get_post_status_object( get_post_status( $post->ID ) )->label );
 		}
 	}
 	/**

--- a/modules/custom-status/custom-status.php
+++ b/modules/custom-status/custom-status.php
@@ -724,7 +724,8 @@ class EF_Custom_Status extends EF_Module {
 
 		if ( $column_name == 'status' ) {
 			global $post;
-			echo esc_html( get_post_status_object( get_post_status( $post->ID ) )->label );
+			$post_status_obj = get_post_status_object( get_post_status( $post->ID ) );
+			echo esc_html( $post_status_obj->label );
 		}
 	}
 	/**
@@ -735,9 +736,9 @@ class EF_Custom_Status extends EF_Module {
 	function check_if_post_state_is_status($post_states) {
 		
 		global $post;
-		$statuses = get_post_status_object(get_post_status($post->ID))->label;
+		$statuses = get_post_status_object(get_post_status($post->ID));
 		foreach ( $post_states as $state ) {
-			if ( $state !== $statuses ) {
+			if ( $state !== $statuses->label ) {
 				echo '<span class="show"></span>';
 			}
 		}

--- a/modules/custom-status/custom-status.php
+++ b/modules/custom-status/custom-status.php
@@ -722,7 +722,7 @@ class EF_Custom_Status extends EF_Module {
 
 		if ( $column_name == 'status' ) {
 			global $post;
-			echo $this->get_post_status_friendly_name( $post->post_status );
+			echo get_post_status_object( get_post_status( $post->ID ) )->label;
 		}
 
 	}

--- a/modules/custom-status/custom-status.php
+++ b/modules/custom-status/custom-status.php
@@ -115,6 +115,8 @@ class EF_Custom_Status extends EF_Module {
 		// Pagination for custom post statuses when previewing posts
 		add_filter( 'wp_link_pages_link', array( $this, 'modify_preview_link_pagination_url' ), 10, 2 );
 
+		// Filter through Post States and run a function to check if they are also a Status
+		add_filter( 'display_post_states', array( $this, 'check_if_post_state_is_status' ), 10, 2 );
 	}
 
 	/**
@@ -724,9 +726,23 @@ class EF_Custom_Status extends EF_Module {
 			global $post;
 			echo get_post_status_object( get_post_status( $post->ID ) )->label;
 		}
-
 	}
-
+	/**
+	 * Check if Post State is a Status and display if it is not.
+	 * 
+	 * @param array $post_states An array of post display states.
+	 */
+	function check_if_post_state_is_status($post_states) {
+		
+		global $post;
+		$statuses = get_post_status_object(get_post_status($post->ID))->label;
+		foreach ( $post_states as $state ) {
+			if ( $state !== $statuses ) {
+				echo '<span class="show"></span>';
+			}
+		}
+			return $post_states;
+	}
 
 	/**
 	 * Determines whether the slug indicated belongs to a restricted status or not

--- a/modules/custom-status/lib/custom-status.css
+++ b/modules/custom-status/lib/custom-status.css
@@ -2,3 +2,6 @@
 span.post-state {
 	display: none;
 }
+.show + span.post-state {
+	display: inline-block;
+}

--- a/modules/notifications/notifications.php
+++ b/modules/notifications/notifications.php
@@ -551,9 +551,9 @@ jQuery(document).ready(function($) {
 			/* translators: 1: date, 2: time, 3: timezone */
 			$body .= sprintf( __( 'This action was taken on %1$s at %2$s %3$s', 'edit-flow' ), date_i18n( get_option( 'date_format' ) ), date_i18n( get_option( 'time_format' ) ), get_option( 'timezone_string' ) ) . "\r\n";
 			
-			$old_status_friendly_name = $this->get_post_status_friendly_name( $old_status );
-			$new_status_friendly_name = $this->get_post_status_friendly_name( $new_status );
-			
+			$old_status_friendly_name = get_post_status_object( $old_status )->label;
+			$new_status_friendly_name = get_post_status_object( $new_status )->label;
+						
 			// Email body
 			$body .= "\r\n";
 			/* translators: 1: old status, 2: new status */

--- a/modules/notifications/notifications.php
+++ b/modules/notifications/notifications.php
@@ -551,7 +551,7 @@ jQuery(document).ready(function($) {
 			/* translators: 1: date, 2: time, 3: timezone */
 			$body .= sprintf( __( 'This action was taken on %1$s at %2$s %3$s', 'edit-flow' ), date_i18n( get_option( 'date_format' ) ), date_i18n( get_option( 'time_format' ) ), get_option( 'timezone_string' ) ) . "\r\n";
 
-			if ( ! is_object( $old_status ) ) {
+			if ( $old_status == 'new' ) {
 				return; 
 			} else {
 				$old_status_friendly_name = get_post_status_object( $old_status )->label;

--- a/modules/notifications/notifications.php
+++ b/modules/notifications/notifications.php
@@ -512,6 +512,7 @@ jQuery(document).ready(function($) {
 			// Email subject and first line of body 
 			// Set message subjects according to what action is being taken on the Post	
 			if ( $old_status == 'new' || $old_status == 'auto-draft' ) {
+				$old_status_friendly_name = "New";
 				/* translators: 1: site name, 2: post type, 3. post title */
 				$subject = sprintf( __( '[%1$s] New %2$s Created: "%3$s"', 'edit-flow' ), $blogname, $post_type, $post_title );
 				/* translators: 1: post type, 2: post id, 3. post title, 4. user name, 5. user email */
@@ -546,19 +547,15 @@ jQuery(document).ready(function($) {
 				$subject = sprintf( __( '[%1$s] %2$s Status Changed for "%3$s"', 'edit-flow' ), $blogname, $post_type, $post_title );
 				/* translators: 1: post type, 2: post id, 3. post title, 4. user name, 5. user email */
 				$body .= sprintf( __( 'Status was changed for %1$s #%2$s "%3$s" by %4$s %5$s', 'edit-flow'), $post_type, $post_id, $post_title, $current_user_display_name, $current_user_email ) . "\r\n";
+				$old_status_post_obj = get_post_status_object( $old_status );
+				$old_status_friendly_name = $old_status_post_obj->label;
 			}
 			
 			/* translators: 1: date, 2: time, 3: timezone */
 			$body .= sprintf( __( 'This action was taken on %1$s at %2$s %3$s', 'edit-flow' ), date_i18n( get_option( 'date_format' ) ), date_i18n( get_option( 'time_format' ) ), get_option( 'timezone_string' ) ) . "\r\n";
 
-			if ( $old_status == 'new' ) {
-				return; 
-			} else {
-				$old_status_post_obj = get_post_status_object( $old_status );
-				$new_status_post_obj = get_post_status_object( $new_status );
-				$old_status_friendly_name = $old_status_post_obj->label;
-				$new_status_friendly_name = $new_status_post_obj->label;
-			}
+			$new_status_post_obj = get_post_status_object( $new_status );
+			$new_status_friendly_name = $new_status_post_obj->label;
 						
 			// Email body
 			$body .= "\r\n";

--- a/modules/notifications/notifications.php
+++ b/modules/notifications/notifications.php
@@ -551,10 +551,12 @@ jQuery(document).ready(function($) {
 			/* translators: 1: date, 2: time, 3: timezone */
 			$body .= sprintf( __( 'This action was taken on %1$s at %2$s %3$s', 'edit-flow' ), date_i18n( get_option( 'date_format' ) ), date_i18n( get_option( 'time_format' ) ), get_option( 'timezone_string' ) ) . "\r\n";
 
-			$old_post_status = get_post_status_object( $old_status );
-			$new_post_status = get_post_status_object( $new_status );
-			$old_status_friendly_name = $old_post_status->label;
-			$new_status_friendly_name = $new_post_status->label;
+			if ( ! is_object( $old_status ) ) {
+				return; 
+			} else {
+				$old_status_friendly_name = get_post_status_object( $old_status )->label;
+				$new_status_friendly_name = get_post_status_object( $new_status )->label;
+			}
 						
 			// Email body
 			$body .= "\r\n";

--- a/modules/notifications/notifications.php
+++ b/modules/notifications/notifications.php
@@ -554,8 +554,10 @@ jQuery(document).ready(function($) {
 			if ( $old_status == 'new' ) {
 				return; 
 			} else {
-				$old_status_friendly_name = get_post_status_object( $old_status )->label;
-				$new_status_friendly_name = get_post_status_object( $new_status )->label;
+				$old_status_post_obj = get_post_status_object( $old_status );
+				$new_status_post_obj = get_post_status_object( $new_status );
+				$old_status_friendly_name = $old_status_post_obj->label;
+				$new_status_friendly_name = $new_status_post_obj->label;
 			}
 						
 			// Email body

--- a/modules/notifications/notifications.php
+++ b/modules/notifications/notifications.php
@@ -550,9 +550,11 @@ jQuery(document).ready(function($) {
 			
 			/* translators: 1: date, 2: time, 3: timezone */
 			$body .= sprintf( __( 'This action was taken on %1$s at %2$s %3$s', 'edit-flow' ), date_i18n( get_option( 'date_format' ) ), date_i18n( get_option( 'time_format' ) ), get_option( 'timezone_string' ) ) . "\r\n";
-			
-			$old_status_friendly_name = get_post_status_object( $old_status )->label;
-			$new_status_friendly_name = get_post_status_object( $new_status )->label;
+
+			$old_post_status = get_post_status_object( $old_status );
+			$new_post_status = get_post_status_object( $new_status );
+			$old_status_friendly_name = $old_post_status->label;
+			$new_status_friendly_name = $new_post_status->label;
 						
 			// Email body
 			$body .= "\r\n";

--- a/modules/story-budget/story-budget.php
+++ b/modules/story-budget/story-budget.php
@@ -497,7 +497,7 @@ class EF_Story_Budget extends EF_Module {
 			
 		switch( $column_name ) {
 			case 'status':
-				$status_name = $this->get_post_status_friendly_name( $post->post_status );
+				$status_name = get_post_status_object( $post->post_status )->label;
 				return $status_name;
 				break;
 			case 'author':

--- a/modules/story-budget/story-budget.php
+++ b/modules/story-budget/story-budget.php
@@ -372,16 +372,16 @@ class EF_Story_Budget extends EF_Module {
 		// Unpublished as a status is just an array of everything but 'publish'
 		if ( $args['post_status'] == 'unpublish' ) {
 			$args['post_status'] = '';
-			$post_statuses = $this->get_post_statuses();
-			foreach ( $post_statuses as $post_status ) {
-				$args['post_status'] .= $post_status->slug . ', ';
+			$post_stati = get_post_stati();
+			unset( $post_stati['inherit'], $post_stati['auto-draft'], $post_stati['trash'], $post_stati['publish'] );
+			if ( ! apply_filters( 'ef_show_scheduled_as_unpublished', false ) ) {
+				unset( $post_stati['future'] );
 			}
-			$args['post_status'] = rtrim( $args['post_status'], ', ' );
-			// Optional filter to include scheduled content as unpublished
-			if ( apply_filters( 'ef_show_scheduled_as_unpublished', false ) )
-				$args['post_status'] .= ', future';
+			foreach ( $post_stati as $post_status ) {
+				$args['post_status'] .= $post_status . ', ';
+			}
 		}
-		
+
 		// Filter by post_author if it's set
 		if ( $args['author'] === '0' ) unset( $args['author'] );
 
@@ -716,17 +716,18 @@ class EF_Story_Budget extends EF_Module {
 	function story_budget_filter_options( $select_id, $select_name, $filters ) {
 		switch( $select_id ) {
 			case 'post_status': 
-			$post_statuses = $this->get_post_statuses();
+			$post_stati = get_post_stati();
+			unset($post_stati['inherit'], $post_stati['auto-draft'], $post_stati['trash']);
 			?>
 				<select id="post_status" name="post_status"><!-- Status selectors -->
 						<option value=""><?php _e( 'View all statuses', 'edit-flow' ); ?></option>
 						<?php
-							foreach ( $post_statuses as $post_status ) {
-								echo "<option value='" . esc_attr( $post_status->slug ) . "' " . selected( $post_status->slug, $filters['post_status'] ) . ">" . esc_html( $post_status->name ) . "</option>";
+							foreach ( $post_stati as $post_status ) {
+								$value = $post_status;
+								$status = get_post_status_object($post_status)->label;
+								echo '<option value="' . esc_attr( $value ) . '" ' . selected( $value, $filters['post_status'] ) . '>' . esc_html( $status ) . '</option>';
 							}
-							echo "<option value='future'" . selected('future', $filters['post_status']) . ">" . __( 'Scheduled', 'edit-flow' ) . "</option>";
-							echo "<option value='unpublish'" . selected('unpublish', $filters['post_status']) . ">" . __( 'Unpublished', 'edit-flow' ) . "</option>";
-							echo "<option value='publish'" . selected('publish', $filters['post_status']) . ">" . __( 'Published', 'edit-flow' ) . "</option>";
+							echo '<option value="unpublish"' . selected('unpublish', $filters['post_status']) . '>' . __( 'Unpublished', 'edit-flow' ) . '</option>';
 						?>
 					</select>
 			<?php

--- a/modules/story-budget/story-budget.php
+++ b/modules/story-budget/story-budget.php
@@ -369,8 +369,8 @@ class EF_Story_Budget extends EF_Module {
 			),
 		);
 
-		// Unpublished as a status is just an array of everything but 'publish'
-		if ( $args['post_status'] == 'unpublish' ) {
+		// Unpublished as a status is just an array of everything but 'publish'.
+		if ( 'unpublish' == $args['post_status'] ) {
 			$args['post_status'] = '';
 			$post_stati = get_post_stati();
 			unset( $post_stati['inherit'], $post_stati['auto-draft'], $post_stati['trash'], $post_stati['publish'] );

--- a/modules/story-budget/story-budget.php
+++ b/modules/story-budget/story-budget.php
@@ -717,7 +717,7 @@ class EF_Story_Budget extends EF_Module {
 		switch( $select_id ) {
 			case 'post_status': 
 			$post_stati = get_post_stati();
-			unset($post_stati['inherit'], $post_stati['auto-draft'], $post_stati['trash']);
+			unset( $post_stati['inherit'], $post_stati['auto-draft'], $post_stati['trash'] );
 			?>
 				<select id="post_status" name="post_status"><!-- Status selectors -->
 						<option value=""><?php _e( 'View all statuses', 'edit-flow' ); ?></option>

--- a/modules/story-budget/story-budget.php
+++ b/modules/story-budget/story-budget.php
@@ -497,8 +497,8 @@ class EF_Story_Budget extends EF_Module {
 			
 		switch( $column_name ) {
 			case 'status':
-				$status_name = get_post_status_object( $post->post_status )->label;
-				return $status_name;
+				$status_name = get_post_status_object( $post->post_status );
+				return $status_name->label;
 				break;
 			case 'author':
 				$post_author = get_userdata( $post->post_author );


### PR DESCRIPTION
Fixes #445

Previously, the `get_post_status_friendly_name` function was retrieving the WordPress built-in Post Statuses and the Custom Statuses set within the plugin interface.  If you happen to register a post status another way, it would not appear in the Status Column of your Post Type.

This PR removes the need for `get_post_status_friendly_name` in the Post List, Calendar, and Story Budget sections and instead just calls the post status label directly.

This also adds a check to see if a Post State does not match the Post Status, and if it does not match, it will show the Post State.  Example:
<img width="603" alt="screen shot 2018-03-20 at 9 32 21 pm" src="https://user-images.githubusercontent.com/3220162/37694671-50f6b930-2c86-11e8-87d4-e4f31ec5c8c9.png">
