### PR TITLE
notifications.js - Update background color that flashes when ticking/unticking users

### DIFF
--- a/modules/notifications/lib/notifications.js
+++ b/modules/notifications/lib/notifications.js
@@ -18,6 +18,7 @@ jQuery(document).ready(function($) {
 			var span = $( '<span />' ).addClass( 'post_following_list-no_access' );
 			span.text( ef_notifications_localization.no_access );
 			$( container ).parent().prepend( span );
+			warning_background = true;
 		}
 		// "No Email" If this user was flagged as not having an email
 		var user_has_no_email = response.data.subscribers_with_no_email.includes( parseInt( $( container ).val() ) );
@@ -25,6 +26,7 @@ jQuery(document).ready(function($) {
 			var span = $( '<span />' ).addClass( 'post_following_list-no_email' );
 			span.text( ef_notifications_localization.no_email );
 			$( container ).parent().prepend( span );
+			warning_background = true;
 		}
 	}
 
@@ -49,20 +51,26 @@ jQuery(document).ready(function($) {
 			data : params,
 
 			success : function( response ) { 
-
-
+				// Reset background color (set during toggle_warning_badges if there's a warning)
+				warning_background = false;
+				
+				// Toggle the warning badges ("No Access" and "No Email") to signal the user won't receive notifications
+				if ( undefined !== response.data ) {
+					toggle_warning_badges( $( parent_this ), response );
+				}
+				// Green 40% by default
+				var backgroundHighlightColor = "#90d296";
+				if ( warning_background ) {
+					// Red 40% if there's a warning
+					var backgroundHighlightColor = "#ea8484";
+				}
 				var backgroundColor = parent_this.css( 'background-color' );
 				$(parent_this.parents('li'))
-					.animate( { 'backgroundColor':'#CCEEBB' }, 200 )
+					.animate( { 'backgroundColor': backgroundHighlightColor }, 200 )
 					.animate( { 'backgroundColor':backgroundColor }, 200 );
-
-					// Toggle the warning badges ("No Access" and "No Email") to signal the user won't receive notifications
-					if ( undefined !== response.data ) {
-						toggle_warning_badges( $( parent_this ), response );
-					}
-				
-					// This event is used to show an updated list of who will be notified of editorial comments and status updates.
-					$( '#ef-post_following_box' ).trigger( 'following_list_updated' );
+			  
+				// This event is used to show an updated list of who will be notified of editorial comments and status updates.
+				$( '#ef-post_following_box' ).trigger( 'following_list_updated' );
 			},
 			error : function(r) { 
 				$('#ef-post_following_users_box').prev().append(' <p class="error">There was an error. Please reload the page.</p>');


### PR DESCRIPTION
( @rinatkhaziev I know you said you were trying to wrap up for today, but it turned out pretty easy to make this change and I think it goes well with the others. The colors are from the WP colors codepen)

Before: It would flash green as long as the AJAX came back
Now: It flashes red when you've ticked a user with a warning, otherwise green

- sets a `warning_background = true` flag during `toggle_warning_badges()`
- uses that flag in the AJAX response to choose between green and red background
- re-organizes the code a bit to run `toggle_warning_badges()` before the animation and fix an indentation issue