### PR TITLE
Fix failing TravisCI tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,8 @@ matrix:
 
 before_script:
     - bash bin/install-wp-tests.sh wordpress_test root '' localhost $WP_VERSION
-    - export PATH="$HOME/.composer/vendor/bin:$PATH"
+    - export COMPOSER_BIN_DIR="$HOME/.config/composer/vendor/bin"
+    - export PATH="$COMPOSER_BIN_DIR:$PATH"
     - |
         if [[ ${TRAVIS_PHP_VERSION:0:2} == "7." ]]; then
           composer global require "phpunit/phpunit=5.7.*"

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ php:
     - "7.0"
     - "7.1"
 
+services:
+    - mysql
+
 env:
     - WP_VERSION=latest WP_MULTISITE=0 #Current stable release
 


### PR DESCRIPTION
- Add MySQL as a service inside Travis
- Use the custom installed version of PHPUnit if there is one.

Travis should have been calling the globally installed version according to [here](https://docs.travis-ci.com/user/languages/php/#default-build-script), but for some reason was not.

The custom PHPUnit install logic can probably be dropped once support for PHP 7.1/7.2 is no longer required.