### PR TITLE
Bump min versions

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,9 +2,9 @@
 Contributors: batmoo, danielbachhuber, sbressler, automattic
 Donate link: http://editflow.org/contribute/
 Tags: edit flow, workflow, editorial, newsroom, management, journalism, post status, custom status, notifications, email, comments, editorial comments, usergroups, calendars, editorial calendar, story budget
-Requires at least: 4.5
-Requires PHP: 5.4
-Tested up to: 5.0.3
+Requires at least: 5.1
+Requires PHP: 5.6
+Tested up to: 5.3
 Stable tag: 0.9
 
 Redefining your editorial workflow.


### PR DESCRIPTION
- WordPress 5.1 (current - 1)
- PHP 5.6 (matches WordPress' min)

And tested up to WordPress 5.3.