### PR TITLE
Add a "No Access" badge to subscribers that will not be able to receive notifications

### DIFF
--- a/common/php/class-module.php
+++ b/common/php/class-module.php
@@ -473,8 +473,8 @@ class EF_Module {
 					<li>
 						<label for="<?php echo esc_attr( $input_id .'-'. $user->ID ) ?>">
 							<div class="ef-user-subscribe-actions">
-									<?php do_action( 'ef_user_subscribe_actions', $user->ID, $checked ) ?>
-									<input type="checkbox" id="<?php echo esc_attr( $input_id .'-'. $user->ID ) ?>" name="<?php echo esc_attr( $input_id ) ?>[]" value="<?php echo esc_attr( $user->ID ); ?>" <?php echo $checked; ?> />
+								<?php do_action( 'ef_user_subscribe_actions', $user->ID, $checked ) ?>
+								<input type="checkbox" id="<?php echo esc_attr( $input_id .'-'. $user->ID ) ?>" name="<?php echo esc_attr( $input_id ) ?>[]" value="<?php echo esc_attr( $user->ID ); ?>" <?php echo $checked; ?> />
 							</div>
 
 							<span class="ef-user_displayname"><?php echo esc_html( $user->display_name ); ?></span>

--- a/common/php/class-module.php
+++ b/common/php/class-module.php
@@ -472,7 +472,11 @@ class EF_Module {
 					<?php $checked = ( in_array($user->ID, $selected) ) ? 'checked="checked"' : ''; ?>
 					<li>
 						<label for="<?php echo esc_attr( $input_id .'-'. $user->ID ) ?>">
-							<input type="checkbox" id="<?php echo esc_attr( $input_id .'-'. $user->ID ) ?>" name="<?php echo esc_attr( $input_id ) ?>[]" value="<?php echo esc_attr( $user->ID ); ?>" <?php echo $checked; ?> />
+							<div class="ef-user-subscribe-actions">
+									<?php do_action( 'ef_user_subscribe_actions', $user->ID, $checked ) ?>
+									<input type="checkbox" id="<?php echo esc_attr( $input_id .'-'. $user->ID ) ?>" name="<?php echo esc_attr( $input_id ) ?>[]" value="<?php echo esc_attr( $user->ID ); ?>" <?php echo $checked; ?> />
+							</div>
+
 							<span class="ef-user_displayname"><?php echo esc_html( $user->display_name ); ?></span>
 							<span class="ef-user_useremail"><?php echo esc_html( $user->user_email ); ?></span>
 						</label>

--- a/modules/notifications/lib/notifications.css
+++ b/modules/notifications/lib/notifications.css
@@ -6,31 +6,46 @@
 	background-position: 5px 7px;
 }
 
-.ef-post_following_list {
+.ef-post_following_list li {
+	padding: 10px 5px 5px 5px;
+	margin: 0;
+	border-bottom: 1px solid #ccc;
+	min-height: 36px;
 }
 
-	.ef-post_following_list li {
-		padding: 10px 5px 5px 5px;
-		margin: 0;
-		border-bottom: 1px solid #ccc;
-	}
-		.ef-post_following_list li:hover {
-			background: #EAF2FA;
-		}
-	.ef-post_following_list li input {
-		float: right;
-	}
-	.ef-post_following_list .ef-user_displayname,
-	.ef-post_following_list .ef-usergroup_name {
-		display: block;
-		font-size: 14px;
-	}
-	.ef-post_following_list .ef-user_useremail,
-	.ef-post_following_list .ef-usergroup_description {
-		display: block;
-		color: #ccc;
-		font-size: 12px;
-	}
+.ef-post_following_list li:hover {
+	background: #EAF2FA;
+}
+
+.ef-post_following_list li input {
+	float: right;
+	margin-top: 0;
+}
+
+.ef-post_following_list .ef-user_displayname,
+.ef-post_following_list .ef-usergroup_name {
+	display: block;
+	font-size: 14px;
+}
+
+.ef-post_following_list .ef-user_useremail,
+.ef-post_following_list .ef-usergroup_description {
+	display: block;
+	color: #ccc;
+	font-size: 12px;
+}
+
+.ef-post_following_list li .ef-user-subscribe-actions {
+	float: right;
+	margin-top: 5px;
+}
+
+.ef-post_following_list li .ef-user-subscribe-actions span {
+	margin-right: 10px;
+	border: solid 2px #FFCCCC;
+	color: #FFCCCC;
+	padding: 4px;
+}
 
 #ef-post_following_box {
 	margin:10px 0;	

--- a/modules/notifications/lib/notifications.js
+++ b/modules/notifications/lib/notifications.js
@@ -11,7 +11,7 @@ jQuery(document).ready(function($) {
 			$( container ).siblings( 'span' ).remove();
 		} else if ( user_has_no_access ) {
 			var span = $( '<span />' );
-			span.text( 'No Access' );
+			span.text( ef_notifications_localization.no_access );
 			$( container ).parent().prepend( span );
 		}
 	}

--- a/modules/notifications/lib/notifications.js
+++ b/modules/notifications/lib/notifications.js
@@ -6,6 +6,16 @@ jQuery(document).ready(function($) {
 		post_id: $('#post_ID').val(),
 	};
 
+	var toggle_no_access_badge = function( container, user_has_no_access ) {
+		if ( $( container ).siblings( 'span' ).length ) {
+			$( container ).siblings( 'span' ).remove();
+		} else if ( user_has_no_access ) {
+			var span = $( '<span />' );
+			span.text( 'No Access' );
+			$( container ).parent().prepend( span );
+		}
+	}
+
 	$(document).on('click','.ef-post_following_list li input:checkbox, .ef-following_usergroups li input:checkbox', function() {
 		var user_group_ids = [];
 		var parent_this = $(this);
@@ -13,9 +23,7 @@ jQuery(document).ready(function($) {
 		params._nonce = $("#ef_notifications_nonce").val();
 
 		$(this)
-			.parent()
-			.parent()
-			.parent()
+			.parents('.ef-post_following_list')
 			.find('input:checked')
 			.map(function(){
 				user_group_ids.push($(this).val());
@@ -27,11 +35,17 @@ jQuery(document).ready(function($) {
 			type : 'POST',
 			url : (ajaxurl) ? ajaxurl : wpListL10n.url,
 			data : params,
-			success : function(x) { 
+			success : function( response ) { 
 				var backgroundColor = parent_this.css( 'background-color' );
-				$(parent_this.parent().parent())
+				$(parent_this.parents('li'))
 					.animate( { 'backgroundColor':'#CCEEBB' }, 200 )
 					.animate( { 'backgroundColor':backgroundColor }, 200 );
+
+					// Toggle the "No Access" badge if the selected user does not have access.
+					if ( undefined !== response.data ) {
+						var user_has_no_access = response.data.subscribers_with_no_access.includes( parseInt( $( parent_this ).val() ) );
+						toggle_no_access_badge( $( parent_this ), user_has_no_access );
+					}
 			},
 			error : function(r) { 
 				$('#ef-post_following_users_box').prev().append(' <p class="error">There was an error. Please reload the page.</p>');

--- a/modules/notifications/notifications.php
+++ b/modules/notifications/notifications.php
@@ -194,6 +194,13 @@ class EF_Notifications extends EF_Module {
 			wp_enqueue_script( 'jquery-listfilterizer' );
 			wp_enqueue_script( 'jquery-quicksearch' );
 			wp_enqueue_script( 'edit-flow-notifications-js', $this->module_url . 'lib/notifications.js', array( 'jquery', 'jquery-listfilterizer', 'jquery-quicksearch' ), EDIT_FLOW_VERSION, true );
+			wp_localize_script(
+				'edit-flow-notifications-js',
+				'ef_notifications_localization',
+				array(
+					'no_access' => esc_html__( 'No Access', 'edit-flow' )
+				)
+			);
 		}
 	}
 	


### PR DESCRIPTION
For https://github.com/Automattic/Edit-Flow/issues/451

Recap of what's being done in this PR:

1) Adds a "No Access" badge for users on page load. The permissions checks are only done for users that are already subscribed.
2) When users are selected and saved via ajax, the response sends back a list of checked user IDs that do not have access. Can then use this list to find out if the newly selected user needs the badge or not.

I prototyped a bit ahead, thinking of how #273 could be implemented. So some of the organization here had those changes in mind.

Also note that I added the `user_can_be_notified()` method in for testing purposes, but can remove/leave out when it comes to merging into the feature branch.

Screenshot:
![no-access](https://user-images.githubusercontent.com/8536129/39651916-5fa39662-4fb1-11e8-9d1f-44e4c577b0ee.png)
