### PR TITLE
settings.css - remove green color on module-enabling button-primary buttons

### DIFF
--- a/modules/settings/lib/settings.css
+++ b/modules/settings/lib/settings.css
@@ -67,15 +67,6 @@
 	width: 210px;
 }
 
-.edit-flow-modules .edit-flow-module .button-primary {
-	color: #f1f1f1;
-	border: solid 1px #538312;
-	background: #64991e;
-	background: -webkit-gradient(linear, left top, left bottom, from(#86C67C), to(#3D8B37));
-	background: -moz-linear-gradient(top,  #86C67C,  #3D8B37);
-	filter:  progid:DXImageTransform.Microsoft.gradient(startColorstr='#86C67C', endColorstr='#3D8B37');
-}
-
 .edit-flow-modules .edit-flow-module .button-primary:hover {
 	color: #FFFFFF;
 	border-color: #3B5D0C;


### PR DESCRIPTION
For #480 

The green color doesn't make a lot of sense, and has had an ugly blue shadow for a long time.

Why not remove the green entirely? It looks good with blue buttons, and won't cause headaches in the future if button-primary changes again.