### PR TITLE
Remove extra plugin headers

### DIFF
--- a/edit-flow.php
+++ b/edit-flow.php
@@ -1,33 +1,11 @@
 <?php
-/*
-Plugin Name: Edit Flow
-Plugin URI: http://editflow.org/
-Description: Remixing the WordPress admin for better editorial workflow options.
-Author: Daniel Bachhuber, Scott Bressler, Mohammad Jangda, Automattic, and others
-Version: 0.9
-Author URI: http://editflow.org/
-
-Copyright 2009-2019 Mohammad Jangda, Daniel Bachhuber, Automattic, et al.
-
-GNU General Public License, Free Software Foundation <http://creativecommons.org/licenses/GPL/2.0/>
-
-This program is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 2 of the License, or
-(at your option) any later version.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this program; if not, write to the Free Software
-Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 /**
- * Load the somewhat poorly named edit_flow.php primary plugin file
+ * Load the somewhat poorly named edit_flow.php primary plugin file.
+ *
  * It's been named edit_flow.php in the master repo since the beginning
- * and we can't rename it because it will break everyone's activations
+ * and we can't rename it because it will break everyone's activations.
+ *
+ * Since this is not the primary plugin file, it does not have the standard WordPress headers.
  */
 require_once dirname( __FILE__ ) . '/edit_flow.php';


### PR DESCRIPTION
From the compat file. Having the headers in both the underscore and hyphen version of the files results in two copies of "Edit Flow" showing up in the Plugin list.

Related #512