### PR TITLE
Post Author notifications UI fixes

### DIFF
--- a/modules/notifications/lib/notifications.css
+++ b/modules/notifications/lib/notifications.css
@@ -108,3 +108,11 @@
 #ef-usergroup-users h4 {
 	margin-top: 0;
 }
+
+.ef-post_following_list .post-author {
+	margin-right: 10px;
+	border: solid 2px #b8b8b8;
+	color: #b8b8b8;
+	padding: 4px;
+}
+

--- a/modules/notifications/lib/notifications.js
+++ b/modules/notifications/lib/notifications.js
@@ -31,25 +31,25 @@ jQuery(document).ready(function($) {
 	}
 
 	var maybe_disable_post_author_checkbox = function( ) {
-		if ( typeof post_author_is_follower == 'undefined' ) {
+		if ( typeof ef_post_author_is_follower == 'undefined' ) {
 			return;
 		}
-		if ( true == post_author_is_follower && true == post_author_auto_subscribe ) {
-			$('#ef-selected-users-' + post_author_id ).prop('disabled', true);
+		if ( true == ef_post_author_is_follower && true == ef_post_author_auto_subscribe ) {
+			$('#ef-selected-users-' + ef_post_author_id ).prop('disabled', true);
 		}
 	}
 
 	var display_post_author_warning = function( ) {
-		if ( typeof post_author_is_follower == 'undefined' ) {
+		if ( typeof ef_post_author_is_follower == 'undefined' ) {
 			return;
 		}
-		if ( true == post_author_is_follower && true == post_author_auto_subscribe ) {
-			$("label[for='ef-selected-users-" + post_author_id + "'] .ef-user-subscribe-actions").prepend( "<span class='post-author'>" + ef_notifications_localization.post_author + "</span>" );
+		if ( true == ef_post_author_is_follower && true == ef_post_author_auto_subscribe ) {
+			$("label[for='ef-selected-users-" + ef_post_author_id + "'] .ef-user-subscribe-actions").prepend( "<span class='post-author'>" + ef_notifications_localization.post_author + "</span>" );
 		}
 	}
 
-	if ( typeof post_author_is_follower !== 'undefined' 
-	&& typeof post_author_auto_subscribe !== 'undefined' ) {
+	if ( typeof ef_post_author_is_follower !== 'undefined' 
+	&& typeof ef_post_author_auto_subscribe !== 'undefined' ) {
 		maybe_disable_post_author_checkbox();
 		display_post_author_warning();
 	}

--- a/modules/notifications/lib/notifications.js
+++ b/modules/notifications/lib/notifications.js
@@ -30,6 +30,30 @@ jQuery(document).ready(function($) {
 		}
 	}
 
+	var maybe_disable_post_author_checkbox = function( ) {
+		if ( typeof post_author_is_follower == 'undefined' ) {
+			return;
+		}
+		if ( true == post_author_is_follower && true == post_author_auto_subscribe ) {
+			$('#ef-selected-users-' + post_author_id ).prop('disabled', true);
+		}
+	}
+
+	var display_post_author_warning = function( ) {
+		if ( typeof post_author_is_follower == 'undefined' ) {
+			return;
+		}
+		if ( true == post_author_is_follower && true == post_author_auto_subscribe ) {
+			$("label[for='ef-selected-users-" + post_author_id + "'] .ef-user-subscribe-actions").prepend( "<span class='post-author'>Post Author</span>" );
+		}
+	}
+
+	if ( typeof post_author_is_follower !== 'undefined' 
+	&& typeof post_author_auto_subscribe !== 'undefined' ) {
+		maybe_disable_post_author_checkbox();
+		display_post_author_warning();
+	}
+
 	$(document).on('click','.ef-post_following_list li input:checkbox, .ef-following_usergroups li input:checkbox', function() {
 		var user_group_ids = [];
 		var parent_this = $(this);

--- a/modules/notifications/lib/notifications.js
+++ b/modules/notifications/lib/notifications.js
@@ -44,7 +44,7 @@ jQuery(document).ready(function($) {
 			return;
 		}
 		if ( true == post_author_is_follower && true == post_author_auto_subscribe ) {
-			$("label[for='ef-selected-users-" + post_author_id + "'] .ef-user-subscribe-actions").prepend( "<span class='post-author'>Post Author</span>" );
+			$("label[for='ef-selected-users-" + post_author_id + "'] .ef-user-subscribe-actions").prepend( "<span class='post-author'>" + ef_notifications_localization.post_author + "</span>" );
 		}
 	}
 

--- a/modules/notifications/notifications.php
+++ b/modules/notifications/notifications.php
@@ -199,7 +199,8 @@ class EF_Notifications extends EF_Module {
 				'ef_notifications_localization',
 				array(
 					'no_access' => esc_html__( 'No Access', 'edit-flow' ),
-					'no_email' => esc_html__( 'No Email', 'edit-flow' )
+					'no_email' => esc_html__( 'No Email', 'edit-flow' ),
+					'post_author' => esc_html__( 'Post Author', 'edit-flow' ),
 				)
 			);
 		}

--- a/modules/notifications/notifications.php
+++ b/modules/notifications/notifications.php
@@ -343,6 +343,17 @@ jQuery(document).ready(function($) {
 				<h4><?php _e( 'Users', 'edit-flow' ); ?></h4>
 				<?php
 				$followers = $this->get_following_users( $post->ID, 'id' );
+
+				$post_author_is_follower = ! empty( in_array( $post->post_author, $followers ) ) ? 'true' : 'false' ;
+				$post_author_auto_subscribe = apply_filters( 'ef_notification_auto_subscribe_post_author', true, 'subscription_action' ) ? 'true' : 'false' ;
+
+				wp_add_inline_script( 'edit-flow-notifications-js', 
+					'var post_author_id = ' . $post->post_author . '; ' . 
+					'var post_author_is_follower = ' . $post_author_is_follower . '; ' .
+					'var post_author_auto_subscribe = ' . $post_author_auto_subscribe . ';',
+					'before'
+				);
+
 				$select_form_args = array(
 					'list_class' => 'ef-post_following_list',
 				);

--- a/modules/notifications/notifications.php
+++ b/modules/notifications/notifications.php
@@ -349,9 +349,9 @@ jQuery(document).ready(function($) {
 				$post_author_auto_subscribe = apply_filters( 'ef_notification_auto_subscribe_post_author', true, 'subscription_action' ) ? 'true' : 'false' ;
 
 				wp_add_inline_script( 'edit-flow-notifications-js', 
-					'var post_author_id = ' . $post->post_author . '; ' . 
-					'var post_author_is_follower = ' . $post_author_is_follower . '; ' .
-					'var post_author_auto_subscribe = ' . $post_author_auto_subscribe . ';',
+					'var ef_post_author_id = ' . wp_json_encode( $post->post_author ) . '; ' . 
+					'var ef_post_author_is_follower = ' .  $post_author_is_follower  . '; ' .
+					'var ef_post_author_auto_subscribe = ' .  $post_author_auto_subscribe  . ';',
 					'before'
 				);
 


### PR DESCRIPTION
This PR will disable the notifications checkbox for `post_authors` if:

- The `ef_notification_auto_subscribe_post_author` filter is true (default behaviour)
- If the `post_author` is currently subscribed (there is an edge case where they might not be)

We also add a visual indication that the user is the Post Author:
<img width="590" alt="Screen Shot 2019-08-22 at 2 33 50 PM" src="https://user-images.githubusercontent.com/3220162/63551388-e6cb0680-c4e9-11e9-9351-2e0063715ae2.png">

**Thoughts on implementation:**
My first attempt was to change how the user list is populated in `class-module.php`, but I quickly realized that looping through each user to programmatically add details is resource-intensive when you have many users.  I opted for JavaScript because this way we don't have to loop through each user, we can just target one specific user and modify the elements that way.

Fixes #508 