### PR TITLE
Display who was notified for an editorial comment

### DIFF
--- a/modules/editorial-comments/editorial-comments.php
+++ b/modules/editorial-comments/editorial-comments.php
@@ -197,13 +197,11 @@ class EF_Editorial_Comments extends EF_Module
 				<textarea id="ef-replycontent" name="replycontent" cols="40" rows="5"></textarea>
 			</div>
 
-			<?php
-			if ($this->module_enabled( 'notifications' )) {
-			// Only show the input if notifications are enabled ?>
-			<label for="ef-reply-notifier"><?php _e('The following will be notified:', 'edit-flow'); ?>
-				<input id="ef-reply-notifier" class="ef-reply-notifier-message" readonly>
-			</label>
-			<?php } ?>
+			<?php if ( $this->module_enabled( 'notifications' ) ) : ?>
+				<label for="ef-reply-notifier"><?php esc_html_e( 'The following will be notified:', 'edit-flow' ); ?>
+					<input id="ef-reply-notifier" class="ef-reply-notifier-message" readonly>
+				</label>
+			<?php endif; ?>
 
 			<p id="ef-replysubmit">
 				<a class="ef-replysave button-primary alignright" href="#comments-form">
@@ -362,8 +360,8 @@ class EF_Editorial_Comments extends EF_Module
 			$comment = get_comment($comment_id);
 
 			// Save the list of notified users/usergroups
