### PR TITLE
Update EF_Notifications->notification_comment() to insert the list of users/groups who were notified

### DIFF
--- a/modules/notifications/notifications.php
+++ b/modules/notifications/notifications.php
@@ -658,12 +658,12 @@ jQuery(document).ready(function($) {
 		}
 		*/
 		
+		
+		$body .= "\r\n--------------------\r\n";
 		// Insert the notification list from comment meta @see EF_Editorial_Comments->maybe_output_comment_meta()
 		if ($notification_list) {
 			$body .= esc_html__( 'Notified', 'edit-flow' ) . ": $notification_list\n";
 		}
-		
-		$body .= "\r\n--------------------\r\n";
 		
 		$edit_link = htmlspecialchars_decode( get_edit_post_link( $post_id ) );
 		$view_link = htmlspecialchars_decode( get_permalink( $post_id ) );

--- a/modules/notifications/notifications.php
+++ b/modules/notifications/notifications.php
@@ -604,7 +604,7 @@ jQuery(document).ready(function($) {
 	 * Set up and set editorial comment notification email
 	 * 
 	 * @param WP_Comment $comment
-	 * @return boolean
+	 * @return boolean|null|void
 	 */
 	function notification_comment( $comment ) {
 		

--- a/modules/notifications/notifications.php
+++ b/modules/notifications/notifications.php
@@ -662,7 +662,7 @@ jQuery(document).ready(function($) {
 		$body .= "\r\n--------------------\r\n";
 		// Insert the notification list from comment meta @see EF_Editorial_Comments->maybe_output_comment_meta()
 		if ($notification_list) {
-			$body .= esc_html__( 'Notified', 'edit-flow' ) . ": $notification_list\n";
+			$body .= esc_html__( 'Notified', 'edit-flow' ) . ": " . esc_html( $notification_list ) . "\n";
 		}
 		
 		$edit_link = htmlspecialchars_decode( get_edit_post_link( $post_id ) );

--- a/modules/notifications/notifications.php
+++ b/modules/notifications/notifications.php
@@ -602,6 +602,9 @@ jQuery(document).ready(function($) {
 	
 	/**
 	 * Set up and set editorial comment notification email
+	 * 
+	 * @param WP_Comment $comment
+	 * @return boolean
 	 */
 	function notification_comment( $comment ) {
 		
@@ -621,7 +624,10 @@ jQuery(document).ready(function($) {
 		$post_id = $post->ID;
 		$post_type = get_post_type_object( $post->post_type )->labels->singular_name;
 		$post_title = ef_draft_or_post_title( $post_id );
-	
+
+		// Fetch the text list of people who were notified from comment meta @see EF_Editorial_Comments->maybe_output_comment_meta()
+		$notification_list = get_comment_meta( $comment->comment_ID, 'notification_list', true );
+
 		// Check if this a reply
 		//$parent_ID = isset( $comment->comment_parent_ID ) ? $comment->comment_parent_ID : 0;
 		//if($parent_ID) $parent = get_comment($parent_ID);
@@ -651,6 +657,11 @@ jQuery(document).ready(function($) {
 			
 		}
 		*/
+		
+		// Insert the notification list from comment meta @see EF_Editorial_Comments->maybe_output_comment_meta()
+		if ($notification_list) {
+			$body .= esc_html__( 'Notified', 'edit-flow' ) . ": $notification_list\n";
+		}
 		
 		$body .= "\r\n--------------------\r\n";
 		


### PR DESCRIPTION
For #478  

- Updates phpdoc to specify that $comment is WP_Comment
- Near the top, we fetch the list of users/groups from comment meta
- Before the "actions" list, we output the list of people who were notified

Note: This template could use so much love, but for now focusing on putting this new feature in a sensible place, with a plan to return and redesign the template later.