### PR TITLE
 Scope module assets ( v2 )

### DIFF
--- a/common/php/class-module-with-view.php
+++ b/common/php/class-module-with-view.php
@@ -1,0 +1,181 @@
+<?php
+
+
+class EF_Module_With_View extends EF_Module {
+
+
+	/**
+	 * Whether or not the current page is an Edit Flow settings view (either main or module)
+	 * Determination is based on $pagenow, $_GET['page'], and the module's $settings_slug
+	 * If there's no module name specified, it will return true against all Edit Flow settings views
+	 *
+	 * @since 0.8.3
+	 *
+	 * @param string $slug (Optional) Module name to check against
+	 * @return bool true if is module settings view
+	 */
+	public function is_module_settings_view( $slug = false ) {
+		global $pagenow, $edit_flow;
+
+		// All of the settings views are based on admin.php and a $_GET['page'] parameter
+		if ( $pagenow !== 'admin.php' || ! isset( $_GET['page'] ) )
+			return false;
+
+		$settings_view_slugs = array();
+		// Load all of the modules that have a settings slug/ callback for the settings page
+		foreach ( $edit_flow->modules as $mod_name => $mod_data ) {
+			if ( isset( $mod_data->options->enabled ) && $mod_data->options->enabled == 'on' && $mod_data->configure_page_cb )
+				$settings_view_slugs[] = $mod_data->settings_slug;
+		}
+
+		// The current page better be in the array of registered settings view slugs
+		if ( empty( $settings_view_slugs ) || ! in_array( $_GET['page'], $settings_view_slugs ) ) {
+			return false;
+		}
+
+		if ( $slug && $edit_flow->modules->{$slug}->settings_slug !== $_GET['page'] ) {
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Check whether if we're at module settings view
+	 * for the current module based on `is_module_settings_view` method
+	 *
+	 * @return bool
+	 */
+	public function is_current_module_settings_view() {
+		return $this->is_module_settings_view( $this->module->name );
+	}
+
+
+	/**
+	 * Check for admin page and whether the current post type is supported
+	 * @param array $allowed_pages
+	 *
+	 * @return bool
+	 */
+	function is_active_view( $allowed_pages = array( 'edit.php', 'post.php', 'post-new.php' ) ) {
+		return ( $this->is_admin_page( $allowed_pages ) && $this->is_supported_post_type() );
+	}
+
+
+	/**
+	 * Check whether the current post type is supported for $this module
+	 *
+	 * @return bool
+	 */
+	public function is_supported_post_type() {
+		$post_type = $this->get_current_post_type();
+
+		return (
+			$post_type
+			&&
+			in_array( $post_type, $this->get_post_types_for_module( $this->module ), true )
+		);
+	}
+
+	/**
+	 * Checks for the current post type
+	 *
+	 * @since 0.7
+	 * @return string|null $post_type The post type we've found, or null if no post type
+	 */
+	function get_current_post_type() {
+		global $post, $typenow, $pagenow, $current_screen;
+		//get_post() needs a variable
+		$post_id = isset( $_REQUEST['post'] ) ? (int) $_REQUEST['post'] : false;
+
+		if ( $post && $post->post_type ) {
+			$post_type = $post->post_type;
+		} elseif ( $typenow ) {
+			$post_type = $typenow;
+		} elseif ( $current_screen && ! empty( $current_screen->post_type ) ) {
+			$post_type = $current_screen->post_type;
+		} elseif ( isset( $_REQUEST['post_type'] ) ) {
+			$post_type = sanitize_key( $_REQUEST['post_type'] );
+		} elseif ( 'post.php' == $pagenow
+		           && $post_id
+		           && ! empty( get_post( $post_id )->post_type ) ) {
+			$post_type = get_post( $post_id )->post_type;
+		} elseif ( in_array( $pagenow, array('edit.php', 'post-new.php' ) ) && empty( $_REQUEST['post_type'] ) ) {
+			$post_type = 'post';
+		} else {
+			$post_type = null;
+		}
+
+		return $post_type;
+	}
+
+	/**
+	 * Check whether currently viewing the desired admin page
+	 *
+	 * @param array $allowed_pages
+	 *
+	 * @return bool
+	 */
+	public function is_admin_page( $allowed_pages = array( 'edit.php', 'post.php', 'post-new.php' ) ) {
+		global $pagenow;
+
+		return ( $pagenow && in_array( $pagenow, $allowed_pages, true ) );
+	}
+
+
+	/**
+	 * Shorthand for `is_active_view` to check for list type views ( list of posts pages, custom post types )
+	 *
+	 * @see is_active_view
+	 * @return bool
+	 */
+	public function is_active_list_view() {
+		return $this->is_active_view( array( 'edit.php' ) );
+	}
+
+	/**
+	 * Shorthand for `is_active_view` to check for editor mode
+	 *
+	 * @see is_active_view
+	 * @return bool
+	 */
+	public function is_active_editor_view() {
+		return $this->is_active_view( array( 'post.php', 'posts-new.php' ) );
+	}
+
+
+	/**
+	 * This method was supposed to check whether or not the current page is a user-facing Edit Flow View
+	 * But it was never implemented
+	 *
+	 * It is now deprecated in favor of `$this->is_active_view`
+	 * @see        EF_Module::is_active_view()
+	 * @since      0.7
+	 * @deprecated 0.8.3
+	 *
+	 * @param string $module_name (Optional) Module name to check against
+	 */
+	public function is_whitelisted_functional_view( $module_name = null ) {
+		_deprecated_function( __FUNCTION__, '0.8.3', 'is_active_view' );
+
+		return true;
+	}
+
+	/**
+	 * Whether or not the current page is an Edit Flow settings view (either main or module)
+	 * Determination is based on $pagenow, $_GET['page'], and the module's $settings_slug
+	 * If there's no module name specified, it will return true against all Edit Flow settings views
+	 *
+	 * @since 0.7
+	 * @deprecated 0.8.3
+	 *
+	 * @param string $module_name (Optional) Module name to check against
+	 * @return bool $is_settings_view Return true if it is
+	 */
+	public function is_whitelisted_settings_view( $module_name = null ) {
+		_deprecated_function( 'is_whitelisted_settings_view', '0.8.3', 'is_module_settings_view' );
+
+		return $this->is_module_settings_view( $module_name );
+	}
+
+}

--- a/common/php/class-module.php
+++ b/common/php/class-module.php
@@ -208,38 +208,7 @@ class EF_Module {
 		wp_enqueue_style( 'jquery-ui-theme', EDIT_FLOW_URL . 'common/css/jquery.ui.theme.css', false, EDIT_FLOW_VERSION, 'screen' );
 	}
 	
-	/**
-	 * Checks for the current post type
-	 *
-	 * @since 0.7
-	 * @return string|null $post_type The post type we've found, or null if no post type
-	 */
-	function get_current_post_type() {
-		global $post, $typenow, $pagenow, $current_screen;
-		//get_post() needs a variable
-		$post_id = isset( $_REQUEST['post'] ) ? (int)$_REQUEST['post'] : false;
 
-		if ( $post && $post->post_type ) {
-			$post_type = $post->post_type;
-		} elseif ( $typenow ) {
-			$post_type = $typenow;
-		} elseif ( $current_screen && !empty( $current_screen->post_type ) ) {
-			$post_type = $current_screen->post_type;
-		} elseif ( isset( $_REQUEST['post_type'] ) ) {
-			$post_type = sanitize_key( $_REQUEST['post_type'] );
-		} elseif ( 'post.php' == $pagenow
-			&& $post_id
-			&& !empty( get_post( $post_id )->post_type ) ) {
-			$post_type = get_post( $post_id )->post_type;
-		} elseif ( 'edit.php' == $pagenow && empty( $_REQUEST['post_type'] ) ) {
-			$post_type = 'post';
-		} else {
-			$post_type = null;
-		}
-
-		return $post_type;
-	}
-	
 	/**
 	 * Wrapper for the get_user_meta() function so we can replace it if we need to
 	 *
@@ -295,55 +264,6 @@ class EF_Module {
 		echo json_encode( array( 'status' => $status, 'message' => $message ) );
 		exit;
 	}
-	
-	/**
-	 * Whether or not the current page is a user-facing Edit Flow View
-	 * @todo Think of a creative way to make this work
-	 *
-	 * @since 0.7
-	 *
-	 * @param string $module_name (Optional) Module name to check against
-	 */
-	function is_whitelisted_functional_view( $module_name = null ) {
-		
-		// @todo complete this method
-		
-		return true;
-	}
-	
-	/**
-	 * Whether or not the current page is an Edit Flow settings view (either main or module)
-	 * Determination is based on $pagenow, $_GET['page'], and the module's $settings_slug
-	 * If there's no module name specified, it will return true against all Edit Flow settings views
-	 *
-	 * @since 0.7
-	 *
-	 * @param string $module_name (Optional) Module name to check against
-	 * @return bool $is_settings_view Return true if it is
-	 */
-	function is_whitelisted_settings_view( $module_name = null ) {
-		global $pagenow, $edit_flow;
-		
-		// All of the settings views are based on admin.php and a $_GET['page'] parameter
-		if ( $pagenow != 'admin.php' || !isset( $_GET['page'] ) )
-			return false;
-		
-		// Load all of the modules that have a settings slug/ callback for the settings page
-		foreach ( $edit_flow->modules as $mod_name => $mod_data ) {
-			if ( isset( $mod_data->options->enabled ) && $mod_data->options->enabled == 'on' && $mod_data->configure_page_cb )
-				$settings_view_slugs[] = $mod_data->settings_slug;
-		}
-	
-		// The current page better be in the array of registered settings view slugs
-		if ( !in_array( $_GET['page'], $settings_view_slugs ) )
-			return false;
-		
-		if ( $module_name && $edit_flow->modules->$module_name->settings_slug != $_GET['page'] )
-			return false;
-			
-		return true;
-	}
-	
 	
 	/**
 	 * This is a hack, Hack, HACK!!!
@@ -573,6 +493,7 @@ class EF_Module {
 			wp_update_term( $term->term_id, $taxonomy, array( 'description' => $new_description ) );
 		}
 	}
-	
+
+
 }
 }

--- a/edit_flow.php
+++ b/edit_flow.php
@@ -93,7 +93,14 @@ class edit_flow {
 
 		// Edit Flow base module
 		require_once( EDIT_FLOW_ROOT . '/common/php/class-module.php' );
-		
+
+		/*
+		 * Include interfaces:
+		 */
+		require_once( EDIT_FLOW_ROOT . '/interfaces/EF_Script_Interface.php' );
+		require_once( EDIT_FLOW_ROOT . '/interfaces/EF_Style_Interface.php' );
+		require_once( EDIT_FLOW_ROOT . '/common/php/class-module-with-view.php' );
+
 		// Scan the modules directory and include any modules that exist there
 		$module_dirs = scandir( EDIT_FLOW_ROOT . '/modules/' );
 		$class_names = array();

--- a/interfaces/EF_Script_Interface.php
+++ b/interfaces/EF_Script_Interface.php
@@ -1,0 +1,9 @@
+<?php
+
+/**
+ * Interface EF_Script_Interface
+ * A very simple interface tor equire a method `enqueue_admin_scripts()`
+ */
+interface EF_Script_Interface {
+	public function enqueue_admin_scripts();
+}

--- a/interfaces/EF_Style_Interface.php
+++ b/interfaces/EF_Style_Interface.php
@@ -1,0 +1,9 @@
+<?php
+
+/**
+ * Interface EF_Style_Interface
+ * A very simple interface tor equire a method `enqueue_admin_styles()`
+ */
+interface EF_Style_Interface {
+	public function enqueue_admin_styles();
+}

--- a/modules/calendar/calendar.php
+++ b/modules/calendar/calendar.php
@@ -7,7 +7,7 @@
  */
 if ( !class_exists('EF_Calendar') ) {
 
-class EF_Calendar extends EF_Module {
+class EF_Calendar extends EF_Module_With_View implements EF_Style_Interface, EF_Script_Interface {
 	
 	const usermeta_key_prefix = 'ef_calendar_';
 	const screen_id = 'dashboard_page_calendar';
@@ -91,7 +91,7 @@ class EF_Calendar extends EF_Module {
 		
 		add_action( 'admin_init', array( $this, 'register_settings' ) );
 		add_action( 'admin_menu', array( $this, 'action_admin_menu' ) );
-		add_action( 'admin_print_styles', array( $this, 'add_admin_styles' ) );
+		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_admin_styles' ) );
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_admin_scripts' ) );
 		
 		// Ajax manipulation for the calendar
@@ -173,10 +173,11 @@ class EF_Calendar extends EF_Module {
 	 *
 	 * @uses wp_enqueue_style()
 	 */
-	function add_admin_styles() {
-		global $pagenow;
-		// Only load calendar styles on the calendar page
-		if ( $pagenow == 'index.php' && isset( $_GET['page'] ) && $_GET['page'] == 'calendar' )
+	public function enqueue_admin_styles() {
+		if ( ! $this->is_calendar_view() ) {
+			return;
+		}
+
 			wp_enqueue_style( 'edit-flow-calendar-css', $this->module_url . 'lib/calendar.css', false, EDIT_FLOW_VERSION );
 	}
 	
@@ -188,9 +189,12 @@ class EF_Calendar extends EF_Module {
 	 */
 	function enqueue_admin_scripts() {
 
+		if ( ! $this->is_calendar_view() ) {
+			return;
+		}
+
 		$this->enqueue_datepicker_resources();
 		
-		if ( $this->is_whitelisted_functional_view() ) {
 			$js_libraries = array(
 				'jquery',
 				'jquery-ui-core',
@@ -198,6 +202,7 @@ class EF_Calendar extends EF_Module {
 				'jquery-ui-draggable',
 				'jquery-ui-droppable',
 			);
+
 			foreach( $js_libraries as $js_library ) {
 				wp_enqueue_script( $js_library );
 			}
@@ -205,7 +210,7 @@ class EF_Calendar extends EF_Module {
 			
 			$ef_cal_js_params = array( 'can_add_posts' => current_user_can( $this->create_post_cap ) ? 'true' : 'false' );
 			wp_localize_script( 'edit-flow-calendar-js', 'ef_calendar_params', $ef_cal_js_params );
-		}
+
 		
 	}
 	
@@ -1851,6 +1856,12 @@ class EF_Calendar extends EF_Module {
 		clean_post_cache( $post_ID );
 	}
 	
+
+	public function is_calendar_view() {
+		global $pagenow;
+
+		return ( 'index.php' === $pagenow && isset( $_GET['page'] ) && $_GET['page'] === 'calendar' );
+	}
 } // EF_Calendar
 	
 } // class_exists('EF_Calendar')

--- a/modules/editorial-metadata/editorial-metadata.php
+++ b/modules/editorial-metadata/editorial-metadata.php
@@ -20,7 +20,8 @@
  */
 if ( !class_exists('EF_Editorial_Metadata') ) {
 
-class EF_Editorial_Metadata extends EF_Module {
+class EF_Editorial_Metadata extends EF_Module_With_View implements EF_Style_Interface, EF_Script_Interface {
+
 
 	/**
 	 * The name of the taxonomy we're going to register for editorial metadata.
@@ -116,7 +117,7 @@ class EF_Editorial_Metadata extends EF_Module {
 		}		
 		
 		// Load necessary scripts and stylesheets
-		add_action( 'admin_enqueue_scripts', array( $this, 'add_admin_scripts' ) );	
+		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_admin_styles' ) );
 		
 	}
 	
@@ -229,21 +230,18 @@ class EF_Editorial_Metadata extends EF_Module {
 	/**
 	 * Enqueue relevant admin Javascript
 	 */ 
-	function add_admin_scripts() {
-		global $current_screen, $pagenow;
-		
+	function enqueue_admin_styles() {
 		// Add the metabox date picker JS and CSS
-		$current_post_type = $this->get_current_post_type();
-		$supported_post_types = $this->get_post_types_for_module( $this->module );
-		if ( in_array( $current_post_type, $supported_post_types ) ) {
+		if ( $this->is_active_editor_view() ) {
 			$this->enqueue_datepicker_resources();
 
 			// Now add the rest of the metabox CSS
 			wp_enqueue_style( 'edit_flow-editorial_metadata-styles', $this->module_url . 'lib/editorial-metadata.css', false, EDIT_FLOW_VERSION, 'all' );
 		}
 		// A bit of custom CSS for the Manage Posts view if we have viewable metadata
-		if ( $current_screen->base == 'edit' && in_array( $current_post_type, $supported_post_types ) ) {
+		if ( $this->is_active_list_view() ) {
 			$terms = $this->get_editorial_metadata_terms();
+
 			$viewable_terms = array();
 			foreach( $terms as $term ) {
 				if ( $term->viewable ) 
@@ -298,9 +296,14 @@ class EF_Editorial_Metadata extends EF_Module {
 			
 		}
 		
+
+	}
+
+
+	public function enqueue_admin_scripts() {
 		// Load Javascript specific to the editorial metadata configuration view
-		if ( $this->is_whitelisted_settings_view( $this->module->name ) ) {
-			wp_enqueue_script( 'jquery-ui-sortable' );			
+		if ( $this->is_current_module_settings_view() ) {
+			wp_enqueue_script( 'jquery-ui-sortable' );
 			wp_enqueue_script( 'edit-flow-editorial-metadata-configure', EDIT_FLOW_URL . 'modules/editorial-metadata/lib/editorial-metadata-configure.js', array( 'jquery', 'jquery-ui-sortable', 'edit-flow-settings-js' ), EDIT_FLOW_VERSION, true );
 		}
 	}
@@ -1555,7 +1558,7 @@ class EF_Editorial_Metadata extends EF_Module {
 		<?php
 		endif;
 	}
-	
+
 }
 
 }

--- a/modules/notifications/notifications.php
+++ b/modules/notifications/notifications.php
@@ -9,8 +9,8 @@ if( ! defined( 'EF_NOTIFICATION_USE_CRON' ) )
 
 if ( !class_exists('EF_Notifications') ) {
 
-class EF_Notifications extends EF_Module {
-	
+class EF_Notifications extends EF_Module_With_View implements EF_Style_Interface, EF_Script_Interface {
+
 	// Taxonomy name used to store users following posts
 	var $following_users_taxonomy = 'following_users';
 	// Taxonomy name used to store user groups following posts
@@ -189,8 +189,7 @@ class EF_Notifications extends EF_Module {
 	 * @uses wp_enqueue_script()
 	 */
 	function enqueue_admin_scripts() {
-		
-		if ( $this->is_whitelisted_functional_view() ) {
+		if ( $this->is_active_editor_view() || $this->is_current_module_settings_view() ) {
 			wp_enqueue_script( 'jquery-listfilterizer' );
 			wp_enqueue_script( 'jquery-quicksearch' );
 			wp_enqueue_script( 'edit-flow-notifications-js', $this->module_url . 'lib/notifications.js', array( 'jquery', 'jquery-listfilterizer', 'jquery-quicksearch' ), EDIT_FLOW_VERSION, true );
@@ -212,8 +211,7 @@ class EF_Notifications extends EF_Module {
 	 * @uses wp_enqueue_style()	
 	 */
 	function enqueue_admin_styles() {
-		
-		if ( $this->is_whitelisted_functional_view() || $this->is_whitelisted_settings_view() ) {
+		if ( $this->is_active_editor_view() || $this->is_module_settings_view() ) {
 			wp_enqueue_style( 'jquery-listfilterizer' );
 			wp_enqueue_style( 'edit-flow-notifications-css', $this->module->module_url . 'lib/notifications.css', false, EDIT_FLOW_VERSION );
 		}

--- a/modules/settings/settings.php
+++ b/modules/settings/settings.php
@@ -2,8 +2,8 @@
 
 if ( !class_exists('EF_Settings') ) {
 
-class EF_Settings extends EF_Module {
-	
+class EF_Settings extends EF_Module_With_View {
+
 	var $module;
 	
 	/**
@@ -65,7 +65,7 @@ class EF_Settings extends EF_Module {
 	
 	function action_admin_enqueue_scripts() {
 		
-		if ( $this->is_whitelisted_settings_view() )
+		if ( $this->is_module_settings_view() )
 			wp_enqueue_script( 'edit-flow-settings-js', $this->module_url . 'lib/settings.js', array( 'jquery' ), EDIT_FLOW_VERSION, true );
 			
 	}
@@ -75,7 +75,7 @@ class EF_Settings extends EF_Module {
 	 */
 	function action_admin_print_styles() {		
 		
-		if ( $this->is_whitelisted_settings_view() )
+		if ( $this->is_module_settings_view() )
 			wp_enqueue_style( 'edit_flow-settings-css', $this->module_url . 'lib/settings.css', false, EDIT_FLOW_VERSION );
 		
 		

--- a/modules/story-budget/story-budget.php
+++ b/modules/story-budget/story-budget.php
@@ -5,8 +5,8 @@
  *
  * @author sbressler
  */
-class EF_Story_Budget extends EF_Module {
-	
+class EF_Story_Budget extends EF_Module_With_View implements EF_Style_Interface, EF_Script_Interface {
+
 	var $taxonomy_used = 'category';
 	
 	var $module;
@@ -75,7 +75,7 @@ class EF_Story_Budget extends EF_Module {
 		add_action( 'admin_menu', array( $this, 'action_admin_menu' ) );
 		// Load necessary scripts and stylesheets
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_admin_scripts' ) );
-		add_action( 'admin_enqueue_scripts', array( $this, 'action_enqueue_admin_styles' ) );
+		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_admin_styles' ) );
 		
 	}
 	
@@ -129,36 +129,43 @@ class EF_Story_Budget extends EF_Module {
 	function action_admin_menu() {
 		add_submenu_page( 'index.php', __('Story Budget', 'edit-flow'), __('Story Budget', 'edit-flow'), apply_filters( 'ef_view_story_budget_cap', 'ef_view_story_budget' ), $this->module->slug, array( $this, 'story_budget') );
 	}
-	
+
 	/**
 	 * Enqueue necessary admin scripts only on the story budget page.
 	 *
 	 * @uses enqueue_admin_script()
 	 */
 	function enqueue_admin_scripts() {
-		global $current_screen;
-		
-		if ( $current_screen->id != self::screen_id )
-			return;
-		
-		$num_columns = $this->get_num_columns();
-		echo '<script type="text/javascript"> var ef_story_budget_number_of_columns="' . esc_js( $this->num_columns ) . '";</script>';
-		
-		$this->enqueue_datepicker_resources();
-		wp_enqueue_script( 'edit_flow-story_budget', $this->module_url . 'lib/story-budget.js', array( 'edit_flow-date_picker' ), EDIT_FLOW_VERSION, true );
+
+		if ( $this->is_story_board_view() ) {
+			$num_columns = $this->get_num_columns();
+			echo '<script type="text/javascript"> var ef_story_budget_number_of_columns="' . esc_js( $this->num_columns ) . '";</script>';
+
+			$this->enqueue_datepicker_resources();
+			wp_enqueue_script( 'edit_flow-story_budget', $this->module_url . 'lib/story-budget.js', array( 'edit_flow-date_picker' ), EDIT_FLOW_VERSION, true );
+		}
+
 	}
 	
 	/**
 	 * Enqueue a screen and print stylesheet for the story budget.
 	 */
-	function action_enqueue_admin_styles() {
+	function enqueue_admin_styles() {
+		if( $this->is_story_board_view() ) {
+			wp_enqueue_style( 'edit_flow-story_budget-styles', $this->module_url . 'lib/story-budget.css', false, EDIT_FLOW_VERSION, 'screen' );
+			wp_enqueue_style( 'edit_flow-story_budget-print-styles', $this->module_url . 'lib/story-budget-print.css', false, EDIT_FLOW_VERSION, 'print' );
+		}
+	}
+
+
+	/**
+	 * Check whether current view is relavant to this module
+	 *
+	 * @return bool
+	 */
+	public function is_story_board_view() {
 		global $current_screen;
-		
-		if ( $current_screen->id != self::screen_id )
-			return;
-		
-		wp_enqueue_style( 'edit_flow-story_budget-styles', $this->module_url . 'lib/story-budget.css', false, EDIT_FLOW_VERSION, 'screen' );
-		wp_enqueue_style( 'edit_flow-story_budget-print-styles', $this->module_url . 'lib/story-budget-print.css', false, EDIT_FLOW_VERSION, 'print' );
+		return ( $current_screen->id === self::screen_id );
 	}
 	
 	/**

--- a/modules/user-groups/user-groups.php
+++ b/modules/user-groups/user-groups.php
@@ -11,7 +11,7 @@
 
 if ( !class_exists( 'EF_User_Groups' ) ) {
 
-class EF_User_Groups extends EF_Module {
+class EF_User_Groups extends EF_Module_With_View implements EF_Style_Interface, EF_Script_Interface {
 	
 	var $module;
 	
@@ -223,32 +223,32 @@ class EF_User_Groups extends EF_Module {
 	 * Enqueue necessary admin scripts
 	 *
 	 * @since 0.7
+	 * @updated 0.8.3
 	 *
 	 * @uses wp_enqueue_script()
 	 */
 	function enqueue_admin_scripts() {
-		
-		if ( $this->is_whitelisted_functional_view() || $this->is_whitelisted_settings_view( $this->module->name ) ) {
+
+		if ( $this->is_current_module_settings_view() ) {
 			wp_enqueue_script( 'jquery-listfilterizer' );
 			wp_enqueue_script( 'jquery-quicksearch' );
 			wp_enqueue_script( 'edit-flow-user-groups-js', $this->module_url . 'lib/user-groups.js', array( 'jquery', 'jquery-listfilterizer', 'jquery-quicksearch' ), EDIT_FLOW_VERSION, true );
-		}
-			
-		if ( $this->is_whitelisted_settings_view( $this->module->name ) )	
 			wp_enqueue_script( 'edit-flow-user-groups-configure-js', $this->module_url . 'lib/user-groups-configure.js', array( 'jquery' ), EDIT_FLOW_VERSION, true );
+		}
+
 	}
 	
 	/**
 	 * Enqueue necessary admin styles, but only on the proper pages
 	 *
 	 * @since 0.7
+	 * @updated 0.8.3
 	 *
 	 * @uses wp_enqueue_style()	
 	 */
 	function enqueue_admin_styles() {
 
-		
-		if ( $this->is_whitelisted_functional_view() || $this->is_whitelisted_settings_view() ) {
+		if ( $this->is_current_module_settings_view() ) {
 			wp_enqueue_style( 'jquery-listfilterizer' );
 			wp_enqueue_style( 'edit-flow-user-groups-css', $this->module_url . 'lib/user-groups.css', false, EDIT_FLOW_VERSION );
 		}
@@ -1070,7 +1070,8 @@ class EF_User_Groups extends EF_Module {
 			return false;
 		}
 	}
-	
+
+
 }
 
 }

--- a/tests/test-edit-flow-with-view-class-module.php
+++ b/tests/test-edit-flow-with-view-class-module.php
@@ -1,9 +1,9 @@
 <?php
 
-class WP_Test_Edit_Flow_Class_Module extends WP_UnitTestCase {
+class WP_Test_Edit_Flow_With_View_Class_Module extends WP_UnitTestCase {
 
 	protected static $admin_user_id;
-	protected static $EditFlowModule;
+	protected static $EF_Module_With_View;
 
 	public static function wpSetUpBeforeClass( $factory ) {
 		self::$admin_user_id = $factory->user->create( array( 'role' => 'administrator' ) );
@@ -21,13 +21,13 @@ class WP_Test_Edit_Flow_Class_Module extends WP_UnitTestCase {
 	function setUp() {
 		parent::setUp();
 		
-		self::$EditFlowModule = new EF_Module();
+		self::$EF_Module_With_View = new EF_Module_With_View();
 
 		$this->_flush_roles();
 	}
 
 	function tearDown() {
-		self::$EditFlowModule = null;
+		self::$EF_Module_With_View = null;
 	}
 	
 	function test_add_caps_to_role() {
@@ -36,7 +36,7 @@ class WP_Test_Edit_Flow_Class_Module extends WP_UnitTestCase {
 		);
 
 		foreach( $usergroup_roles as $role => $caps ) {
-			self::$EditFlowModule->add_caps_to_role( $role, $caps );
+			self::$EF_Module_With_View->add_caps_to_role( $role, $caps );
 		}
 
 		$user = new WP_User( self::$admin_user_id );
@@ -52,7 +52,7 @@ class WP_Test_Edit_Flow_Class_Module extends WP_UnitTestCase {
 	function test_current_post_type_post_type_set() {
 		$_REQUEST['post_type'] = 'not-real';
 
-		$this->assertEquals( 'not-real', self::$EditFlowModule->get_current_post_type() );
+		$this->assertEquals( 'not-real', self::$EF_Module_With_View->get_current_post_type() );
 	}
 
 	function test_current_post_type_post_screen() {
@@ -64,7 +64,7 @@ class WP_Test_Edit_Flow_Class_Module extends WP_UnitTestCase {
 
 		$_REQUEST['post'] = $post_id; 
 
-		$this->assertEquals( 'post', self::$EditFlowModule->get_current_post_type() );
+		$this->assertEquals( 'post', self::$EF_Module_With_View->get_current_post_type() );
 
 		unset( $_REQUEST['post_type'] );
 		set_current_screen( 'front' );
@@ -73,7 +73,7 @@ class WP_Test_Edit_Flow_Class_Module extends WP_UnitTestCase {
 	function test_current_post_type_edit_screen() {
 		set_current_screen( 'edit.php' );		
 
-		$this->assertEquals( 'post', self::$EditFlowModule->get_current_post_type() );
+		$this->assertEquals( 'post', self::$EF_Module_With_View->get_current_post_type() );
 
 		set_current_screen( 'front' );
 	}
@@ -82,7 +82,7 @@ class WP_Test_Edit_Flow_Class_Module extends WP_UnitTestCase {
 		register_post_type( 'content' );
 		set_current_screen( 'content' );
 
-		$this->assertEquals( 'content', self::$EditFlowModule->get_current_post_type() );
+		$this->assertEquals( 'content', self::$EF_Module_With_View->get_current_post_type() );
 
 		_unregister_post_type( 'content' );
 		set_current_screen( 'front' );


### PR DESCRIPTION
Previous PR (#441) history was messed up, re-creating it here with a better history:


**Overview**
At the moment, almost all assets are loaded on every admin page (for example - `calendar.js` is loaded in "Settings -> General”). Overall there were a lot of inconsistencies in asset enqueuing. The goal of this PR is to provide a reliable and predictable way of enqueuing module assets.

**Background**
Every Edit Flow module extends the `EF_Module`  class. However, some modules have dedicated views and some modules (like Dashboard widgets module) don’t. That’s where the inconsistencies begin. 

Most EF Modules enqueue assets. Some check whether they should enqueue assets, some perform the same checks in a different way, and some don’t check at all. Most of the modules use method `EF_Module::is_whitelisted_functional_view` which simply always returns true, with a `//@todo` attached to it :) - the whole asset enqueuing process needed a refactor. 

**Introducing** `EF_Module_With_View`
The EF modules needed a few methods to make it easy to check whether the any given module is visible at the moment (and therefore, whether they should enqueue assets). In most cases this is either in the edit, list and settings views. 

At first I dumped all the necessary methods on `EF_Module` class because all of the modules already are extending it. But `EF_Module` is also instantiated directly **and** it’s also extended by a `EF_Dashboard` class that doesn’t utilize the any of the “new” methods, so it didn’t make sense to keep them there. 

`EF_Module_With_View extends EF_Module` and is meant to be extended further by modules that have views, that way they have access to necessary methods, like `is_current_module_settings_view()` and `is_active_view()`


**Adding PHP interfaces**
There was no streamlined way of dealing with assets. Even enqueuing method names varied from module to module. That’s why I decided to 2 simple interfaces: `EF_Script_Interface` and  `EF_Style_Interface` - they will ensure that asset enqueuing methods are consistent and predictable. Also, by reading the class declaration it’s immediately clear whether or not the current module is enqueuing any assets.

**Summary**
* Force predictable and consistent enqueuing methods with PHP Interfaces across EF Modules
* Add a an reusable and easy to use class `EF_Module_With_View` that provides methods to easily determine whether or not assets are needed
* Refactor most modules to extend `EF_Module_With_View` instead of  `EF_Module` and enqueue assets when they’re needed

Fixes #351 