### PR TITLE
notifications.php - fix old_status_friendly_name undefined warning

### DIFF
--- a/modules/notifications/notifications.php
+++ b/modules/notifications/notifications.php
@@ -583,6 +583,12 @@ jQuery(document).ready(function($) {
 				$current_user_email = '';
 			}
 			
+			// Set up default old and new status "friendly" names using it's label
+			$old_status_post_obj = get_post_status_object( $old_status );
+			$old_status_friendly_name = $old_status_post_obj->label;	
+			$new_status_post_obj = get_post_status_object( $new_status );
+			$new_status_friendly_name = $new_status_post_obj->label;
+			
 			// Email subject and first line of body 
 			// Set message subjects according to what action is being taken on the Post	
 			if ( $old_status == 'new' || $old_status == 'auto-draft' ) {
@@ -621,15 +627,10 @@ jQuery(document).ready(function($) {
 				$subject = sprintf( __( '[%1$s] %2$s Status Changed for "%3$s"', 'edit-flow' ), $blogname, $post_type, $post_title );
 				/* translators: 1: post type, 2: post id, 3. post title, 4. user name, 5. user email */
 				$body .= sprintf( __( 'Status was changed for %1$s #%2$s "%3$s" by %4$s %5$s', 'edit-flow'), $post_type, $post_id, $post_title, $current_user_display_name, $current_user_email ) . "\r\n";
-				$old_status_post_obj = get_post_status_object( $old_status );
-				$old_status_friendly_name = $old_status_post_obj->label;
 			}
 			
 			/* translators: 1: date, 2: time, 3: timezone */
 			$body .= sprintf( __( 'This action was taken on %1$s at %2$s %3$s', 'edit-flow' ), date_i18n( get_option( 'date_format' ) ), date_i18n( get_option( 'time_format' ) ), get_option( 'timezone_string' ) ) . "\r\n";
-
-			$new_status_post_obj = get_post_status_object( $new_status );
-			$new_status_friendly_name = $new_status_post_obj->label;
 						
 			// Email body
 			$body .= "\r\n";


### PR DESCRIPTION
- affects `notification_status_change()`
- Moves the definition of $old_status_friendly_name (as well as $new_status_friendly_name) to above the complex `else if` block to ensure that it is always defined.
- Fixes a recent change to this code, which moved the definition of $old_status_friendly_name to places where it didn’t effect all of the `else if` clauses:

https://github.com/Automattic/Edit-Flow/commit/071791d0ed2ec676895f4f133e16642a54b17c65#diff-59ee072dc425b09b6d748cb84634734b

- This triggered a `PHP Warning: PHP Notice:  Undefined variable: old_status_friendly_name` because the variable is used right after in all cases.
- This warning also reflected that the string would be missing in many cases.
- I tried to test this with all the possible status transition but might have missed some. Certainly the common ones of new->draft->pending->publish->trash are all working as expected now.
