### PR TITLE
160 quick edit

### DIFF
--- a/modules/editorial-metadata/editorial-metadata.php
+++ b/modules/editorial-metadata/editorial-metadata.php
@@ -400,9 +400,9 @@ class EF_Editorial_Metadata extends EF_Module {
 	/**
 	 * Displays HTML output for inputs in meta box and quick edit box
 	 *
-	 * @param object $term 
-	 * @param int $post_id
-	 * @param boolean $quick_edit
+	 * @param object $term Term's object representation
+	 * @param int $post_id The ID of the post
+	 * @param boolean $quick_edit If in quick edit box or not
 	 */
 	public function display_field( $term, $post_id = 0, $quick_edit = false ) {
 		$postmeta_key = $this->get_postmeta_key( $term );

--- a/modules/editorial-metadata/editorial-metadata.php
+++ b/modules/editorial-metadata/editorial-metadata.php
@@ -105,7 +105,7 @@ class EF_Editorial_Metadata extends EF_Module {
 		}
 
 		// Add Editorial Metadata to quick edit box
-		// add_action( 'quick_edit_custom_box', array( $this, 'action_quick_edit_custom_box' ), 10, 2 );
+		add_action( 'quick_edit_custom_box', array( $this, 'action_quick_edit_custom_box' ), 10, 2 );
 		
 		// Add Editorial Metadata to the calendar if the calendar is activated
 		if ( $this->module_enabled( 'calendar' ) )

--- a/modules/editorial-metadata/editorial-metadata.php
+++ b/modules/editorial-metadata/editorial-metadata.php
@@ -439,7 +439,10 @@ class EF_Editorial_Metadata extends EF_Module {
 				}
 				if ( $description_span )
 					echo "<label for='$postmeta_key'>$description_span</label>";
-				echo "<input id='$postmeta_key' name='$postmeta_key' type='text' class='date-time-pick' value='$current_metadata' />";
+
+				$class = !$quick_edit ? 'date-time-pick' : '';
+
+				echo "<input id='$postmeta_key' name='$postmeta_key' type='text' class='$class' value='$current_metadata' />";
 				break;
 			case "location":
 				if ( $description_span )
@@ -766,7 +769,7 @@ class EF_Editorial_Metadata extends EF_Module {
 		}
 		
 	}
-	
+
 	/**
 	 * Handle the output of editorial metadata quick edit box
 	 *

--- a/modules/editorial-metadata/editorial-metadata.php
+++ b/modules/editorial-metadata/editorial-metadata.php
@@ -105,7 +105,7 @@ class EF_Editorial_Metadata extends EF_Module {
 		}
 
 		// Add Editorial Metadata to quick edit box
-		add_action( 'quick_edit_custom_box', array( $this, 'action_quick_edit_custom_box' ), 10, 2 );
+		// add_action( 'quick_edit_custom_box', array( $this, 'action_quick_edit_custom_box' ), 10, 2 );
 		
 		// Add Editorial Metadata to the calendar if the calendar is activated
 		if ( $this->module_enabled( 'calendar' ) )

--- a/modules/editorial-metadata/editorial-metadata.php
+++ b/modules/editorial-metadata/editorial-metadata.php
@@ -103,6 +103,9 @@ class EF_Editorial_Metadata extends EF_Module {
 			add_filter( "manage_{$post_type}_posts_columns", array( $this, 'filter_manage_posts_columns' ) );
 			add_action( "manage_{$post_type}_posts_custom_column", array( $this, 'action_manage_posts_custom_column' ), 10, 2 );
 		}
+
+		// Add Editorial Metadata to quick edit box
+		// add_action( 'quick_edit_custom_box', array( $this, 'action_quick_edit_custom_box' ), 10, 2 );
 		
 		// Add Editorial Metadata to the calendar if the calendar is activated
 		if ( $this->module_enabled( 'calendar' ) )
@@ -243,11 +246,14 @@ class EF_Editorial_Metadata extends EF_Module {
 		}
 		// A bit of custom CSS for the Manage Posts view if we have viewable metadata
 		if ( $current_screen->base == 'edit' && in_array( $current_post_type, $supported_post_types ) ) {
+			// data to pass for quick edit
+			$ef_quick_edit_data = array();
+
 			$terms = $this->get_editorial_metadata_terms();
 			$viewable_terms = array();
 			foreach( $terms as $term ) {
-				if ( $term->viewable ) 
-					$viewable_terms[] = $term;
+				if ( $term->viewable )
+					$viewable_terms[] = $term; 
 			}
 			if ( !empty( $viewable_terms ) ) {
 				$css_rules = array(
@@ -286,6 +292,12 @@ class EF_Editorial_Metadata extends EF_Module {
 							);
 							break;
 					}
+
+					// quick edit lookup selector and type by input name
+					$ef_quick_edit_data['_ef_editorial_meta_' . $viewable_term->type . '_' . $viewable_term->slug] = array(
+						'type' => $viewable_term->type,
+						'selector' => '.column-' . $this->module->slug . '-' . $viewable_term->slug
+					);
 				}
 				// Allow users to filter out rules if there's something wonky
 				$css_rules = apply_filters( 'ef_editorial_metadata_manage_posts_css_rules', $css_rules );
@@ -295,7 +307,13 @@ class EF_Editorial_Metadata extends EF_Module {
 				}
 				echo '</style>';
 			}
-			
+
+			// Javascript for quick edit ( display input values )
+			$ef_quick_edit_handle = 'edit-flow-editorial-metadata-quick-edit';
+
+			wp_register_script( $ef_quick_edit_handle, EDIT_FLOW_URL . 'modules/editorial-metadata/lib/editorial-metadata-quick-edit.js', array( 'jquery' ), EDIT_FLOW_VERSION, true );
+			wp_localize_script( $ef_quick_edit_handle, 'ef_quick_edit', $ef_quick_edit_data );
+			wp_enqueue_script( $ef_quick_edit_handle );
 		}
 		
 		// Load Javascript specific to the editorial metadata configuration view
@@ -373,69 +391,96 @@ class EF_Editorial_Metadata extends EF_Module {
 			echo '<p>' . $message . '</p>';
 		} else {
 			foreach ( $terms as $term ) {
-				$postmeta_key = $this->get_postmeta_key( $term );
-				$current_metadata = esc_attr( $this->get_postmeta_value( $term, $post->ID ) );
-				$type = $term->type;
-				$description = $term->description;
-				if ( $description )
-					$description_span = "<span class='description'>$description</span>";
-				else
-					$description_span = '';
-				echo "<div class='" . self::metadata_taxonomy . " " . self::metadata_taxonomy . "_$type'>";
-				switch( $type ) {
-					case "date":
-						// TODO: Move this to a function
-						if ( !empty( $current_metadata ) ) {
-							// Turn timestamp into a human-readable date
-							$current_metadata = $this->show_date_or_datetime( intval( $current_metadata ) );	
-						}
-						echo "<label for='$postmeta_key'>{$term->name}</label>";
-						if ( $description_span )
-							echo "<label for='$postmeta_key'>$description_span</label>";
-						echo "<input id='$postmeta_key' name='$postmeta_key' type='text' class='date-time-pick' value='$current_metadata' />";
-						break;
-					case "location":
-						echo "<label for='$postmeta_key'>{$term->name}</label>";
-						if ( $description_span )
-							echo "<label for='$postmeta_key'>$description_span</label>";
-						echo "<input id='$postmeta_key' name='$postmeta_key' type='text' value='$current_metadata' />";
-						if ( !empty( $current_metadata ) )
-							echo "<div><a href='http://maps.google.com/?q={$current_metadata}&t=m' target='_blank'>" . sprintf( __( 'View &#8220;%s&#8221; on Google Maps', 'edit-flow' ), $current_metadata ) . "</a></div>";
-						break;
-					case "text":
-						echo "<label for='$postmeta_key'>{$term->name}$description_span</label>";
-						echo "<input id='$postmeta_key' name='$postmeta_key' type='text' value='$current_metadata' />";
-						break;
-					case "paragraph":
-						echo "<label for='$postmeta_key'>{$term->name}$description_span</label>";
-						echo "<textarea id='$postmeta_key' name='$postmeta_key'>$current_metadata</textarea>";
-						break;
-					case "checkbox":
-						echo "<label for='$postmeta_key'>{$term->name}$description_span</label>";
-						echo "<input id='$postmeta_key' name='$postmeta_key' type='checkbox' value='1' " . checked($current_metadata, 1, false) . " />";
-						break;
-					case "user": 
-						echo "<label for='$postmeta_key'>{$term->name}$description_span</label>";
-						$user_dropdown_args = array( 
-								'show_option_all' => __( '-- Select a user --', 'edit-flow' ), 
-								'name'     => $postmeta_key,
-								'selected' => $current_metadata 
-							);
-						$user_dropdown_args = apply_filters( 'ef_editorial_metadata_user_dropdown_args', $user_dropdown_args );
-						wp_dropdown_users( $user_dropdown_args );
-						break;
-					case "number":
-						echo "<label for='$postmeta_key'>{$term->name}$description_span</label>";
-						echo "<input id='$postmeta_key' name='$postmeta_key' type='text' value='$current_metadata' />";
-						break;					
-					default:
-						echo "<p>" . __( 'This editorial metadata type is not yet supported.', 'edit-flow' ) . "</p>";
-				}
-			echo "</div>";
-			echo "<div class='clear'></div>";
-		} // Done iterating through metadata terms
+				$this->display_field( $term, $post->ID );
+			} // Done iterating through metadata terms
 		}		
 		echo "</div>";
+	}
+
+	/**
+	 * Displays HTML output for inputs in meta box and quick edit box
+	 *
+	 * @param object $term Term's object representation
+	 * @param int $post_id The ID of the post
+	 * @param boolean $quick_edit If in quick edit box or not
+	 */
+	public function display_field( $term, $post_id = 0, $quick_edit = false ) {
+		$postmeta_key = $this->get_postmeta_key( $term );
+		$current_metadata = esc_attr( $this->get_postmeta_value( $term, $post_id ) );
+		$type = $term->type;
+		$description = $term->description;
+
+		if ( $description && $post_id )
+			$description_span = "<span class='description'>$description</span>";
+		else
+			$description_span = '';
+		echo "<div class='" . self::metadata_taxonomy . " " . self::metadata_taxonomy . "_$type'>";
+
+		if( $type == 'date' || $type == 'location' ) {
+			$label = "<label for='$postmeta_key'>{$term->name}</label>";
+		} else {
+			$label = "<label for='$postmeta_key'>{$term->name}$description_span</label>";
+		}
+
+		if( $quick_edit )
+			$label = "<div class='ef_editorial_meta_left'>$label</div>";
+
+		echo $label;
+
+		if( $quick_edit )
+			echo "<div class='ef_editorial_meta_right'>";
+
+		switch( $type ) {
+			case "date":
+				// TODO: Move this to a function
+				if ( !empty( $current_metadata ) ) {
+					// Turn timestamp into a human-readable date
+					$current_metadata = $this->show_date_or_datetime( intval( $current_metadata ) );	
+				}
+				if ( $description_span )
+					echo "<label for='$postmeta_key'>$description_span</label>";
+
+				$class = !$quick_edit ? 'date-time-pick' : '';
+
+				echo "<input id='$postmeta_key' name='$postmeta_key' type='text' class='$class' value='$current_metadata' />";
+				break;
+			case "location":
+				if ( $description_span )
+					echo "<label for='$postmeta_key'>$description_span</label>";
+				echo "<input id='$postmeta_key' name='$postmeta_key' type='text' value='$current_metadata' />";
+				if ( !empty( $current_metadata ) )
+					echo "<div><a href='http://maps.google.com/?q={$current_metadata}&t=m' target='_blank'>" . sprintf( __( 'View &#8220;%s&#8221; on Google Maps', 'edit-flow' ), $current_metadata ) . "</a></div>";
+				break;
+			case "text":
+				echo "<input id='$postmeta_key' name='$postmeta_key' type='text' value='$current_metadata' />";
+				break;
+			case "paragraph":
+				echo "<textarea id='$postmeta_key' name='$postmeta_key'>$current_metadata</textarea>";
+				break;
+			case "checkbox":
+				echo "<input id='$postmeta_key' name='$postmeta_key' type='checkbox' value='1' " . checked($current_metadata, 1, false) . " />";
+				break;
+			case "user": 
+				$user_dropdown_args = array( 
+						'show_option_all' => __( '-- Select a user --', 'edit-flow' ), 
+						'name'     => $postmeta_key,
+						'selected' => $current_metadata 
+					);
+				$user_dropdown_args = apply_filters( 'ef_editorial_metadata_user_dropdown_args', $user_dropdown_args );
+				wp_dropdown_users( $user_dropdown_args );
+				break;
+			case "number":
+				echo "<input id='$postmeta_key' name='$postmeta_key' type='text' value='$current_metadata' />";
+				break;					
+			default:
+				echo "<p>" . __( 'This editorial metadata type is not yet supported.', 'edit-flow' ) . "</p>";
+		}
+
+		if( $quick_edit )
+			echo "</div>";
+
+		echo "</div>";
+		echo "<div class='clear'></div>";
 	}
 	
 	/**
@@ -653,13 +698,15 @@ class EF_Editorial_Metadata extends EF_Module {
 		$screen = get_current_screen();
 		if ( $screen ) {
 			add_filter( "manage_{$screen->id}_sortable_columns", array( $this, 'filter_manage_posts_sortable_columns' ) );
-			$terms = $this->get_editorial_metadata_terms( array( 'viewable' => true ) );
-			foreach( $terms as $term ) {
-				// Prefixing slug with module slug because it isn't stored prefixed and we want to avoid collisions
-				$key = $this->module->slug . '-' . $term->slug;
-				$posts_columns[$key] = $term->name;
-			}
 		}
+			
+		$terms = $this->get_editorial_metadata_terms( array( 'viewable' => true ) );
+		foreach( $terms as $term ) {
+			// Prefixing slug with module slug because it isn't stored prefixed and we want to avoid collisions
+			$key = $this->module->slug . '-' . $term->slug;
+			$posts_columns[$key] = $term->name;
+		}
+		
 		return $posts_columns;
 	}
 	
@@ -721,6 +768,56 @@ class EF_Editorial_Metadata extends EF_Module {
 			echo $this->generate_editorial_metadata_term_output( $term, $current_metadata );
 		}
 		
+	}
+
+	/**
+	 * Handle the output of editorial metadata quick edit box
+	 *
+	 * @since 2.7
+	 * @uses do_action( 'quick_edit_custom_box' ) in wp-admin/includes/class-wp-terms-list-table.php
+	 *
+	 * @param string $column_name Unique string for the column
+	 * @param string $post_type Type of posts
+	 */
+	function action_quick_edit_custom_box( $column_name, $post_type ) {
+		$supported_post_types = $this->get_post_types_for_module( $this->module );
+
+		if( !in_array( $post_type, $supported_post_types ) )
+			return;
+
+		$terms = $this->get_editorial_metadata_terms( array( 'viewable' => true ) );
+		$terms_count = count( $terms );
+
+		if( !$terms_count )
+			return;
+
+		$counter = -1; 
+
+		foreach( $terms as $term ) {
+			$counter++;
+
+			$key = $this->module->slug . '-' . $term->slug;
+			if ( $column_name != $key )
+				continue;
+
+			// Wrap inputs in fieldset
+			if( $counter === 0 ) {
+				echo '<div class="clear"></div>';
+				echo '<fieldset class="ef_editorial_meta_quick_edit">';
+				echo '<div class="inline-edit-col">';
+
+				// Add nonce for verification upon save
+				echo "<input type='hidden' name='" . self::metadata_taxonomy . "_nonce' value='" . wp_create_nonce(__FILE__) . "' />";
+			}
+
+			$this->display_field( $term , 0, true );
+
+			// Wrap inputs in fieldset
+			if( $counter === $terms_count - 1 ) {
+				echo '</div>';
+				echo '</fieldset>';
+			}
+		}
 	}
 	
 	/**

--- a/modules/editorial-metadata/editorial-metadata.php
+++ b/modules/editorial-metadata/editorial-metadata.php
@@ -103,9 +103,6 @@ class EF_Editorial_Metadata extends EF_Module {
 			add_filter( "manage_{$post_type}_posts_columns", array( $this, 'filter_manage_posts_columns' ) );
 			add_action( "manage_{$post_type}_posts_custom_column", array( $this, 'action_manage_posts_custom_column' ), 10, 2 );
 		}
-
-		// Add Editorial Metadata to quick edit box
-		// add_action( 'quick_edit_custom_box', array( $this, 'action_quick_edit_custom_box' ), 10, 2 );
 		
 		// Add Editorial Metadata to the calendar if the calendar is activated
 		if ( $this->module_enabled( 'calendar' ) )
@@ -246,14 +243,11 @@ class EF_Editorial_Metadata extends EF_Module {
 		}
 		// A bit of custom CSS for the Manage Posts view if we have viewable metadata
 		if ( $current_screen->base == 'edit' && in_array( $current_post_type, $supported_post_types ) ) {
-			// data to pass for quick edit
-			$ef_quick_edit_data = array();
-
 			$terms = $this->get_editorial_metadata_terms();
 			$viewable_terms = array();
 			foreach( $terms as $term ) {
-				if ( $term->viewable )
-					$viewable_terms[] = $term; 
+				if ( $term->viewable ) 
+					$viewable_terms[] = $term;
 			}
 			if ( !empty( $viewable_terms ) ) {
 				$css_rules = array(
@@ -292,12 +286,6 @@ class EF_Editorial_Metadata extends EF_Module {
 							);
 							break;
 					}
-
-					// quick edit lookup selector and type by input name
-					$ef_quick_edit_data['_ef_editorial_meta_' . $viewable_term->type . '_' . $viewable_term->slug] = array(
-						'type' => $viewable_term->type,
-						'selector' => '.column-' . $this->module->slug . '-' . $viewable_term->slug
-					);
 				}
 				// Allow users to filter out rules if there's something wonky
 				$css_rules = apply_filters( 'ef_editorial_metadata_manage_posts_css_rules', $css_rules );
@@ -307,13 +295,7 @@ class EF_Editorial_Metadata extends EF_Module {
 				}
 				echo '</style>';
 			}
-
-			// Javascript for quick edit ( display input values )
-			$ef_quick_edit_handle = 'edit-flow-editorial-metadata-quick-edit';
-
-			wp_register_script( $ef_quick_edit_handle, EDIT_FLOW_URL . 'modules/editorial-metadata/lib/editorial-metadata-quick-edit.js', array( 'jquery' ), EDIT_FLOW_VERSION, true );
-			wp_localize_script( $ef_quick_edit_handle, 'ef_quick_edit', $ef_quick_edit_data );
-			wp_enqueue_script( $ef_quick_edit_handle );
+			
 		}
 		
 		// Load Javascript specific to the editorial metadata configuration view
@@ -391,96 +373,69 @@ class EF_Editorial_Metadata extends EF_Module {
 			echo '<p>' . $message . '</p>';
 		} else {
 			foreach ( $terms as $term ) {
-				$this->display_field( $term, $post->ID );
-			} // Done iterating through metadata terms
+				$postmeta_key = $this->get_postmeta_key( $term );
+				$current_metadata = esc_attr( $this->get_postmeta_value( $term, $post->ID ) );
+				$type = $term->type;
+				$description = $term->description;
+				if ( $description )
+					$description_span = "<span class='description'>$description</span>";
+				else
+					$description_span = '';
+				echo "<div class='" . self::metadata_taxonomy . " " . self::metadata_taxonomy . "_$type'>";
+				switch( $type ) {
+					case "date":
+						// TODO: Move this to a function
+						if ( !empty( $current_metadata ) ) {
+							// Turn timestamp into a human-readable date
+							$current_metadata = $this->show_date_or_datetime( intval( $current_metadata ) );	
+						}
+						echo "<label for='$postmeta_key'>{$term->name}</label>";
+						if ( $description_span )
+							echo "<label for='$postmeta_key'>$description_span</label>";
+						echo "<input id='$postmeta_key' name='$postmeta_key' type='text' class='date-time-pick' value='$current_metadata' />";
+						break;
+					case "location":
+						echo "<label for='$postmeta_key'>{$term->name}</label>";
+						if ( $description_span )
+							echo "<label for='$postmeta_key'>$description_span</label>";
+						echo "<input id='$postmeta_key' name='$postmeta_key' type='text' value='$current_metadata' />";
+						if ( !empty( $current_metadata ) )
+							echo "<div><a href='http://maps.google.com/?q={$current_metadata}&t=m' target='_blank'>" . sprintf( __( 'View &#8220;%s&#8221; on Google Maps', 'edit-flow' ), $current_metadata ) . "</a></div>";
+						break;
+					case "text":
+						echo "<label for='$postmeta_key'>{$term->name}$description_span</label>";
+						echo "<input id='$postmeta_key' name='$postmeta_key' type='text' value='$current_metadata' />";
+						break;
+					case "paragraph":
+						echo "<label for='$postmeta_key'>{$term->name}$description_span</label>";
+						echo "<textarea id='$postmeta_key' name='$postmeta_key'>$current_metadata</textarea>";
+						break;
+					case "checkbox":
+						echo "<label for='$postmeta_key'>{$term->name}$description_span</label>";
+						echo "<input id='$postmeta_key' name='$postmeta_key' type='checkbox' value='1' " . checked($current_metadata, 1, false) . " />";
+						break;
+					case "user": 
+						echo "<label for='$postmeta_key'>{$term->name}$description_span</label>";
+						$user_dropdown_args = array( 
+								'show_option_all' => __( '-- Select a user --', 'edit-flow' ), 
+								'name'     => $postmeta_key,
+								'selected' => $current_metadata 
+							);
+						$user_dropdown_args = apply_filters( 'ef_editorial_metadata_user_dropdown_args', $user_dropdown_args );
+						wp_dropdown_users( $user_dropdown_args );
+						break;
+					case "number":
+						echo "<label for='$postmeta_key'>{$term->name}$description_span</label>";
+						echo "<input id='$postmeta_key' name='$postmeta_key' type='text' value='$current_metadata' />";
+						break;					
+					default:
+						echo "<p>" . __( 'This editorial metadata type is not yet supported.', 'edit-flow' ) . "</p>";
+				}
+			echo "</div>";
+			echo "<div class='clear'></div>";
+		} // Done iterating through metadata terms
 		}		
 		echo "</div>";
-	}
-
-	/**
-	 * Displays HTML output for inputs in meta box and quick edit box
-	 *
-	 * @param object $term Term's object representation
-	 * @param int $post_id The ID of the post
-	 * @param boolean $quick_edit If in quick edit box or not
-	 */
-	public function display_field( $term, $post_id = 0, $quick_edit = false ) {
-		$postmeta_key = $this->get_postmeta_key( $term );
-		$current_metadata = esc_attr( $this->get_postmeta_value( $term, $post_id ) );
-		$type = $term->type;
-		$description = $term->description;
-
-		if ( $description && $post_id )
-			$description_span = "<span class='description'>$description</span>";
-		else
-			$description_span = '';
-		echo "<div class='" . self::metadata_taxonomy . " " . self::metadata_taxonomy . "_$type'>";
-
-		if( $type == 'date' || $type == 'location' ) {
-			$label = "<label for='$postmeta_key'>{$term->name}</label>";
-		} else {
-			$label = "<label for='$postmeta_key'>{$term->name}$description_span</label>";
-		}
-
-		if( $quick_edit )
-			$label = "<div class='ef_editorial_meta_left'>$label</div>";
-
-		echo $label;
-
-		if( $quick_edit )
-			echo "<div class='ef_editorial_meta_right'>";
-
-		switch( $type ) {
-			case "date":
-				// TODO: Move this to a function
-				if ( !empty( $current_metadata ) ) {
-					// Turn timestamp into a human-readable date
-					$current_metadata = $this->show_date_or_datetime( intval( $current_metadata ) );	
-				}
-				if ( $description_span )
-					echo "<label for='$postmeta_key'>$description_span</label>";
-
-				$class = !$quick_edit ? 'date-time-pick' : '';
-
-				echo "<input id='$postmeta_key' name='$postmeta_key' type='text' class='$class' value='$current_metadata' />";
-				break;
-			case "location":
-				if ( $description_span )
-					echo "<label for='$postmeta_key'>$description_span</label>";
-				echo "<input id='$postmeta_key' name='$postmeta_key' type='text' value='$current_metadata' />";
-				if ( !empty( $current_metadata ) )
-					echo "<div><a href='http://maps.google.com/?q={$current_metadata}&t=m' target='_blank'>" . sprintf( __( 'View &#8220;%s&#8221; on Google Maps', 'edit-flow' ), $current_metadata ) . "</a></div>";
-				break;
-			case "text":
-				echo "<input id='$postmeta_key' name='$postmeta_key' type='text' value='$current_metadata' />";
-				break;
-			case "paragraph":
-				echo "<textarea id='$postmeta_key' name='$postmeta_key'>$current_metadata</textarea>";
-				break;
-			case "checkbox":
-				echo "<input id='$postmeta_key' name='$postmeta_key' type='checkbox' value='1' " . checked($current_metadata, 1, false) . " />";
-				break;
-			case "user": 
-				$user_dropdown_args = array( 
-						'show_option_all' => __( '-- Select a user --', 'edit-flow' ), 
-						'name'     => $postmeta_key,
-						'selected' => $current_metadata 
-					);
-				$user_dropdown_args = apply_filters( 'ef_editorial_metadata_user_dropdown_args', $user_dropdown_args );
-				wp_dropdown_users( $user_dropdown_args );
-				break;
-			case "number":
-				echo "<input id='$postmeta_key' name='$postmeta_key' type='text' value='$current_metadata' />";
-				break;					
-			default:
-				echo "<p>" . __( 'This editorial metadata type is not yet supported.', 'edit-flow' ) . "</p>";
-		}
-
-		if( $quick_edit )
-			echo "</div>";
-
-		echo "</div>";
-		echo "<div class='clear'></div>";
 	}
 	
 	/**
@@ -698,15 +653,13 @@ class EF_Editorial_Metadata extends EF_Module {
 		$screen = get_current_screen();
 		if ( $screen ) {
 			add_filter( "manage_{$screen->id}_sortable_columns", array( $this, 'filter_manage_posts_sortable_columns' ) );
+			$terms = $this->get_editorial_metadata_terms( array( 'viewable' => true ) );
+			foreach( $terms as $term ) {
+				// Prefixing slug with module slug because it isn't stored prefixed and we want to avoid collisions
+				$key = $this->module->slug . '-' . $term->slug;
+				$posts_columns[$key] = $term->name;
+			}
 		}
-			
-		$terms = $this->get_editorial_metadata_terms( array( 'viewable' => true ) );
-		foreach( $terms as $term ) {
-			// Prefixing slug with module slug because it isn't stored prefixed and we want to avoid collisions
-			$key = $this->module->slug . '-' . $term->slug;
-			$posts_columns[$key] = $term->name;
-		}
-		
 		return $posts_columns;
 	}
 	
@@ -768,56 +721,6 @@ class EF_Editorial_Metadata extends EF_Module {
 			echo $this->generate_editorial_metadata_term_output( $term, $current_metadata );
 		}
 		
-	}
-
-	/**
-	 * Handle the output of editorial metadata quick edit box
-	 *
-	 * @since 2.7
-	 * @uses do_action( 'quick_edit_custom_box' ) in wp-admin/includes/class-wp-terms-list-table.php
-	 *
-	 * @param string $column_name Unique string for the column
-	 * @param string $post_type Type of posts
-	 */
-	function action_quick_edit_custom_box( $column_name, $post_type ) {
-		$supported_post_types = $this->get_post_types_for_module( $this->module );
-
-		if( !in_array( $post_type, $supported_post_types ) )
-			return;
-
-		$terms = $this->get_editorial_metadata_terms( array( 'viewable' => true ) );
-		$terms_count = count( $terms );
-
-		if( !$terms_count )
-			return;
-
-		$counter = -1; 
-
-		foreach( $terms as $term ) {
-			$counter++;
-
-			$key = $this->module->slug . '-' . $term->slug;
-			if ( $column_name != $key )
-				continue;
-
-			// Wrap inputs in fieldset
-			if( $counter === 0 ) {
-				echo '<div class="clear"></div>';
-				echo '<fieldset class="ef_editorial_meta_quick_edit">';
-				echo '<div class="inline-edit-col">';
-
-				// Add nonce for verification upon save
-				echo "<input type='hidden' name='" . self::metadata_taxonomy . "_nonce' value='" . wp_create_nonce(__FILE__) . "' />";
-			}
-
-			$this->display_field( $term , 0, true );
-
-			// Wrap inputs in fieldset
-			if( $counter === $terms_count - 1 ) {
-				echo '</div>';
-				echo '</fieldset>';
-			}
-		}
 	}
 	
 	/**

--- a/modules/editorial-metadata/lib/editorial-metadata-quick-edit.js
+++ b/modules/editorial-metadata/lib/editorial-metadata-quick-edit.js
@@ -1,0 +1,52 @@
+(function($) {
+
+	// we create a copy of the WP inline edit post function
+	var $wp_inline_edit = inlineEditPost.edit;
+
+	// and then we overwrite the function with our own code
+	inlineEditPost.edit = function( id ) {
+
+		// "call" the original WP edit function
+		// we don't want to leave WordPress hanging
+		$wp_inline_edit.apply( this, arguments );
+
+		// now we take care of our business
+
+		// check for ef_quick_edit global var
+		if ( !window.hasOwnProperty( 'ef_quick_edit' ) )
+			return;
+
+		// get the post ID
+		var $post_id = 0;
+
+		if ( typeof( id ) == 'object' ) {
+			$post_id = parseInt( this.getId( id ) );
+		}
+
+		if ( $post_id > 0 ) {
+			// define the edit row
+			var $edit_row = $( '#edit-' + $post_id );
+			var $post_row = $( '#post-' + $post_id );
+
+			// loop through input names and display value from column value ( fetched with selector )
+			for ( var name in ef_quick_edit ) {
+				var selector = ef_quick_edit[name].selector,
+					type = ef_quick_edit[name].type,
+					val = $( selector, $post_row ).text(),
+					$input = $( '#' + name, $edit_row );
+
+				if ( type == 'checkbox' ) {
+					val = val.toLowerCase();
+					$input.prop( 'checked', val == 'yes' ? true : false );
+				} else if ( type == 'user' ) {
+					$input.find( 'option' ).filter( function() {
+						return $( this ).text() == val;
+					} ).prop( 'selected', true );
+				} else {
+					$input.val( val );
+				}
+			}
+		}
+	};
+
+})(jQuery);

--- a/modules/editorial-metadata/lib/editorial-metadata-quick-edit.js
+++ b/modules/editorial-metadata/lib/editorial-metadata-quick-edit.js
@@ -43,16 +43,24 @@
 						return $( this ).text() == val;
 					} ).prop( 'selected', true );
 				} else if ( type == 'date' ) {
-					var date = new Date( val.replace( 'at ', '' ) );
+					var date = '',
+						args = {
+							dateFormat: 'M dd yy',
+							firstDay: ef_week_first_day,
+							alwaysSetTime: false,
+							controlType: 'select'
+						};
+
+					if( val ) {
+						date = new Date( val.replace( 'at ', '' ) );
+						args['defaultDate'] = date;
+					}
 
 					// init datetime picker
-					$input.datetimepicker( {
-						dateFormat: 'M dd yy',
-						firstDay: ef_week_first_day,
-						alwaysSetTime: false,
-						controlType: 'select',
-						defaultDate: date
-					} ).datetimepicker( 'setDate', date );
+					$input.datetimepicker( args );
+
+					if( val )
+						$input.datetimepicker( 'setDate', date );
 				} else {
 					$input.val( val );
 				}

--- a/modules/editorial-metadata/lib/editorial-metadata-quick-edit.js
+++ b/modules/editorial-metadata/lib/editorial-metadata-quick-edit.js
@@ -33,7 +33,7 @@
 				var selector = ef_quick_edit[name].selector,
 					type = ef_quick_edit[name].type,
 					val = $( selector, $post_row ).text(),
-					$input = $( '#' + name, $edit_row );
+					$input = $( '[name="' + name + '"]', $edit_row );
 
 				if ( type == 'checkbox' ) {
 					val = val.toLowerCase();
@@ -42,6 +42,17 @@
 					$input.find( 'option' ).filter( function() {
 						return $( this ).text() == val;
 					} ).prop( 'selected', true );
+				} else if ( type == 'date' ) {
+					var date = new Date( val.replace( 'at ', '' ) );
+
+					// init datetime picker
+					$input.datetimepicker( {
+						dateFormat: 'M dd yy',
+						firstDay: ef_week_first_day,
+						alwaysSetTime: false,
+						controlType: 'select',
+						defaultDate: date
+					} ).datetimepicker( 'setDate', date );
 				} else {
 					$input.val( val );
 				}

--- a/modules/editorial-metadata/lib/editorial-metadata.css
+++ b/modules/editorial-metadata/lib/editorial-metadata.css
@@ -73,6 +73,61 @@
 	margin-top: 6px;
 }
 
+/* Quick edit styles */
+#wpbody-content .inline-edit-row fieldset.ef_editorial_meta_quick_edit {
+	width: 40%;
+	margin-top: 3px;
+}
+
+.ef_editorial_meta_quick_edit .ef_editorial_meta,
+.ef_editorial_meta_quick_edit .ef_editorial_meta_left,
+.ef_editorial_meta_quick_edit .ef_editorial_meta_right {
+	box-sizing: border-box;
+}
+
+.ef_editorial_meta_quick_edit .ef_editorial_meta {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-flex-wrap: wrap;
+    -ms-flex-wrap: wrap;
+    flex-wrap: wrap;
+    margin: -5px -5px 2px -5px;
+}
+
+.ef_editorial_meta_quick_edit .ef_editorial_meta_left,
+.ef_editorial_meta_quick_edit .ef_editorial_meta_right {
+	padding: 5px;
+}
+
+.ef_editorial_meta_quick_edit .ef_editorial_meta_left {
+    width: 8em;
+}
+
+.ef_editorial_meta_quick_edit .ef_editorial_meta_right {
+	width: calc(100% - 8em);
+}
+
+.ef_editorial_meta_quick_edit label {
+	line-height: unset !important;
+	margin: 0 !important;
+	font-style: italic;
+}
+
+.ef_editorial_meta_quick_edit input[type=text],
+.ef_editorial_meta_quick_edit textarea {
+	width: 100%;
+}
+
+@media screen and ( max-width: 782px ) {
+	#wpbody-content .inline-edit-row fieldset.ef_editorial_meta_quick_edit,
+	.ef_editorial_meta_quick_edit .ef_editorial_meta_left,
+	.ef_editorial_meta_quick_edit .ef_editorial_meta_right {
+		width: 100%;
+	}
+}
+
 /*
  * If editorial metadata is in the main post column, allow the metadata to be laid out in
  * multiple columns in browsers that support it.


### PR DESCRIPTION
Issue #160 discusses the addition of editorial metadata to the quick edit box to make it easier for users to update this content. Below is the php, js and css to make this addition. I've added the output for the editorial metadata fields, that are 'viewable' to match what is in the custom columns. I also added some js to display the right values in the fields. This all pretty much follows: https://codex.wordpress.org/Plugin_API/Action_Reference/quick_edit_custom_box. I did rework a bit of the existing code in the editorial-meta.php file like taking the input generation out of the display_meta_box method into it's own method for use in the quick_edit_custom_box callback and removing the get_current_screen() conditional from the manage_posts_custom_column callback output because it resulted in empty table cells when updating the quick edit box since it's undefined in ajax calls.