### PR TITLE
Replace “$” with “jQuery”.

### DIFF
--- a/modules/editorial-comments/lib/editorial-comments.js
+++ b/modules/editorial-comments/lib/editorial-comments.js
@@ -23,7 +23,7 @@ editorialCommentReply = {
 		jQuery('a.ef-replysave', row).click(function() { return editorialCommentReply.send(); });
 
 		// Watch for changes to the subscribed users.
-		$( '#ef-post_following_box' ).on( 'following_list_updated', function() {
+		jQuery( '#ef-post_following_box' ).on( 'following_list_updated', function() {
 			editorialCommentReply.notifiedMessage();
 		} );
 	},
@@ -145,8 +145,8 @@ editorialCommentReply = {
 		var usernames = [];
 		subscribed_users.each( function() {			
 			// Add usernames of checked users to the list if they don't have a blocking class
-			if ( ! $( this ).siblings().is( '.post_following_list-no_email,.post_following_list-no_access' ) && ! $( this ).hasClass( 'post_following_list-current_user' ) ) {
-				usernames.push( $( this ).parent().siblings( '.ef-user_displayname, .ef-usergroup_name' ).text() );
+			if ( ! jQuery( this ).siblings().is( '.post_following_list-no_email,.post_following_list-no_access' ) && ! jQuery( this ).hasClass( 'post_following_list-current_user' ) ) {
+				usernames.push( jQuery( this ).parent().siblings( '.ef-user_displayname, .ef-usergroup_name' ).text() );
 			}
 		} );
 


### PR DESCRIPTION
Was getting a missing function error for the $, and it was creating a conflict with another plugin. As I understand it, when using jQuery in WordPress, best practice is to always use the jQuery function instead of the $. Updated this file (the source of the error) and everything is peachy. It would be great to have this change rolled into the plug-in, so that I don’t have to keep making it after each update.

Also, I hope I’m going about this the correct way. I got followed the instructions from the plugin website (I think). I’ve never use git for collaboration, so if I did this wrong, please feel free to correct me, it won’t hurt my feelings at all.