### PR TITLE
Display who will be notified of post status changes

### DIFF
--- a/modules/notifications/lib/notifications.css
+++ b/modules/notifications/lib/notifications.css
@@ -93,6 +93,6 @@
 	margin-top: 0;
 }
 
-.misc-pub-follower-count span {
+.misc-pub-follower-count #post-follower-count-display {
 	font-weight: bold;
 }

--- a/modules/notifications/lib/notifications.js
+++ b/modules/notifications/lib/notifications.js
@@ -58,27 +58,29 @@ var ef_displayFollowerCountInSubmitBox = function() {
 	var subscribed_users  = jQuery( '#ef-post_following_users_box li input:checkbox:checked' ).length;
 	var subscribed_groups = jQuery( '#ef-following_usergroups li input:checkbox:checked' ).length;
 
+	// Example: "1 user" or "23 users".
 	var users_message_part = '';
 	if ( subscribed_users > 0 ) {
 		if ( 1 === subscribed_users ) {
-			users_message_part = subscribed_users + ' user';
+			users_message_part = subscribed_users + ' ' + __ef_localize_notifications.user;
 		} else {
-			users_message_part = subscribed_users + ' users';
+			users_message_part = subscribed_users + ' ' + __ef_localize_notifications.users;
 		}
 	}
 
+	// Example: "1 user group" or "23 user groups".
 	var groups_message_part = '';
 	if ( subscribed_groups > 0 ) {
 		if ( 1 === subscribed_groups ) {
-			groups_message_part = subscribed_groups + ' user group';
+			groups_message_part = subscribed_groups + ' ' + __ef_localize_notifications.user_group;
 		} else {
-			groups_message_part = subscribed_groups + ' user groups';
+			groups_message_part = subscribed_groups + ' ' + __ef_localize_notifications.user_groups;
 		}
 	}
 
-	var message = 'none';
+	var message = __ef_localize_notifications.none;
 	if ( subscribed_users > 0 && subscribed_groups > 0 ) {
-		message = users_message_part + ' and ' + groups_message_part;
+		message = users_message_part + ' ' + __ef_localize_notifications.ampersand + ' ' + groups_message_part;
 	} else if ( subscribed_users > 0 || subscribed_groups > 0 ) {
 		// Only one will be displayed, the other is an empty string.
 		message = users_message_part + groups_message_part;

--- a/modules/notifications/lib/notifications.js
+++ b/modules/notifications/lib/notifications.js
@@ -51,42 +51,38 @@ jQuery(document).ready(function($) {
 });
 
 /**
- * Count the users and user groups who will be notified of a status change
- * Display the message in the submit box
+ * Display the number of users and user groups who will be notified of a status change in the submit box.
  */
 var ef_displayFollowerCountInSubmitBox = function() {
-	var checkedFollowers, checkedUserGroups, countDisplay, message = '', followerMessage = '', userGroupMessage = '',conjunction = '';
+	var message_wrapper   = jQuery( '#post-follower-count-display' );
+	var subscribed_users  = jQuery( '#ef-post_following_users_box li input:checkbox:checked' ).length;
+	var subscribed_groups = jQuery( '#ef-following_usergroups li input:checkbox:checked' ).length;
 
-	// Get checked checkboxes
-	checkedFollowers = jQuery('.ef-post_following_list li input:checkbox:checked');
-	checkedUserGroups = jQuery('#ef-following_usergroups li input:checkbox:checked');
-	// checkedFollowers includes user groups
-	userCount = checkedFollowers.length - checkedUserGroups.length;
-	userGroupCount = checkedUserGroups.length;
-
-	// The <span> within which the message will be displayed
-	countDisplay = jQuery('#post-follower-count-display');
-
-	// Create the individual messages
-	if (userCount > 0) {
-		followerMessage = userCount + ((userCount === 1) ? ' user' : ' users');
-	}
-	if (userGroupCount > 0) {
-		userGroupMessage = userGroupCount + ((userGroupCount === 1) ? ' user group' : ' user groups');
+	var users_message_part = '';
+	if ( subscribed_users > 0 ) {
+		if ( 1 === subscribed_users ) {
+			users_message_part = subscribed_users + ' user';
+		} else {
+			users_message_part = subscribed_users + ' users';
+		}
 	}
 
-	if (userCount > 0 && userGroupCount > 0) {
-		// Both will be displayed, so we need a conjunction
-		conjunction = ' & ';
-		message = (followerMessage + conjunction + userGroupMessage);
-	} else if (userCount > 0 || userGroupCount > 0) {
-		// Only one will be displayed, the other is an empty string
-		message = (followerMessage + userGroupMessage);
-	} else {
-		// Default message
-		message = 'none';
+	var groups_message_part = '';
+	if ( subscribed_groups > 0 ) {
+		if ( 1 === subscribed_groups ) {
+			groups_message_part = subscribed_groups + ' user group';
+		} else {
+			groups_message_part = subscribed_groups + ' user groups';
+		}
 	}
 
-	// Print the message
-	countDisplay.html(message);
+	var message = 'none';
+	if ( subscribed_users > 0 && subscribed_groups > 0 ) {
+		message = users_message_part + ' and ' + groups_message_part;
+	} else if ( subscribed_users > 0 || subscribed_groups > 0 ) {
+		// Only one will be displayed, the other is an empty string.
+		message = users_message_part + groups_message_part;
+	}
+
+	message_wrapper.text( message );
 };

--- a/modules/notifications/lib/notifications.js
+++ b/modules/notifications/lib/notifications.js
@@ -6,8 +6,11 @@ jQuery(document).ready(function($) {
 		post_id: $('#post_ID').val(),
 	};
 
-	// Display the user/group follower count in the post submit box
+	// Display the user/group follower count in the post submit box and watch for changes.
 	ef_displayFollowerCountInSubmitBox();
+	$( '#ef-post_following_box' ).on( 'following_list_updated', function() {
+		ef_displayFollowerCountInSubmitBox();
+	} );
 
 	$(document).on('click','.ef-post_following_list li input:checkbox, .ef-following_usergroups li input:checkbox', function() {
 		var user_group_ids = [];
@@ -30,9 +33,11 @@ jQuery(document).ready(function($) {
 			type : 'POST',
 			url : (ajaxurl) ? ajaxurl : wpListL10n.url,
 			data : params,
-			success : function(x) { 
-				// Update the user/group follower count in the post submit box
-				ef_displayFollowerCountInSubmitBox();
+			success : function(x) {
+
+				// This event is used to show an updated list of who will be notified of editorial comments and status updates.
+				$( '#ef-post_following_box' ).trigger( 'following_list_updated' );
+
 				var backgroundColor = parent_this.css( 'background-color' );
 				$(parent_this.parent().parent())
 					.animate( { 'backgroundColor':'#CCEEBB' }, 200 )

--- a/modules/notifications/notifications.php
+++ b/modules/notifications/notifications.php
@@ -191,7 +191,16 @@ class EF_Notifications extends EF_Module {
 		if ( $this->is_whitelisted_functional_view() ) {
 			wp_enqueue_script( 'jquery-listfilterizer' );
 			wp_enqueue_script( 'jquery-quicksearch' );
+
 			wp_enqueue_script( 'edit-flow-notifications-js', $this->module_url . 'lib/notifications.js', array( 'jquery', 'jquery-listfilterizer', 'jquery-quicksearch' ), EDIT_FLOW_VERSION, true );
+			wp_localize_script( 'edit-flow-notifications-js', '__ef_localize_notifications', array(
+				'none'        => esc_html__( 'none', 'edit-flow' ),
+				'ampersand'   => esc_html__( '&amp;', 'edit-flow' ),
+				'user'        => esc_html__( 'user', 'edit-flow' ),
+				'users'       => esc_html__( 'users', 'edit-flow' ),
+				'user_group'  => esc_html__( 'user group', 'edit-flow' ),
+				'user_groups' => esc_html__( 'user groups', 'edit-flow' ),
+			) );
 		}
 	}
 	

--- a/modules/notifications/notifications.php
+++ b/modules/notifications/notifications.php
@@ -78,7 +78,7 @@ class EF_Notifications extends EF_Module {
 		add_action( 'ef_post_insert_editorial_comment', array( $this, 'notification_comment') );
 		add_action( 'delete_user',  array($this, 'delete_user_action') );
 		add_action( 'ef_send_scheduled_email', array( $this, 'send_single_email' ), 10, 4 );
-		add_action( 'post_submitbox_misc_actions', array($this, 'submitbox_followers_message') );
+		add_action( 'post_submitbox_misc_actions', array( $this, 'submitbox_followers_message' ) );
 		
 		add_action( 'admin_init', array( $this, 'register_settings' ) );
 		
@@ -426,11 +426,11 @@ jQuery(document).ready(function($) {
 	 */
 	function submitbox_followers_message() {
 		?>
-		<hr>
-		<div class="misc-pub-section misc-pub-follower-count" id="follower-count"><?php _e('Followers', 'edit-flow'); ?>: <span id="post-follower-count-display"></span>
-			<a href="#edit-flow-notifications">
-				<span aria-hidden="true"><?php _e('Edit', 'edit-flow'); ?></span>
-				<span class="screen-reader-text"><?php _e('Edit followers', 'edit-flow'); ?></span>
+		<div class="misc-pub-section misc-pub-follower-count" id="follower-count">
+			<?php _e( 'Followers', 'edit-flow' ); ?>: <span id="post-follower-count-display"></span>
+			<a href="#edit-flow-notifications" class="hide-if-no-js" role="button">
+				<span aria-hidden="true"><?php esc_html_e( 'Edit', 'edit-flow' ); ?></span>
+				<span class="screen-reader-text"><?php esc_html_e( 'Edit followers', 'edit-flow' ); ?></span>
 			</a>
 		</div>
 		<?php


### PR DESCRIPTION
Part of #270. This PR started in #272, and is continued with some edits here.

To test:

1) Enable Subscribers feature.
2) Subscribe some users and/or groups to a post.
3) Check the posts submit box to ensure it shows the correct counts and updates accordingly.

Screenshots can be found in #272, as there weren't many changes to the display.