-			if ($this->module_enabled( 'notifications' )) {
-				add_comment_meta( $comment_id, 'notification_list', $notification, false );
+			if ( $this->module_enabled( 'notifications' ) ) {
+				add_comment_meta( $comment_id, 'notification_list', $notification );
 			}
 
 			// Register actions -- will be used to set up notifications and other modules can hook into this

--- a/modules/editorial-comments/editorial-comments.php
+++ b/modules/editorial-comments/editorial-comments.php
@@ -229,17 +229,20 @@ class EF_Editorial_Comments extends EF_Module
 	/**
 	 * Print a list of notified users/usergroups
 	 */
-	function get_comment_notification_meta($comment_id) {
-		$notification = get_comment_meta( $comment_id, 'notification_list', true );
-		if ($notification) {
-			if ($notification == 1) {
-				// There were no users or user groups selected when this comment was posted
-				$message = '<em>'.__('No users or groups were notified', 'edit-flow').'</em>';
-			} else {
-				$message = '<strong>'.__('Notified', 'edit-flow').':</strong> ' . esc_html( $notification );
-			}
-			echo '<p class="ef-notification-meta">' . $message . '</p>';
+	function maybe_output_comment_meta($comment_id) {
+		if ( ! $this->module_enabled( 'notifications' ) ) {
+			return;
 		}
+
+		$notification = get_comment_meta( $comment_id, 'notification_list', true );
+
+		if ( empty( $notification ) ) {
+			$message = esc_html__( 'No users or groups were notified.', 'edit-flow' );
+		} else {
+			$message = '<strong>'. esc_html__( 'Notified', 'edit-flow' ) . ':</strong> ' . esc_html( $notification );
+		}
+
+		echo '<p class="ef-notification-meta">' . $message . '</p>';
 	}
 
 	/**
@@ -292,7 +295,7 @@ class EF_Editorial_Comments extends EF_Module
 				</h5>
 
 				<div class="comment-content"><?php comment_text(); ?></div>
-				<?php $this->get_comment_notification_meta($comment->comment_ID); ?>
+				<?php $this->maybe_output_comment_meta( $comment->comment_ID ); ?>
 				<p class="row-actions"><?php echo $actions_string; ?></p>
 
 			</div>

--- a/modules/editorial-comments/editorial-comments.php
+++ b/modules/editorial-comments/editorial-comments.php
@@ -92,6 +92,11 @@ class EF_Editorial_Comments extends EF_Module
 			return;
 
 		wp_enqueue_script( 'edit_flow-post_comment', $this->module_url . 'lib/editorial-comments.js', array( 'jquery','post' ), EDIT_FLOW_VERSION, true );
+		wp_localize_script( 'edit_flow-post_comment', '__ef_localize_post_comment', array(
+			'and'           => esc_html__( 'and', 'edit-flow' ),
+			'none_notified' => esc_html__( 'No one will be notified.', 'edit-flow' ),
+		) );
+
 		wp_enqueue_style( 'edit-flow-editorial-comments-css', $this->module_url . 'lib/editorial-comments.css', false, EDIT_FLOW_VERSION, 'all' );
 
 		$thread_comments = (int) get_option('thread_comments');

--- a/modules/editorial-comments/editorial-comments.php
+++ b/modules/editorial-comments/editorial-comments.php
@@ -236,7 +236,7 @@ class EF_Editorial_Comments extends EF_Module
 				// There were no users or user groups selected when this comment was posted
 				$message = '<em>'.__('No users or groups were notified', 'edit-flow').'</em>';
 			} else {
-				$message = '<strong>'.__('Notified', 'edit-flow').':</strong> ' . $notification;
+				$message = '<strong>'.__('Notified', 'edit-flow').':</strong> ' . esc_html( $notification );
 			}
 			echo '<p class="ef-notification-meta">' . $message . '</p>';
 		}
@@ -314,9 +314,9 @@ class EF_Editorial_Comments extends EF_Module
       	wp_get_current_user();
 
       	// Set up comment data
-		$post_id = absint( $_POST['post_id'] );
-		$parent = absint( $_POST['parent'] );
-		$notification = $_POST['notification'];
+		$post_id      = absint( $_POST['post_id'] );
+		$parent       = absint( $_POST['parent'] );
+		$notification = isset( $_POST['notification'] ) ? sanitize_text_field( $_POST['notification'] ) : '';
 
       	// Only allow the comment if user can edit post
       	// @TODO: allow contributers to add comments as well (?)

--- a/modules/editorial-comments/editorial-comments.php
+++ b/modules/editorial-comments/editorial-comments.php
@@ -233,7 +233,7 @@ class EF_Editorial_Comments extends EF_Module
 	 * Print a list of notified users/usergroups
 	 */
 	function maybe_output_comment_meta($comment_id) {
-		if ( ! $this->module_enabled( 'notifications' ) ) {
+		if ( ! $this->module_enabled( 'notifications' ) || ! apply_filters( 'ef_editorial_comments_show_notified_users', true ) ) {
 			return;
 		}
 
@@ -320,9 +320,8 @@ class EF_Editorial_Comments extends EF_Module
       	wp_get_current_user();
 
       	// Set up comment data
-		$post_id      = absint( $_POST['post_id'] );
-		$parent       = absint( $_POST['parent'] );
-		$notification = isset( $_POST['notification'] ) ? sanitize_text_field( $_POST['notification'] ) : '';
+		$post_id = absint( $_POST['post_id'] );
+		$parent  = absint( $_POST['parent'] );
 
       	// Only allow the comment if user can edit post
       	// @TODO: allow contributers to add comments as well (?)
@@ -364,9 +363,13 @@ class EF_Editorial_Comments extends EF_Module
 			$comment_id = wp_insert_comment($data);
 			$comment = get_comment($comment_id);
 
-			// Save the list of notified users/usergroups
-			if ( $this->module_enabled( 'notifications' ) && ! empty( $notification ) && __( 'No one will be notified.', 'edit-flow' ) !== $notification ) {
-				add_comment_meta( $comment_id, 'notification_list', $notification );
+			// Save the list of notified users/usergroups.
+			if ( $this->module_enabled( 'notifications' ) && apply_filters( 'ef_editorial_comments_show_notified_users', true ) ) {
+				$notification = isset( $_POST['notification'] ) ? sanitize_text_field( $_POST['notification'] ) : '';
+
+				if ( ! empty( $notification ) && __( 'No one will be notified.', 'edit-flow' ) !== $notification ) {
+					add_comment_meta( $comment_id, 'notification_list', $notification );
+				}
 			}
 
 			// Register actions -- will be used to set up notifications and other modules can hook into this

--- a/modules/editorial-comments/editorial-comments.php
+++ b/modules/editorial-comments/editorial-comments.php
@@ -230,9 +230,12 @@ class EF_Editorial_Comments extends EF_Module
 	}
 
 	/**
-	 * Print a list of notified users/usergroups
+	 * Maybe display who was notified underneath an editorial comment.
+	 * 
+	 * @param int $comment_id
+	 * @return void
 	 */
-	function maybe_output_comment_meta($comment_id) {
+	function maybe_output_comment_meta( $comment_id ) {
 		if ( ! $this->module_enabled( 'notifications' ) || ! apply_filters( 'ef_editorial_comments_show_notified_users', true ) ) {
 			return;
 		}

--- a/modules/editorial-comments/editorial-comments.php
+++ b/modules/editorial-comments/editorial-comments.php
@@ -365,7 +365,7 @@ class EF_Editorial_Comments extends EF_Module
 			$comment = get_comment($comment_id);
 
 			// Save the list of notified users/usergroups
-			if ( $this->module_enabled( 'notifications' ) ) {
+			if ( $this->module_enabled( 'notifications' ) && ! empty( $notification ) && __( 'No one will be notified.', 'edit-flow' ) !== $notification ) {
 				add_comment_meta( $comment_id, 'notification_list', $notification );
 			}
 

--- a/modules/editorial-comments/lib/editorial-comments.css
+++ b/modules/editorial-comments/lib/editorial-comments.css
@@ -33,6 +33,7 @@
 	#ef-comments li:hover .ef-notification-meta {
 		visibility: visible;
 	}
+
 	#ef-comments li p.row-actions {
 		text-align: right;
 	}
@@ -125,25 +126,20 @@ input[readonly].ef-reply-notifier-message {
 	padding: 0.5em;
 	border: none;
 	font-size: 1em;
+	border-left: 0.5em solid #80a029;
 }
 
-	label[for="ef-reply-notifier"] {
-		margin: 0.75em 0;
-		display: block;
-		cursor: default;
-	}
+label[for="ef-reply-notifier"] {
+	margin: 0.75em 0;
+	display: block;
+	cursor: default;
+}
 
-	input[readonly].ef-selection-success {
-		border-left: 0.5em solid #80a029;
-	}
-
-	input[readonly].ef-none-selected {
-		border-left: 0.5em solid #a00;
-	}
+input[readonly].ef-none-selected {
+	border-left: 0.5em solid #a00;
+}
 
 .ef-notification-meta {
-	text-align: right;
 	margin-bottom: 0;
 	visibility: hidden;
 }
-

--- a/modules/editorial-comments/lib/editorial-comments.css
+++ b/modules/editorial-comments/lib/editorial-comments.css
@@ -126,7 +126,7 @@ input[readonly].ef-reply-notifier-message {
 	padding: 0.5em;
 	border: none;
 	font-size: 1em;
-	border-left: 0.5em solid #80a029;
+	border-left: 4px solid #46b450;
 }
 
 label[for="ef-reply-notifier"] {
@@ -136,7 +136,7 @@ label[for="ef-reply-notifier"] {
 }
 
 input[readonly].ef-none-selected {
-	border-left: 0.5em solid #a00;
+	border-left: 4px solid #dc3232;
 }
 
 .ef-notification-meta {

--- a/modules/editorial-comments/lib/editorial-comments.js
+++ b/modules/editorial-comments/lib/editorial-comments.js
@@ -21,6 +21,11 @@ editorialCommentReply = {
 		// Bind click events to cancel and submit buttons
 		jQuery('a.ef-replycancel', row).click(function() { return editorialCommentReply.revert(); });
 		jQuery('a.ef-replysave', row).click(function() { return editorialCommentReply.send(); });
+
+		// Watch for changes to the subscribed users.
+		$( '#ef-post_following_box' ).on( 'following_list_updated', function() {
+			editorialCommentReply.notifiedMessage();
+		} );
 	},
 
 	revert : function() {

--- a/modules/editorial-comments/lib/editorial-comments.js
+++ b/modules/editorial-comments/lib/editorial-comments.js
@@ -138,7 +138,7 @@ editorialCommentReply = {
 		// No users will be notified, so return early with a default message.
 		if ( 0 === subscribed_users.length ) {
 			message_wrapper.addClass( 'ef-none-selected' );
-			message_wrapper.val( 'No one will be notified.' );
+			message_wrapper.val( __ef_localize_post_comment.none_notified );
 			return;
 		}
 
@@ -150,7 +150,7 @@ editorialCommentReply = {
 		// Convert array of usernames into a sentence.
 		var message = usernames.pop();
 		if ( usernames.length > 0 ) {
-			message = usernames.join( ', ' ) + ' and ' + message;
+			message = usernames.join( ', ' ) + ' ' + __ef_localize_post_comment.and + ' ' + message + '.';
 		}
 
 		message_wrapper.removeClass( 'ef-none-selected' );

--- a/modules/editorial-comments/lib/editorial-comments.js
+++ b/modules/editorial-comments/lib/editorial-comments.js
@@ -67,7 +67,7 @@ editorialCommentReply = {
 		jQuery('#ef-comment_respond').hide();
 
 		// Display who will be notified for this comment
-		editorialCommentReply.notify();
+		this.notifiedMessage();
 		
 		// Show reply textbox
 		jQuery('#ef-replyrow')
@@ -104,9 +104,8 @@ editorialCommentReply = {
 		post.parent = (jQuery("#ef-comment_parent").val()=='') ? 0 : jQuery("#ef-comment_parent").val();
 		post._nonce = jQuery("#ef_comment_nonce").val();
 		post.post_id = jQuery("#ef-post_id").val();
-		post.notification = (jQuery('#ef-reply-notifier').val() == 'No one will be notified' ||
-					jQuery('#ef-reply-notifier').val() == '') ? 1 : jQuery('#ef-reply-notifier').val()
-		
+		post.notification = jQuery('#ef-reply-notifier').val();
+
 		// Send the request
 		jQuery.ajax({
 			type : 'POST',
@@ -120,51 +119,37 @@ editorialCommentReply = {
 	},
 
 	/**
-	 * Display who will be notified of the new comment
+	 * Display who will be notified of the new comment.
 	 */
-	notify : function() {
-		var checked_notifiers = [], usernames = [], message = "", lastUser = "";
+	notifiedMessage : function() {
+		var message_wrapper = jQuery( '#ef-reply-notifier' );
 
-		// Get notification field and make sure it's empty
-		// If there is no wrapper, we need to get out
-		var message_wrapper = jQuery('#ef-reply-notifier');
-		if (message_wrapper[0]) {
-			message_wrapper.val('');
-		} else {
+		if ( ! message_wrapper[0] ) {
 			return;
 		}
 
-		// Get checked checkboxes
-		checked_notifiers = jQuery('.ef-post_following_list li input:checkbox:checked');
+		var subscribed_users = jQuery( '.ef-post_following_list li input:checkbox:checked' );
 
-		if (checked_notifiers.length > 0) {
-			var current_item;
-			// There are checked users/usergroups
-			// Set the class to 'selection-success'
-			message_wrapper.removeClass('ef-none-selected').addClass('ef-selection-success');
-			for (var i = 0; i < checked_notifiers.length; i++) {
-				current_item = checked_notifiers[i];
-				// Add usernames to the usernames array
-				usernames.push(jQuery(current_item).next().html());
-			}
-			// Create the message
-			// We don't want a comma on the last item or if there is only one item
-			lastUser = usernames.pop();
-			if (usernames.length > 0) {
-				// There is still at least one item in the array after popping off the last item
-				message = usernames.join(', ') + ' and ' + lastUser;
-			} else {
-				// There was only one item to begin with
-				message = lastUser;
-			}
-			// Display the message
-			message_wrapper.val(message);
-		} else {
-			// There are no checked users/usergroups
-			// Set input class to 'none-selected' and display message
-			message_wrapper.removeClass('ef-selection-success').addClass('ef-none-selected');
-			message_wrapper.val('No one will be notified');
+		// No users will be notified, so return early with a default message.
+		if ( 0 === subscribed_users.length ) {
+			message_wrapper.addClass( 'ef-none-selected' );
+			message_wrapper.val( 'No one will be notified.' );
+			return;
 		}
+
+		var usernames = [];
+		subscribed_users.each( function() {
+			usernames.push( $( this ).next().text() );
+		} );
+
+		// Convert array of usernames into a sentence.
+		var message = usernames.pop();
+		if ( usernames.length > 0 ) {
+			message = usernames.join( ', ' ) + ' and ' + message;
+		}
+
+		message_wrapper.removeClass( 'ef-none-selected' );
+		message_wrapper.val( message );
 	},
 
 	show : function(xml) {

--- a/modules/notifications/lib/notifications.js
+++ b/modules/notifications/lib/notifications.js
@@ -31,7 +31,7 @@ jQuery(document).ready(function($) {
 				// Update the list of users/groups to be notified of new comment
 				// Check for editorialCommentReply, in case EF Comments are disabled
 				if (typeof editorialCommentReply == 'object') {
-					editorialCommentReply.notify();
+					editorialCommentReply.notifiedMessage();
 				}
 				var backgroundColor = parent_this.css( 'background-color' );
 				$(parent_this.parent().parent())

--- a/modules/notifications/lib/notifications.js
+++ b/modules/notifications/lib/notifications.js
@@ -28,11 +28,10 @@ jQuery(document).ready(function($) {
 			url : (ajaxurl) ? ajaxurl : wpListL10n.url,
 			data : params,
 			success : function(x) { 
-				// Update the list of users/groups to be notified of new comment
-				// Check for editorialCommentReply, in case EF Comments are disabled
-				if (typeof editorialCommentReply == 'object') {
-					editorialCommentReply.notifiedMessage();
-				}
+
+				// This event is used to show an updated list of who will be notified of editorial comments and status updates.
+				$( '#ef-post_following_box' ).trigger( 'following_list_updated' );
+
 				var backgroundColor = parent_this.css( 'background-color' );
 				$(parent_this.parent().parent())
 					.animate( { 'backgroundColor':'#CCEEBB' }, 200 )


### PR DESCRIPTION
Part of https://github.com/Automattic/Edit-Flow/issues/270. This PR started in https://github.com/Automattic/Edit-Flow/pull/271, and continued with some edits here.

The functionality is the same as described in 271 above, with a few smaller changes:

- Only save comment meta if needed (don't save empty messages).
- Localize all text strings.
- Add filter so this feature can be disabled.

To test:

1) Enable notifications & editorial comments features.
2) Add people and/or groups to be notified.
3) Leave editorial comments.

Screenshots can be found in https://github.com/Automattic/Edit-Flow/pull/271, as there weren't many changes to the display (aside from colors and text aligning).