### PR TITLE
Check if a user can edit the post/page before sending a notification.

### DIFF
--- a/modules/notifications/notifications.php
+++ b/modules/notifications/notifications.php
@@ -740,9 +740,8 @@ jQuery(document).ready(function($) {
 		
 		$post_id = $post->ID;
 		if( !$post_id ) return;
-		
-		$authors = array();
-		$admins = array();
+
+		$admins     = array();
 		$recipients = array();
 
 		// Email all admins, if enabled
@@ -773,8 +772,7 @@ jQuery(document).ready(function($) {
 		}
 
 		// Merge arrays and filter any duplicates
-		$recipients = array_merge( $authors, $admins, $users, $usergroup_users );
-		$recipients = array_unique( $recipients );
+		$recipients = array_unique( array_merge( $admins, $users, $usergroup_users ) );
 
 		// Process the recipients for this email to be sent
 		foreach( $recipients as $key => $user_email ) {

--- a/modules/notifications/notifications.php
+++ b/modules/notifications/notifications.php
@@ -764,7 +764,7 @@ jQuery(document).ready(function($) {
 		}
 
 		$user_recipients = $this->get_following_users( $post_id, 'user_email' );
-		foreach( (array) $user_recipients as $key => $user ) {
+		foreach( $user_recipients as $key => $user ) {
 			$user_object = get_user_by( 'email', $user );
 			if ( ! $this->user_can_be_notified( $user_object, $post_id ) ) {
 				unset( $user_recipients[ $key ] );
@@ -782,7 +782,13 @@ jQuery(document).ready(function($) {
 			}
 		}
 
-		// Filter to allow further modification of recipients.
+		/**
+		 * Filters the list of notification recipients.
+		 *
+		 * @param array $recipients List of recipient email addresses.
+		 * @param WP_Post $post
+		 * @param bool $string True if the recipients list will later be returned as a string.
+		 */
 		$recipients = apply_filters( 'ef_notification_recipients', $recipients, $post, $string );
 
 		// If string set to true, return comma-delimited.
@@ -810,7 +816,14 @@ jQuery(document).ready(function($) {
 			$can_be_notified = $user->has_cap( 'edit_post', $post_id );
 		}
 
-		return apply_filters( 'ef_notification_user_can_be_notified', $can_be_notified, $user, $post_id );
+		/**
+		 * Filters if a user can be notified. Defaults to true if they can edit the post/page.
+		 *
+		 * @param bool $can_be_notified True if the user can be notified.
+		 * @param WP_User|bool $user The user object, otherwise false.
+		 * @param int $post_id The post the user will be notified about.
+		 */
+		return (bool) apply_filters( 'ef_notification_user_can_be_notified', $can_be_notified, $user, $post_id );
 	}
 
 	/**

--- a/modules/notifications/notifications.php
+++ b/modules/notifications/notifications.php
@@ -749,31 +749,30 @@ jQuery(document).ready(function($) {
 			$admins[] = get_option('admin_email');
 		}
 
-		$usergroup_users = array();
+		$usergroup_recipients = array();
 		if ( $this->module_enabled( 'user_groups' ) ) {
-			// Get following users and usergroups.
 			$usergroups = $this->get_following_usergroups( $post_id, 'ids' );
 			foreach ( (array) $usergroups as $usergroup_id ) {
 				$usergroup = $edit_flow->user_groups->get_usergroup_by( 'id', $usergroup_id );
 				foreach ( (array) $usergroup->user_ids as $user_id ) {
 					$usergroup_user = get_user_by( 'id', $user_id );
 					if ( $this->user_can_be_notified( $usergroup_user, $post_id ) ) {
-						$usergroup_users[] = $usergroup_user->user_email;
+						$usergroup_recipients[] = $usergroup_user->user_email;
 					}
 				}
 			}
 		}
 
-		$users = $this->get_following_users( $post_id, 'user_email' );
-		foreach( (array) $users as $key => $user ) {
+		$user_recipients = $this->get_following_users( $post_id, 'user_email' );
+		foreach( (array) $user_recipients as $key => $user ) {
 			$user_object = get_user_by( 'email', $user );
 			if ( ! $this->user_can_be_notified( $user_object, $post_id ) ) {
-				unset( $users[ $key ] );
+				unset( $user_recipients[ $key ] );
 			}
 		}
 
 		// Merge arrays, filter any duplicates, and remove empty entries.
-		$recipients = array_filter( array_unique( array_merge( $admins, $users, $usergroup_users ) ) );
+		$recipients = array_filter( array_unique( array_merge( $admins, $user_recipients, $usergroup_recipients ) ) );
 
 		// Process the recipients for this email to be sent.
 		foreach(  $recipients as $key => $user_email ) {

--- a/modules/notifications/notifications.php
+++ b/modules/notifications/notifications.php
@@ -772,16 +772,11 @@ jQuery(document).ready(function($) {
 			}
 		}
 
-		// Merge arrays and filter any duplicates.
-		$recipients = array_unique( array_merge( $admins, $users, $usergroup_users ) );
+		// Merge arrays, filter any duplicates, and remove empty entries.
+		$recipients = array_filter( array_unique( array_merge( $admins, $users, $usergroup_users ) ) );
 
 		// Process the recipients for this email to be sent.
 		foreach(  $recipients as $key => $user_email ) {
-			// Get rid of empty email entries.
-			if ( empty( $recipients[ $key ] ) ) {
-				unset( $recipients[ $key ] );
-			}
-
 			// Don't send the email to the current user unless we've explicitly indicated they should receive it.
 			if ( false === apply_filters( 'ef_notification_email_current_user', false ) && wp_get_current_user()->user_email == $user_email ) {
 				unset( $recipients[ $key ] );

--- a/modules/notifications/notifications.php
+++ b/modules/notifications/notifications.php
@@ -740,7 +740,7 @@ jQuery(document).ready(function($) {
 
 		$post_id = $post->ID;
 		if ( ! $post_id ) {
-			return;
+			return $string ? '' : array();
 		}
 
 		// Email all admins if enabled.


### PR DESCRIPTION
Part of https://github.com/Automattic/Edit-Flow/issues/265

The functionality is all implemented in the first commit, the other two are cleanup for it's surroundings.

## Some things to note:

It's possible that the `user_can_be_notified` method will need to be abstracted and put into the `EF_Module` parent class for part 2 of the above issue, but that can be done if/when necessary.

And then it seems calling both `edit_post` or `edit_page` conditionally would be redundant according to the core method: https://github.com/WordPress/WordPress/blob/master/wp-includes/capabilities.php#L127-L128. Would be nice to have a second pair of eyes to confirm this, but my testing showed that this was indeed the case. Some more info on what I found here https://github.com/Automattic/Edit-Flow/issues/265#issuecomment-378419531

## Steps for testing

1) Add multiple authors and editors to a user group.
2) Using the current master branch, select this user group to be notified on a draft post. 
3) Post an editorial comment.
4) Look at the email logs or just error_log the `$recipients` variable at the end of `_get_notification_recipients`.
5) Note that all authors/editors that were signed up received this email.

5) Switch to this branch and post another editorial comment.
6) Note that only editors were sent the email, along with the post author if they were selected.

Can repeat and test with individual user notifications as well instead or alongside groups.

