### PR TITLE
Enlarged modules box up to 250px, so that buttons don't overlap anymore

### DIFF
--- a/modules/settings/lib/settings.css
+++ b/modules/settings/lib/settings.css
@@ -24,6 +24,8 @@
 	width: 100%;
 	overflow: hidden;
 	margin-top: 20px;
+	display: flex;
+	flex-wrap: wrap;
 }
 
 .edit-flow-modules .edit-flow-module {
@@ -89,6 +91,11 @@
 	box-shadow: none;
 	filter:  progid:DXImageTransform.Microsoft.gradient(startColorstr='#BBB', endColorstr='#888');
 	text-shadow: none;
+	float: right;
+}
+
+.edit-flow-modules .edit-flow-module .button-primary.enable-disable-edit-flow-module {
+	float: left;
 }
 
 .edit-flow-modules .edit-flow-module .button-primary.configure-edit-flow-module:hover {

--- a/modules/settings/lib/settings.css
+++ b/modules/settings/lib/settings.css
@@ -21,7 +21,6 @@
 }
 
 .edit-flow-modules {
-	min-width: 740px;
 	width: 100%;
 	overflow: hidden;
 	margin-top: 20px;

--- a/modules/settings/lib/settings.css
+++ b/modules/settings/lib/settings.css
@@ -28,7 +28,7 @@
 }
 
 .edit-flow-modules .edit-flow-module {
-	width: 210px;
+	width: 250px;
 	min-height: 150px;
 	position: relative;
 	float: left;
@@ -64,7 +64,7 @@
 	position: absolute;
 	bottom: 0px;
 	left: 10px;
-	width: 210px;
+	width: 250px;
 }
 
 .edit-flow-modules .edit-flow-module .button-primary {


### PR DESCRIPTION
Fix styling not being optimal on mobile devices (and small resolutions in general), as proposed in #361. 
In particular,
- Enlarged module boxes and button divs from 210px to 250px to prevent buttons from overlapping.
- Removed `min-width` property from modules container, which prevented the page from being fully adaptable to different resolutions.

Any viewer which is at least ~ 250px wide should see the page well. Tested with Chrome (with variable window size) and a mobile emulator. Now, if the viewer is not at least ~ 500px wide, module boxes are all stacked in a single column.

**Before CSS changes**

<img src="https://user-images.githubusercontent.com/7880569/40645086-90f7d80e-6325-11e8-9634-0896e6aa264b.png" width="300">

**After CSS changes**

<img src="https://user-images.githubusercontent.com/7880569/40645012-55943da2-6325-11e8-9e5c-2a88eb61e056.png" width="300">

