### PR TITLE
editorial-comments.js - replace faulty `$()` with `jQuery()` to match the rest of file

### DIFF
--- a/modules/editorial-comments/lib/editorial-comments.js
+++ b/modules/editorial-comments/lib/editorial-comments.js
@@ -23,7 +23,7 @@ editorialCommentReply = {
 		jQuery('a.ef-replysave', row).click(function() { return editorialCommentReply.send(); });
 
 		// Watch for changes to the subscribed users.
-		$( '#ef-post_following_box' ).on( 'following_list_updated', function() {
+		jQuery( '#ef-post_following_box' ).on( 'following_list_updated', function() {
 			editorialCommentReply.notifiedMessage();
 		} );
 	},

--- a/modules/editorial-comments/lib/editorial-comments.js
+++ b/modules/editorial-comments/lib/editorial-comments.js
@@ -145,8 +145,8 @@ editorialCommentReply = {
 		var usernames = [];
 		subscribed_users.each( function() {			
 			// Add usernames of checked users to the list if they don't have a blocking class
-			if ( ! $( this ).siblings().is( '.post_following_list-no_email,.post_following_list-no_access' ) && ! $( this ).hasClass( 'post_following_list-current_user' ) ) {
-				usernames.push( $( this ).parent().siblings( '.ef-user_displayname, .ef-usergroup_name' ).text() );
+			if ( ! jQuery( this ).siblings().is( '.post_following_list-no_email,.post_following_list-no_access' ) && ! jQuery( this ).hasClass( 'post_following_list-current_user' ) ) {
+				usernames.push( jQuery( this ).parent().siblings( '.ef-user_displayname, .ef-usergroup_name' ).text() );
 			}
 		} );
 


### PR DESCRIPTION
- On one of my sites, I was getting a site-breaking js error for `$ not defined` caused by line 26 of this file, which had a `$()` jQuery command
- For some reason, most of my sites never had this problem, but this one did. Maybe it's a combination of plugins and a common one makes `$()` available by coincidence.
- Either way, the surrounding code makes it obvious that `editorial-comments` relies on `jQuery()` being available, rather than `$()`
- This patch just fixes that one line (which was the most recently added, it's part of the "notified list" feature added in 0.9) to match the rest and use `jQuery()` like a good kid.