### PR TITLE
Story budget - Screen Option columns option fix

### DIFF
--- a/modules/story-budget/lib/story-budget.css
+++ b/modules/story-budget/lib/story-budget.css
@@ -30,17 +30,16 @@
 	font-size: 14px;
 }
 
-
-.postbox-container {
-	float: left;
-	padding-right: 0;
-}
-
 .postbox {
 	display: block;
-	margin-bottom: 10px;
-	margin-left: 10px;
-	margin-right: 10px;
+	margin: 0 auto 10px;
+	justify-content: space-between;
+}
+
+.postbox-container {
+	padding-right: 0;
+	display: flex;
+	flex-flow: row wrap;
 }
 
 .postbox .inside {

--- a/modules/story-budget/lib/story-budget.js
+++ b/modules/story-budget/lib/story-budget.js
@@ -18,33 +18,33 @@ jQuery(document).ready(function($) {
 	});
 
 	// Change number of columns when choosing a new number from Screen Options
-	//$("input[name=ef_story_budget_screen_columns]").click(function() {
-		var columnsSwitch = $("input[name=ef_story_budget_screen_columns]");
-		columnsSwitch.click(function() {
-			var numColumns = parseInt($(this).val());
-			var classPrefix = 'columns-number-';
-			$(".postbox-container").removeClass(function() {
-				for (var index = 1, c = []; index <= columnsSwitch.length; index++) {
-					c.push( classPrefix + index )
-				}
-				return c.join(' ');
-			}).addClass(classPrefix + numColumns);
-		});
-	//});
+
+	var columnsSwitch = $("input[name=ef_story_budget_screen_columns]");
+	columnsSwitch.click(function() {
+		var numColumns = parseInt($(this).val());
+		var classPrefix = 'columns-number-';
+		$(".postbox-container").removeClass(function() {
+			for (var index = 1, c = []; index <= columnsSwitch.length; index++) {
+				c.push( classPrefix + index )
+			}
+			return c.join(' ');
+		}).addClass(classPrefix + numColumns);
+	});
+
 	
-	jQuery('h2 a.change-date').click(function(){
-		jQuery(this).hide();
-		jQuery('h2 form .form-value').hide();
-		jQuery('h2 form input').show();
-		jQuery('h2 form a.change-date-cancel').show();
+	$('h2 a.change-date').click(function(){
+		$(this).hide();
+		$('h2 form .form-value').hide();
+		$('h2 form input').show();
+		$('h2 form a.change-date-cancel').show();
 		return false;
 	});
 	
-	jQuery('h2 form a.change-date-cancel').click(function(){
-		jQuery(this).hide();
-		jQuery('h2 form .form-value').show();
-		jQuery('h2 form input').hide();
-		jQuery('h2 form a.change-date').show();
+	$('h2 form a.change-date-cancel').click(function(){
+		$(this).hide();
+		$('h2 form .form-value').show();
+		$('h2 form input').hide();
+		$('h2 form a.change-date').show();
 		return false;
 	});
 });

--- a/modules/story-budget/lib/story-budget.js
+++ b/modules/story-budget/lib/story-budget.js
@@ -16,13 +16,21 @@ jQuery(document).ready(function($) {
 	$("h3.hndle,div.handlediv").click(function() {
 		$(this).parent().children("div.inside").toggle();
 	});
-	
+
 	// Change number of columns when choosing a new number from Screen Options
-	$("input[name=ef_story_budget_screen_columns]").click(function() {
-		var numColumns = $(this).val();
-		
-		jQuery(".postbox-container").css('width', (100 / numColumns) + '%' );
-	});
+	//$("input[name=ef_story_budget_screen_columns]").click(function() {
+		var columnsSwitch = $("input[name=ef_story_budget_screen_columns]");
+		columnsSwitch.click(function() {
+			var numColumns = parseInt($(this).val());
+			var classPrefix = 'columns-number-';
+			$(".postbox-container").removeClass(function() {
+				for (var index = 1, c = []; index <= columnsSwitch.length; index++) {
+					c.push( classPrefix + index )
+				}
+				return c.join(' ');
+			}).addClass(classPrefix + numColumns);
+		});
+	//});
 	
 	jQuery('h2 a.change-date').click(function(){
 		jQuery(this).hide();

--- a/modules/story-budget/story-budget.php
+++ b/modules/story-budget/story-budget.php
@@ -284,23 +284,25 @@ class EF_Story_Budget extends EF_Module {
 			<?php $this->print_messages(); ?>
 			<?php $this->table_navigation(); ?>
 			<div class="metabox-holder">
-			<?php
-				// Handle the calculation of terms to postbox-containers
-				$terms_per_container = ceil( count( $terms ) / $this->num_columns );
-				$term_index = 0;
-				// Show just one column if we've filtered to one term
-				if ( count( $this->terms ) == 1 )
-					$this->num_columns = 1;
-				for( $i = 1; $i <= $this->num_columns; $i++ ) {
-					echo '<div class="postbox-container" style="width:' . ( 100 / $this->num_columns ) . '%;">';
-					for( $j = 0; $j < $terms_per_container; $j++ ) {
-						if ( isset( $this->terms[$term_index] ) )
-							$this->print_term( $this->terms[$term_index] );
-						$term_index++;
+				<?php
+					echo '<div class="postbox-container columns-number-' . $this->num_columns . '">';
+					foreach( (array) $this->terms as $term ) {
+						$this->print_term( $term );
 					}
+
 					echo '</div>';
-				}
-			?>
+				?>
+				<style>
+					<?php
+					  for ( $i = 1; $i <= $this->max_num_columns; ++$i ) {
+						?>
+					.columns-number-<?php echo (int) $i; ?> .postbox {
+						flex-basis: <?php echo  99 / $i ?>%;
+					}
+					<?php
+				  }
+				?>
+				</style>
 			</div>
 		</div>
 		<?php

--- a/modules/story-budget/story-budget.php
+++ b/modules/story-budget/story-budget.php
@@ -285,7 +285,7 @@ class EF_Story_Budget extends EF_Module {
 			<?php $this->table_navigation(); ?>
 			<div class="metabox-holder">
 				<?php
-					echo '<div class="postbox-container columns-number-' . $this->num_columns . '">';
+					echo '<div class="postbox-container columns-number-' . absint( $this->num_columns ) . '">';
 					foreach( (array) $this->terms as $term ) {
 						$this->print_term( $term );
 					}


### PR DESCRIPTION
Made the changes discussed here: https://github.com/Automattic/Edit-Flow/pull/409#issuecomment-383417463

The old branch was no longer available so I created another PR. The only thing that I made different is that I added `columns-number-` in

```
echo '<div class="postbox-container columns-number-' . $this->num_columns . '">';
					foreach( (array) $this->terms as $term ) {
						$this->print_term( $term );
					}
```

because it wasn't working without this part. Basically, this is the initial number of columns that it's removed by this JS code:

```
$(".postbox-container").removeClass(function() {
				for (var index = 1, c = []; index <= columnsSwitch.length; index++) {
					c.push( classPrefix + index )
				}
				return c.join(' ');
			})
```

Everything else is just what you suggested.