### PR TITLE
editorial-comments.js - fix jQuery that updates notified list

### DIFF
--- a/modules/editorial-comments/lib/editorial-comments.js
+++ b/modules/editorial-comments/lib/editorial-comments.js
@@ -144,7 +144,7 @@ editorialCommentReply = {
 
 		var usernames = [];
 		subscribed_users.each( function() {
-			usernames.push( $( this ).next().text() );
+			usernames.push( $( this ).parent().siblings('.ef-user_displayname').text() );
 		} );
 
 		// Convert array of usernames into a sentence.


### PR DESCRIPTION
Update jQuery that pulls text from subscribed users

This is a fix for the already-merged #461 already described in a comment there: 

https://github.com/Automattic/Edit-Flow/pull/461#issuecomment-437193887

Currently the "notified list" feature is totally broken. 

WHAT THIS CHANGES

- The jQuery used to get the text from the node next to the textbox (username)
- There is now an extra div around the checkbox (added as part of the NO ACCESS feature), so this is broken.
- New jQuery gets the parent of the checkbox, then searches it's siblings for the displayname and uses that