### PR TITLE
Update PHP 7 version in TravicCI build Matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ language: php
 
 php:
     - "5.6"
-    - "7.0"
-    - "7.1"
+    - "7.2"
+    - "7.3"
 
 services:
     - mysql
@@ -11,7 +11,7 @@ services:
 env:
     - WP_VERSION=latest WP_MULTISITE=0 #Current stable release
 
-# Test WP 5.1 and 5.2 and on PHP 5.6, 7.0 and 7.1 (w and w/o multisite enabled)
+# Test WP 5.1 and 5.2 and on PHP 5.6, 7.2 and 7.3 (w and w/o multisite enabled)
 # Test WP master on PHP nightly and allow_failures (w/o multisite enabled)
 
 matrix:
@@ -19,27 +19,27 @@ matrix:
     # current stable release w/ multisite
     - php: "5.6"
       env: WP_VERSION=5.1 WP_MULTISITE=0
-    - php: "7.0"
+    - php: "7.2"
       env: WP_VERSION=5.1 WP_MULTISITE=0
-    - php: "7.1"
+    - php: "7.3"
       env: WP_VERSION=5.1 WP_MULTISITE=0
     - php: "5.6"
       env: WP_VERSION=5.1 WP_MULTISITE=1
-    - php: "7.0"
+    - php: "7.2"
       env: WP_VERSION=5.1 WP_MULTISITE=1
-    - php: "7.1"
+    - php: "7.3"
       env: WP_VERSION=5.1 WP_MULTISITE=1
     - php: "5.6"
       env: WP_VERSION=5.2 WP_MULTISITE=0
-    - php: "7.0"
+    - php: "7.2"
       env: WP_VERSION=5.2 WP_MULTISITE=0
-    - php: "7.1"
+    - php: "7.3"
       env: WP_VERSION=5.2 WP_MULTISITE=0
     - php: "5.6"
       env: WP_VERSION=5.2 WP_MULTISITE=1
-    - php: "7.0"
+    - php: "7.2"
       env: WP_VERSION=5.2 WP_MULTISITE=1
-    - php: "7.1"
+    - php: "7.3"
       env: WP_VERSION=5.2 WP_MULTISITE=1
     - php: "nightly"
       env: WP_VERSION=latest WP_MULTISITE=0


### PR DESCRIPTION
Updates the CI build versions to use current and previous version of PHP 7.x

Note: `nightly` cannot currently work due to a conflict between PHPUnit dependencies and the WordPress version requirements.  Nightly (PHP 8.0.0-dev) requires PHPUnit 8+ but the WordPress test suite only works with PHPUnit 5.7 or older.