### PR TITLE
Fixed the php 7.2 count warning on the Settings page

### DIFF
--- a/modules/settings/settings.php
+++ b/modules/settings/settings.php
@@ -228,8 +228,8 @@ class EF_Settings extends EF_Module {
 	
 	function print_modules() {
 		global $edit_flow;
-		
-		if ( !count( $edit_flow->modules ) ) {
+
+		if ( !count( get_object_vars ( $edit_flow->modules ) ) ) {
 			echo '<div class="message error">' . __( 'There are no Edit Flow modules registered', 'edit-flow' ) . '</div>';
 		} else {
 			


### PR DESCRIPTION
`$edit_flow->modules` is an object with all the active modules but `count` cannot be used on it because it's not a countable object. 
The `Settings` page where this warning appears is a module too so this check is redundant since the result here will always be at least 1.
However, in order to make the warning go away, I choose to  use `get_object_vars` because it's turning `$edit_flow->modules` object into an array of objects (that can be counted).