### PR TITLE
Changed $_REQUEST usage to $_POST usage in handle_notepad_update()

### DIFF
--- a/modules/dashboard/widgets/dashboard-notepad.php
+++ b/modules/dashboard/widgets/dashboard-notepad.php
@@ -35,7 +35,7 @@ class EF_Dashboard_Notepad_Widget {
 		global $pagenow;
 
 		if ( 'index.php' != $pagenow
-		|| ( empty( $_REQUEST['action'] ) || 'dashboard-notepad' != $_REQUEST['action'] ) )
+		|| ( empty( $_POST['action'] ) || 'dashboard-notepad' != $_POST['action'] ) )
 			return;
 
 		check_admin_referer( 'dashboard-notepad' );
@@ -43,17 +43,17 @@ class EF_Dashboard_Notepad_Widget {
 		if ( ! current_user_can( $this->edit_cap ) )
 			wp_die( EditFlow()->dashboard->messages['invalid-permissions'] );
 
-		$current_id = (int)$_REQUEST['notepad-id'];
+		$current_id = (int) $_POST['notepad-id'];
 		$current_notepad = get_post( $current_id );
 		$new_note = array(
-				'post_content'           => wp_filter_nohtml_kses( $_REQUEST['note'] ),
+				'post_content'           => wp_filter_nohtml_kses( $_POST['note'] ),
 				'post_type'              => self::notepad_post_type,
 				'post_status'            => 'draft',
 				'post_author'            => get_current_user_id(),
 			);
 		if ( $current_notepad
 			&& self::notepad_post_type == $current_notepad->post_type
-			&& ! isset ( $_REQUEST['create-note'] ) ) {
+			&& ! isset ( $_POST['create-note'] ) ) {
 			$new_note['ID'] = $current_id;
 			wp_update_post( $new_note );
 		} else {


### PR DESCRIPTION
The function `handle_notepad_update()` used to use `$_REQUEST`, which is [against best practices](https://vip.wordpress.com/documentation/code-review-what-we-look-for/#using-_request). 

Before #469, the form did not specify a method so it defaulted to GET. With #469, we changed the method to POST, so all references to `$_REQUEST` have been updated with the corresponding `$_POST` ones.

**NOTE** that this depends on #469, because it expects the HTML form to use the POST method, or the note saving will just not work.