### PR TITLE
Capabilities: add capabilities via filters on VIP Go sites.

### DIFF
--- a/vipgo-helper.php
+++ b/vipgo-helper.php
@@ -5,6 +5,16 @@
 add_action( 'after_setup_theme', 'EditFlow' );
 
 /**
+ * Caps don't get loaded on install on VIP Go. Instead, let's add
+ * them via filters.
+ */
+add_filter( 'ef_kill_add_caps_to_role', '__return_true' );
+add_filter( 'ef_view_calendar_cap', function() {return 'edit_posts'; } );
+add_filter( 'ef_view_story_budget_cap', function() { return 'edit_posts'; } );
+add_filter( 'ef_edit_post_subscriptions_cap', function() { return 'edit_others_posts'; } );
+add_filter( 'ef_manage_usergroups_cap', function() { return 'manage_options'; } );
+
+/**
  * Edit Flow loads modules after plugins_loaded, which has already been fired when loading via wpcom_vip_load_plugins
  * Let's run the method at after_setup_themes
  */


### PR DESCRIPTION
In Edit Flow, we check for the `ef_view_story_budget` capability before to display some of the admin pages. The `ef_view_story_budget` capability should be given to admins, editors, and authors here:
- https://github.com/Automattic/Edit-Flow/blob/master/modules/story-budget/story-budget.php#L86-L101
- https://github.com/Automattic/Edit-Flow/blob/master/edit_flow.php#L194-L197

However, this does not get to run on VIP Go sites, thus leaving users without the custom caps necessary to access the different Edit Flow custom screens. To solve this, let's add all necessary caps via filters.

Reported in 76616-zd-wordpressvip