### PR TITLE
Wrap network check in function_exists() block

### DIFF
--- a/modules/user-groups/user-groups.php
+++ b/modules/user-groups/user-groups.php
@@ -687,9 +687,13 @@ class EF_User_Groups extends EF_Module {
 		if ( !$update )
 			return array( &$errors, $update, &$user );
 
-		//Don't allow update of user groups from network
-		if ( ( !is_null( get_current_screen() ) ) && ( get_current_screen()->is_network ) )
-			return;
+		// `get_current_screen()` is defined on most admin pages, but not all.
+		if( is_admin() && function_exists( 'get_current_screen' ) ){
+			//Don't allow update of user groups from network
+			if ( ( !is_null( get_current_screen() ) ) && ( get_current_screen()->is_network ) ) {
+				return;
+			}
+		}
 
 		if ( current_user_can( $this->manage_usergroups_cap ) && wp_verify_nonce( $_POST['ef_edit_profile_usergroups_nonce'], 'ef_edit_profile_usergroups_nonce' ) ) {
 			// Sanitize the data and save

--- a/modules/user-groups/user-groups.php
+++ b/modules/user-groups/user-groups.php
@@ -688,7 +688,7 @@ class EF_User_Groups extends EF_Module {
 			return array( &$errors, $update, &$user );
 
 		// `get_current_screen()` is defined on most admin pages, but not all.
-		if( is_admin() && function_exists( 'get_current_screen' ) ){
+		if( function_exists( 'get_current_screen' ) ){
 			//Don't allow update of user groups from network
 			if ( ( !is_null( get_current_screen() ) ) && ( get_current_screen()->is_network ) ) {
 				return;


### PR DESCRIPTION
Resolves #489.

Resolves #255.

This pull request adds a check for `is_admin` before checking if the `get_current_screen()` function exists.

The function `get_current_screen()` "[is defined on most admin pages, but not all.](https://codex.wordpress.org/Function_Reference/get_current_screen#Usage_Restrictions)". This suggests that the function should be checked before being called, particulalry if not the code is used on admin and non-admin pages alike.

Specifically, this code runs on the `user_profile_update_errors` action which is triggered by front-end user profile pages.