### PR TITLE
Don't auto-subscribe the current user when notification settings are changed

### DIFF
--- a/modules/notifications/notifications.php
+++ b/modules/notifications/notifications.php
@@ -420,6 +420,7 @@ jQuery(document).ready(function($) {
 		}
 
 		if ( 'ef-selected-users[]' === $_POST['ef_notifications_name'] ) {
+		    add_filter('ef_notification_auto_subscribe_current_user', false, 10, 3);
 			$this->save_post_following_users( $post, $user_group_ids );
 			
 			if ( defined( 'DOING_AJAX' ) && DOING_AJAX && isset( $_POST['post_id'] ) ) {
@@ -509,7 +510,7 @@ jQuery(document).ready(function($) {
 	 *
 	 * @param int $post ID of the post
 	 */
-	function save_post_following_users( $post, $users = null ) {
+	function save_post_following_users( $post, $users = null, $options = array() ) {
 		if( !is_array( $users ) )
 			$users = array();
 		

--- a/modules/notifications/notifications.php
+++ b/modules/notifications/notifications.php
@@ -420,6 +420,7 @@ jQuery(document).ready(function($) {
 		}
 
 		if ( 'ef-selected-users[]' === $_POST['ef_notifications_name'] ) {
+			// Prevent auto-subscribing users that have opted out of notifications.
 			add_filter( 'ef_notification_auto_subscribe_current_user', '__return_false', PHP_INT_MAX );
 			$this->save_post_following_users( $post, $user_group_ids );
 			

--- a/modules/notifications/notifications.php
+++ b/modules/notifications/notifications.php
@@ -447,7 +447,8 @@ jQuery(document).ready(function($) {
 				
 				wp_send_json_success( $json_success );
 			}
-			remove_filter( 'ef_notification_auto_subscribe_current_user' );
+			// Remove auto-subscribe prevention behavior from earlier.
+			remove_filter( 'ef_notification_auto_subscribe_current_user', '__return_false', PHP_INT_MAX );
 		}
 		
 		$groups_enabled = $this->module_enabled( 'user_groups' ) && in_array( get_post_type( $post_id ), $this->get_post_types_for_module( $edit_flow->user_groups->module ) );

--- a/modules/notifications/notifications.php
+++ b/modules/notifications/notifications.php
@@ -420,7 +420,7 @@ jQuery(document).ready(function($) {
 		}
 
 		if ( 'ef-selected-users[]' === $_POST['ef_notifications_name'] ) {
-		    add_filter('ef_notification_auto_subscribe_current_user', false, 10, 3);
+			add_filter( 'ef_notification_auto_subscribe_current_user', '__return_false', PHP_INT_MAX );
 			$this->save_post_following_users( $post, $user_group_ids );
 			
 			if ( defined( 'DOING_AJAX' ) && DOING_AJAX && isset( $_POST['post_id'] ) ) {
@@ -447,6 +447,7 @@ jQuery(document).ready(function($) {
 				
 				wp_send_json_success( $json_success );
 			}
+			remove_filter( 'ef_notification_auto_subscribe_current_user' );
 		}
 		
 		$groups_enabled = $this->module_enabled( 'user_groups' ) && in_array( get_post_type( $post_id ), $this->get_post_types_for_module( $edit_flow->user_groups->module ) );
@@ -510,7 +511,7 @@ jQuery(document).ready(function($) {
 	 *
 	 * @param int $post ID of the post
 	 */
-	function save_post_following_users( $post, $users = null, $options = array() ) {
+	function save_post_following_users( $post, $users = null ) {
 		if( !is_array( $users ) )
 			$users = array();
 		


### PR DESCRIPTION
## Description

Anytime a post is saved, the current user is subscribed to the notifications. This includes when trying to remove themselves from the notification list resulting in it being impossible to unsubscribe from a post..  

This PR skips auto-subscribing the current user whenever the notifications settings are updated.All other auto-subscribe functionality is retained. The current user can still subscribe to the post and if they explicitly save it, they will be resubscribed. 

Related to #519 #520 

## Steps to Test

1. Edit to a post not owned by you
2. Unsubscribe from notifications.
3. Refresh the page and note that you were not unsubscribed
4. Apply patch
5. Unsubscribe from the post
6. Refresh the page, and note that you are now unsubscribed
7. Save the post
8. Refresh the page and confirm you are resubscribed
