### PR TITLE
Check module is enabled before compat init

### DIFF
--- a/common/php/class-module.php
+++ b/common/php/class-module.php
@@ -28,6 +28,17 @@ class EF_Module {
 	function __construct() {}
 
 	/**
+	 * Returns whether the current module is enabled.
+	 *
+	 * @since 0.9.1
+	 *
+	 * @return <code>true</code> if the module is enabled, <code>false</code> otherwise
+	 */
+	public function is_enabled() {
+		return $this->module->options->enabled === 'on';
+	}
+
+	/**
 	 * Returns whether the module with the given name is enabled.
 	 *
 	 * @since 0.7
@@ -38,7 +49,7 @@ class EF_Module {
 	function module_enabled( $slug ) {
 		global $edit_flow;
 
-		return isset( $edit_flow->$slug ) && $edit_flow->$slug->module->options->enabled == 'on';
+		return isset( $edit_flow->$slug ) && $edit_flow->$slug->is_enabled();
 	}
 
 	/**

--- a/common/php/trait-block-editor-compatible.php
+++ b/common/php/trait-block-editor-compatible.php
@@ -49,6 +49,10 @@ trait Block_Editor_Compatible {
 	 * @return void
 	 */
 	function action_init_for_admin() {
+		if ( ! $this->ef_module->is_enabled() ) {
+			return;
+		}
+
 		$this->check_active_plugins();
 
 		if ( $this->should_apply_compat() ) {

--- a/modules/custom-status/compat/block-editor.php
+++ b/modules/custom-status/compat/block-editor.php
@@ -10,15 +10,15 @@ class EF_Custom_Status_Block_Editor_Compat {
 	 * @return void
 	 */
 	function action_admin_enqueue_scripts() {
+		if ( $this->ef_module->disable_custom_statuses_for_post_type() ) {
+			return;
+		}
+
 		/**
 		 * WP_Screen::is_block_editor only available in 5.0. If it's available and is false it's safe to say we should only pass through to the module.
 		 */
 		if ( Block_Editor_Compatible::is_at_least_50() && ! get_current_screen()->is_block_editor() ) {
 			return $this->ef_module->action_admin_enqueue_scripts();
-		}
-
-		if ( $this->ef_module->disable_custom_statuses_for_post_type() ) {
-			return;
 		}
 
 		wp_enqueue_style( 'edit-flow-block-custom-status', EDIT_FLOW_URL . 'blocks/dist/custom-status.editor.build.css', false, EDIT_FLOW_VERSION );

--- a/modules/custom-status/custom-status.php
+++ b/modules/custom-status/custom-status.php
@@ -282,11 +282,13 @@ class EF_Custom_Status extends EF_Module {
 		if ( ! in_array( $pagenow, array( 'edit.php', 'post.php', 'post-new.php' ) ) )
 			return false;
 
-		if ( is_null( $post_type ) )
+		if ( is_null( $post_type ) ) {
 			$post_type = $this->get_current_post_type();
+		}
 
-		if ( $post_type && ! in_array( $post_type, $this->get_post_types_for_module( $this->module ) ) )
+		if ( $post_type && ! in_array( $post_type, $this->get_post_types_for_module( $this->module ) ) ) {
 			return true;
+		}
 
 		return false;
 	}
@@ -300,8 +302,9 @@ class EF_Custom_Status extends EF_Module {
 	function action_admin_enqueue_scripts() {
 		global $pagenow;
 
-		if ( $this->disable_custom_statuses_for_post_type() )
+		if ( $this->disable_custom_statuses_for_post_type() ) {
 			return;
+		}
 
 		// Load Javascript we need to use on the configuration views (jQuery Sortable and Quick Edit)
 		if ( $this->is_whitelisted_settings_view( $this->module->name ) ) {

--- a/readme.txt
+++ b/readme.txt
@@ -2,9 +2,9 @@
 Contributors: batmoo, danielbachhuber, sbressler, automattic
 Donate link: http://editflow.org/contribute/
 Tags: edit flow, workflow, editorial, newsroom, management, journalism, post status, custom status, notifications, email, comments, editorial comments, usergroups, calendars, editorial calendar, story budget
-Requires at least: 4.5
-Requires PHP: 5.4
-Tested up to: 5.0.3
+Requires at least: 5.1
+Requires PHP: 5.6
+Tested up to: 5.3
 Stable tag: 0.9
 
 Redefining your editorial workflow.


### PR DESCRIPTION
Otherwise we end up triggering the compat hooks which can lead to breakages because of unexpected contexts (e.g. custom status javascript being loaded without necessary data).

Fixes #522

### To Test

1. Disable block editor (by installing and activating "Classic Editor" plugin)
1. Disable "Custom Statuses" module.
1. Editing a post will throw the error.
1. Apply patch.
1. Error should be gone.

Also, verify that the Block Editor is not impacted in any way:

1. Enable Custom Status and make sure editing works and custom status can be set and changed.
1. Disable Custom Status and make sure editing still works.
