### PR TITLE
Remove TravisCI tests for anything below PHP 5.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: php
 
 php:
-    - "5.4"
-    - "5.5"
     - "5.6"
     - "7.0"
     - "7.1"
@@ -10,83 +8,40 @@ php:
 env:
     - WP_VERSION=latest WP_MULTISITE=0 #Current stable release
 
-# Test WP 4.8 and on PHP 5.4, 5.5, 5.6, 7.0 and 7.1 (w and w/o multisite enabled)
-# Test WP 4.8 and on PHP 5.2 and 5.3 and allow_failures (w and w/o multisite enabled)
-# Test WP master on PHP nightly (w/o multisite enabled)
+# Test WP 5.1 and 5.2 and on PHP 5.6, 7.0 and 7.1 (w and w/o multisite enabled)
+# Test WP master on PHP nightly and allow_failures (w/o multisite enabled)
 
 matrix:
   include:
     # current stable release w/ multisite
-    - php: "5.2"
-      env: WP_VERSION=4.8 WP_MULTISITE=0
-      dist: precise
-    - php: "5.3"
-      env: WP_VERSION=4.8 WP_MULTISITE=0
-      dist: precise
-    - php: "5.4"
-      env: WP_VERSION=4.8 WP_MULTISITE=0
-    - php: "5.5"
-      env: WP_VERSION=4.8 WP_MULTISITE=0
     - php: "5.6"
-      env: WP_VERSION=4.8 WP_MULTISITE=0
+      env: WP_VERSION=5.1 WP_MULTISITE=0
     - php: "7.0"
-      env: WP_VERSION=4.8 WP_MULTISITE=0
+      env: WP_VERSION=5.1 WP_MULTISITE=0
     - php: "7.1"
-      env: WP_VERSION=4.8 WP_MULTISITE=0
-    - php: "5.2"
-      env: WP_VERSION=4.8 WP_MULTISITE=1
-      dist: precise
-    - php: "5.3"
-      env: WP_VERSION=4.8 WP_MULTISITE=1
-      dist: precise
-    - php: "5.4"
-      env: WP_VERSION=4.8 WP_MULTISITE=1
-    - php: "5.5"
-      env: WP_VERSION=4.8 WP_MULTISITE=1
+      env: WP_VERSION=5.1 WP_MULTISITE=0
     - php: "5.6"
-      env: WP_VERSION=4.8 WP_MULTISITE=1
+      env: WP_VERSION=5.1 WP_MULTISITE=1
     - php: "7.0"
-      env: WP_VERSION=4.8 WP_MULTISITE=1
+      env: WP_VERSION=5.1 WP_MULTISITE=1
     - php: "7.1"
-      env: WP_VERSION=4.8 WP_MULTISITE=1
-    - php: "5.2"
-      env: WP_VERSION=4.9 WP_MULTISITE=0
-      dist: precise
-    - php: "5.3"
-      env: WP_VERSION=4.9 WP_MULTISITE=0
-      dist: precise
-    - php: "5.4"
-      env: WP_VERSION=4.9 WP_MULTISITE=0
-    - php: "5.5"
-      env: WP_VERSION=4.9 WP_MULTISITE=0
+      env: WP_VERSION=5.1 WP_MULTISITE=1
     - php: "5.6"
-      env: WP_VERSION=4.9 WP_MULTISITE=0
+      env: WP_VERSION=5.2 WP_MULTISITE=0
     - php: "7.0"
-      env: WP_VERSION=4.9 WP_MULTISITE=0
+      env: WP_VERSION=5.2 WP_MULTISITE=0
     - php: "7.1"
-      env: WP_VERSION=4.9 WP_MULTISITE=0
-    - php: "5.2"
-      env: WP_VERSION=4.9 WP_MULTISITE=1
-      dist: precise
-    - php: "5.3"
-      env: WP_VERSION=4.9 WP_MULTISITE=1
-      dist: precise
-    - php: "5.4"
-      env: WP_VERSION=4.9 WP_MULTISITE=1
-    - php: "5.5"
-      env: WP_VERSION=4.9 WP_MULTISITE=1
+      env: WP_VERSION=5.2 WP_MULTISITE=0
     - php: "5.6"
-      env: WP_VERSION=4.9 WP_MULTISITE=1
+      env: WP_VERSION=5.2 WP_MULTISITE=1
     - php: "7.0"
-      env: WP_VERSION=4.9 WP_MULTISITE=1
+      env: WP_VERSION=5.2 WP_MULTISITE=1
     - php: "7.1"
-      env: WP_VERSION=4.9 WP_MULTISITE=1
+      env: WP_VERSION=5.2 WP_MULTISITE=1
     - php: "nightly"
       env: WP_VERSION=latest WP_MULTISITE=0
   allow_failures:
     - php: "nightly"
-    - php: "5.2"
-    - php: "5.3"
 
 before_script:
     - bash bin/install-wp-tests.sh wordpress_test root '' localhost $WP_VERSION


### PR DESCRIPTION
Also bump up testing using WP 5.1+