### PR TITLE
For #483 - Updates notifications js/php to only show users who will be notified

### DIFF
--- a/common/php/class-module.php
+++ b/common/php/class-module.php
@@ -469,13 +469,16 @@ class EF_Module {
 
 		<?php if( !empty($users) ) : ?>
 			<ul class="<?php echo esc_attr( $list_class ) ?>">
-				<?php foreach( $users as $user ) : ?>
-					<?php $checked = ( in_array($user->ID, $selected) ) ? 'checked="checked"' : ''; ?>
+				<?php foreach( $users as $user ) : 
+					$checked = ( in_array($user->ID, $selected) ) ? 'checked="checked"' : '';
+					// Add a class to checkbox of current user so we know not to add them in notified list during notifiedMessage() js function
+					$current_user_class = ( get_current_user_id() == $user->ID ) ? 'class="post_following_list-current_user" ' : '';
+				?>
 					<li>
 						<label for="<?php echo esc_attr( $input_id .'-'. $user->ID ) ?>">
 							<div class="ef-user-subscribe-actions">
 								<?php do_action( 'ef_user_subscribe_actions', $user->ID, $checked ) ?>
-								<input type="checkbox" id="<?php echo esc_attr( $input_id .'-'. $user->ID ) ?>" name="<?php echo esc_attr( $input_id ) ?>[]" value="<?php echo esc_attr( $user->ID ); ?>" <?php echo $checked; ?> />
+								<input type="checkbox" id="<?php echo esc_attr( $input_id .'-'. $user->ID ) ?>" name="<?php echo esc_attr( $input_id ) ?>[]" value="<?php echo esc_attr( $user->ID ); ?>" <?php echo $checked; echo $current_user_class; ?> />
 							</div>
 
 							<span class="ef-user_displayname"><?php echo esc_html( $user->display_name ); ?></span>

--- a/modules/editorial-comments/lib/editorial-comments.js
+++ b/modules/editorial-comments/lib/editorial-comments.js
@@ -145,7 +145,7 @@ editorialCommentReply = {
 		var usernames = [];
 		subscribed_users.each( function() {			
 			// Add usernames of checked users to the list if they don't have a blocking class
-			if ( ! $( this ).siblings().is( '.post_following_list-no_email,.post_following_list-no_access' )) {
+			if ( ! $( this ).siblings().is( '.post_following_list-no_email,.post_following_list-no_access' ) && ! $( this ).hasClass( 'post_following_list-current_user' ) ) {
 				usernames.push( $( this ).parent().siblings( '.ef-user_displayname, .ef-usergroup_name' ).text() );
 			}
 		} );

--- a/modules/editorial-comments/lib/editorial-comments.js
+++ b/modules/editorial-comments/lib/editorial-comments.js
@@ -145,8 +145,8 @@ editorialCommentReply = {
 		var usernames = [];
 		subscribed_users.each( function() {			
 			// Add usernames of checked users to the list if they don't have a blocking class
-			if ( ! $( this ).siblings().hasClass('post_following_list-no_access')) {
-				usernames.push( $( this ).parent().siblings('.ef-user_displayname, .ef-usergroup_name').text() );
+			if ( ! $( this ).siblings().is( '.post_following_list-no_email,.post_following_list-no_access' )) {
+				usernames.push( $( this ).parent().siblings( '.ef-user_displayname, .ef-usergroup_name' ).text() );
 			}
 		} );
 

--- a/modules/editorial-comments/lib/editorial-comments.js
+++ b/modules/editorial-comments/lib/editorial-comments.js
@@ -143,8 +143,11 @@ editorialCommentReply = {
 		}
 
 		var usernames = [];
-		subscribed_users.each( function() {
-			usernames.push( $( this ).parent().siblings('.ef-user_displayname, .ef-usergroup_name').text() );
+		subscribed_users.each( function() {			
+			// Add usernames of checked users to the list if they don't have a blocking class
+			if ( ! $( this ).siblings().hasClass('post_following_list-no_access')) {
+				usernames.push( $( this ).parent().siblings('.ef-user_displayname, .ef-usergroup_name').text() );
+			}
 		} );
 
 		// Convert array of usernames into a sentence.

--- a/modules/notifications/lib/notifications.css
+++ b/modules/notifications/lib/notifications.css
@@ -40,10 +40,11 @@
 	margin-top: 5px;
 }
 
-.ef-post_following_list li .ef-user-subscribe-actions span {
+.ef-post_following_list li .ef-user-subscribe-actions .post_following_list-no_email,
+.ef-post_following_list li .ef-user-subscribe-actions .post_following_list-no_access {
 	margin-right: 10px;
-	border: solid 2px #FFCCCC;
-	color: #FFCCCC;
+	border: solid 2px #DC3232;
+	color: #DC3232;
 	padding: 4px;
 }
 

--- a/modules/notifications/lib/notifications.js
+++ b/modules/notifications/lib/notifications.js
@@ -10,7 +10,7 @@ jQuery(document).ready(function($) {
 		if ( $( container ).siblings( 'span' ).length ) {
 			$( container ).siblings( 'span' ).remove();
 		} else if ( user_has_no_access ) {
-			var span = $( '<span />' );
+			var span = $( '<span />' ).addClass( 'post_following_list-no_access' );
 			span.text( ef_notifications_localization.no_access );
 			$( container ).parent().prepend( span );
 		}
@@ -38,8 +38,6 @@ jQuery(document).ready(function($) {
 
 			success : function( response ) { 
 
-				// This event is used to show an updated list of who will be notified of editorial comments and status updates.
-				$( '#ef-post_following_box' ).trigger( 'following_list_updated' );
 
 				var backgroundColor = parent_this.css( 'background-color' );
 				$(parent_this.parents('li'))
@@ -51,6 +49,9 @@ jQuery(document).ready(function($) {
 						var user_has_no_access = response.data.subscribers_with_no_access.includes( parseInt( $( parent_this ).val() ) );
 						toggle_no_access_badge( $( parent_this ), user_has_no_access );
 					}
+				
+					// This event is used to show an updated list of who will be notified of editorial comments and status updates.
+					$( '#ef-post_following_box' ).trigger( 'following_list_updated' );
 			},
 			error : function(r) { 
 				$('#ef-post_following_users_box').prev().append(' <p class="error">There was an error. Please reload the page.</p>');

--- a/modules/notifications/lib/notifications.js
+++ b/modules/notifications/lib/notifications.js
@@ -5,13 +5,25 @@ jQuery(document).ready(function($) {
 		action: 'save_notifications',
 		post_id: $('#post_ID').val(),
 	};
-
-	var toggle_no_access_badge = function( container, user_has_no_access ) {
+	
+	var toggle_warning_badges = function( container, response ) {
+		// Remove any existing badges
 		if ( $( container ).siblings( 'span' ).length ) {
 			$( container ).siblings( 'span' ).remove();
-		} else if ( user_has_no_access ) {
+		}
+		
+		// "No Access" If this user was flagged as not having access
+		var user_has_no_access = response.data.subscribers_with_no_access.includes( parseInt( $( container ).val() ) );
+		if ( user_has_no_access ) {
 			var span = $( '<span />' ).addClass( 'post_following_list-no_access' );
 			span.text( ef_notifications_localization.no_access );
+			$( container ).parent().prepend( span );
+		}
+		// "No Email" If this user was flagged as not having an email
+		var user_has_no_email = response.data.subscribers_with_no_email.includes( parseInt( $( container ).val() ) );
+		if ( user_has_no_email ) {
+			var span = $( '<span />' ).addClass( 'post_following_list-no_email' );
+			span.text( ef_notifications_localization.no_email );
 			$( container ).parent().prepend( span );
 		}
 	}
@@ -44,10 +56,9 @@ jQuery(document).ready(function($) {
 					.animate( { 'backgroundColor':'#CCEEBB' }, 200 )
 					.animate( { 'backgroundColor':backgroundColor }, 200 );
 
-					// Toggle the "No Access" badge if the selected user does not have access.
+					// Toggle the warning badges ("No Access" and "No Email") to signal the user won't receive notifications
 					if ( undefined !== response.data ) {
-						var user_has_no_access = response.data.subscribers_with_no_access.includes( parseInt( $( parent_this ).val() ) );
-						toggle_no_access_badge( $( parent_this ), user_has_no_access );
+						toggle_warning_badges( $( parent_this ), response );
 					}
 				
 					// This event is used to show an updated list of who will be notified of editorial comments and status updates.

--- a/modules/notifications/notifications.php
+++ b/modules/notifications/notifications.php
@@ -71,7 +71,7 @@ class EF_Notifications extends EF_Module {
 		add_action( 'add_meta_boxes', array( $this, 'add_post_meta_box' ) );
 
 		// Add "access badge" to the subscribers list.
-		add_action( 'ef_user_subscribe_actions', array( $this, 'display_subscriber_access_badge' ), 10, 2 );
+		add_action( 'ef_user_subscribe_actions', array( $this, 'display_subscriber_warning_badges' ), 10, 2 );
 	
 		// Saving post actions
 		// self::save_post_subscriptions() is hooked into transition_post_status so we can ensure usergroup data
@@ -198,7 +198,8 @@ class EF_Notifications extends EF_Module {
 				'edit-flow-notifications-js',
 				'ef_notifications_localization',
 				array(
-					'no_access' => esc_html__( 'No Access', 'edit-flow' )
+					'no_access' => esc_html__( 'No Access', 'edit-flow' ),
+					'no_email' => esc_html__( 'No Email', 'edit-flow' )
 				)
 			);
 		}
@@ -379,18 +380,32 @@ jQuery(document).ready(function($) {
 	}
 
 	/**
-	 * Show a badge next to a subscriber's name showing if they have the permissions needed to recieve notifications.
+	 * Show warning badges next to a subscriber's name if they won't receive notifications
 	 *
+	 * Applies on initial loading of list via. PHP. JS will set these spans based on AJAX response when box is ticked/unticked.
+	 * 
 	 * @param int $user_id 
 	 * @param bool $checked True if the user is subscribed already, false otherwise.
 	 * @return void
 	 */	
-	function display_subscriber_access_badge( $user_id, $checked ) {
+	function display_subscriber_warning_badges( $user_id, $checked ) {
 		global $post;
 
-		if ( isset( $post ) && $checked && ! $this->user_can_be_notified( get_user_by( 'id', $user_id ), $post->ID ) ) {
+		if (!isset( $post ) OR !$checked ) {
+			return;
+		}
+		
+		// Add No Access span if they won't be notified
+		if (! $this->user_can_be_notified( get_user_by( 'id', $user_id ), $post->ID )) {
 			// span.post_following_list-no_access is also added in notifications.js after AJAX that ticks/unticks a user
 			echo '<span class="post_following_list-no_access">' . esc_html__( 'No Access', 'edit-flow' ) . '</span>';
+		}
+		
+		// Add No Email span if they have no email
+		$user_object = get_user_by( 'id', $user_id );
+		if ( !is_a( $user_object, 'WP_User') OR empty( $user_object->user_email )  ) {
+			// span.post_following_list-no_email is also added in notifications.js after AJAX that ticks/unticks a user
+			echo '<span class="post_following_list-no_email">' . esc_html__( 'No Email', 'edit-flow' ) . '</span>';
 		}
 	}
 	
@@ -422,11 +437,28 @@ jQuery(document).ready(function($) {
 			$this->save_post_following_users( $post, $user_group_ids );
 			
 			if ( defined( 'DOING_AJAX' ) && DOING_AJAX && isset( $_POST['post_id'] ) ) {
+				
+				// Determine if any of the selected users won't have notification access
 				$subscribers_with_no_access = array_filter( $user_group_ids, function( $user_id ) {
 					return ! $this->user_can_be_notified( get_user_by( 'id', $user_id ), $_POST['post_id'] );
 				} );
 
-				wp_send_json_success( array( 'subscribers_with_no_access' => array_values( $subscribers_with_no_access ) ) );
+				// Determine if any of the selected users are missing their emails				
+				$subscribers_with_no_email = array();
+				foreach ( $user_group_ids AS $user_id ) {
+					$user_object = get_user_by( 'id', $user_id );
+					if ( !is_a( $user_object, 'WP_User') OR empty( $user_object->user_email )  ) {
+						$subscribers_with_no_email[] = $user_id;
+					}
+				}
+				
+				// Assemble the json reply with various lists of problematic users
+				$json_success = array( 
+					'subscribers_with_no_access' => array_values( $subscribers_with_no_access ),
+					'subscribers_with_no_email' => array_values( $subscribers_with_no_email ),
+				);
+				
+				wp_send_json_success( $json_success );
 			}
 		}
 		

--- a/modules/notifications/notifications.php
+++ b/modules/notifications/notifications.php
@@ -389,7 +389,8 @@ jQuery(document).ready(function($) {
 		global $post;
 
 		if ( isset( $post ) && $checked && ! $this->user_can_be_notified( get_user_by( 'id', $user_id ), $post->ID ) ) {
-			echo '<span>' . esc_html__( 'No Access', 'edit-flow' ) . '</span>';
+			// span.post_following_list-no_access is also added in notifications.js after AJAX that ticks/unticks a user
+			echo '<span class="post_following_list-no_access">' . esc_html__( 'No Access', 'edit-flow' ) . '</span>';
 		}
 	}
 	


### PR DESCRIPTION
### I've now added all three major changes needed to ensure only users who will be sent a notification are listed in the Editorial Comments "Notification list". 

No Access and No Email badges both work using a unified system now, and those users aren't added to the "Notified list". 

The current user's checkbox is marked with a special class, and the "Notification list" JS is set up to ignore the current user. 

### Text below describes the original commit.

For #483 - Updates notifications js/php to avoid "No Access" users showing in the notified list in editorial comments

Adds `.post_following_list-no_access` to the "No Access" warning spans (in two places), then uses that during "Notified list" generation to exclude people without access from the list (which already happens during email sending, this just cleans up the display so it matches the actual outcome).

My intention is to add similar tests for current_user and no_email users.

- `notifications.php` - add `.post_following_list-no_access` to the initial PHP-created "No Access" span
- `notifications.js` - add `.post_following_list-no_access` to the post-AJAX JS-created "No Access" span
- `notifications.js` - Move the triggering of `following_list_updated()` to AFTER the no access stuff runs, so that it can see the span. Previously the "notified list" was updated before, so it couldn't see any of the results of the access test
- `editorial-comments.js` - before inserting a user into the "notified list" array, check if a span indicating a problem is next to the checkbox