### PR TITLE
Fix PHP count() warning

### DIFF
--- a/edit_flow.php
+++ b/edit_flow.php
@@ -95,9 +95,8 @@ class edit_flow {
 	}
 
 	private function setup_globals() {
-
 		$this->modules = new stdClass();
-
+		$this->modules_count = 0;
 	}
 
 	/**
@@ -295,6 +294,8 @@ class edit_flow {
 			add_action( 'load-edit-flow_page_' . $args['settings_slug'], array( &$this->$name, 'action_settings_help_menu' ) );
 
 		$this->modules->$name = (object) $args;
+
+		$this->modules_count++;
 
 		/**
 		 * Fires after edit_flow has registered a module.

--- a/modules/settings/settings.php
+++ b/modules/settings/settings.php
@@ -225,18 +225,18 @@ class EF_Settings extends EF_Module {
 		<?php endif; ?>
 		<?php
 	}
-	
+
 	function print_modules() {
 		global $edit_flow;
-		
-		if ( !count( $edit_flow->modules ) ) {
+
+		if ( ! $edit_flow->modules_count ) {
 			echo '<div class="message error">' . __( 'There are no Edit Flow modules registered', 'edit-flow' ) . '</div>';
 		} else {
-			
+
 			foreach ( $edit_flow->modules as $mod_name => $mod_data ) {
 				if ( $mod_data->autoload )
 					continue;
-				
+
 				$classes = array(
 					'edit-flow-module',
 				);


### PR DESCRIPTION
```
PHP Warning: count(): Parameter must be an array or an object that implements Countable
```

Switch to a another instance var that tracks the module count rather than trying to force the `modules` object into an array and back.

Fixes #498 

## To Test

1. Make sure you're using PHP 7.2 or newer and `WP_DEBUG` is set.
1. Goto `/wp-admin/admin.php?page=ef-settings`
1. Should see the warning.
1. Apply patch.
1. Refresh page and verify that error is gone and page renders correctly.