### PR TITLE
Remove status column on posts and post types, replace with default labels

### DIFF
--- a/modules/custom-status/custom-status.php
+++ b/modules/custom-status/custom-status.php
@@ -100,15 +100,6 @@ class EF_Custom_Status extends EF_Module {
 		add_action( 'wp_ajax_update_status_positions', array( $this, 'handle_ajax_update_status_positions' ) );
 		add_action( 'wp_ajax_inline_save_status', array( $this, 'ajax_inline_save_status' ) );
 
-		// Hook to add the status column to Manage Posts
-
-		add_filter( 'manage_posts_columns', array( $this, '_filter_manage_posts_columns') );
-		add_action( 'manage_posts_custom_column', array( $this, '_filter_manage_posts_custom_column') );
-
-		// We need these for pages (http://core.trac.wordpress.org/browser/tags/3.3.1/wp-admin/includes/class-wp-posts-list-table.php#L283)
-		add_filter( 'manage_pages_columns', array( $this, '_filter_manage_posts_columns' ) );
-		add_action( 'manage_pages_custom_column', array( $this, '_filter_manage_posts_custom_column' ) );
-
 		// These seven-ish methods are hacks for fixing bugs in WordPress core
 		add_action( 'admin_init', array( $this, 'check_timestamp_on_publish' ) );
 		add_filter( 'wp_insert_post_data', array( $this, 'fix_custom_status_timestamp' ), 10, 2 );
@@ -127,7 +118,7 @@ class EF_Custom_Status extends EF_Module {
 		add_filter( 'wp_link_pages_link', array( $this, 'modify_preview_link_pagination_url' ), 10, 2 );
 
 		// Filter through Post States and run a function to check if they are also a Status
-		add_filter( 'display_post_states', array( $this, 'check_if_post_state_is_status' ), 10, 2 );
+		add_filter( 'display_post_states', array( $this, 'display_actual_post_state' ), 10, 2 );
 	}
 
 	/**
@@ -705,60 +696,25 @@ class EF_Custom_Status extends EF_Module {
 	}
 
 	/**
-	 * Insert new column header for post status after the title column
-	 *
-	 * @param array $posts_columns Columns currently shown on the Edit Posts screen
-	 * @return array Same array as the input array with a "status" column added after the "title" column
-	 */
-	function _filter_manage_posts_columns( $posts_columns ) {
-		// Return immediately if the supplied parameter isn't an array (which shouldn't happen in practice?)
-		// http://wordpress.org/support/topic/plugin-edit-flow-bug-shows-2-drafts-when-there-are-none-leads-to-error-messages
-		if ( !is_array( $posts_columns ) )
-			return $posts_columns;
-
-		// Only do it for the post types this module is activated for
-		if ( !in_array( $this->get_current_post_type(), $this->get_post_types_for_module( $this->module ) ) )
-			return $posts_columns;
-
-		$result = array();
-		foreach ( $posts_columns as $key => $value ) {
-			if ($key == 'title') {
-				$result[$key] = $value;
-				$result['status'] = __('Status', 'edit-flow');
-			} else $result[$key] = $value;
-		}
-		return $result;
-
-	}
-
-	/**
-	 * Adds a Post's status to its row on the Edit page
-	 *
-	 * @param string $column_name
-	 **/
-	function _filter_manage_posts_custom_column( $column_name ) {
-
-		if ( $column_name == 'status' ) {
-			global $post;
-			$post_status_obj = get_post_status_object( get_post_status( $post->ID ) );
-			echo esc_html( $post_status_obj->label );
-		}
-	}
-	/**
-	 * Check if Post State is a Status and display if it is not.
+	 * Display the actual post state where needed
 	 *
 	 * @param array $post_states An array of post display states.
 	 */
-	function check_if_post_state_is_status($post_states) {
+	function display_actual_post_state( $post_states, $post ) {
+		$status = get_post_status_object( get_post_status( $post->ID ) );
+		$status_key = $status->name;
 
-		global $post;
-		$statuses = get_post_status_object(get_post_status($post->ID));
-		foreach ( $post_states as $state ) {
-			if ( $state !== $statuses->label ) {
-				echo '<span class="show"></span>';
-			}
+		if ( $status_key === 'future' ) {
+			$status_key = 'scheduled';
 		}
+
+		if ( !isset( $_REQUEST['post_status'] ) 
+			&& !isset( $post_states[ $status_key ] )
+			&& 'publish' !== $post->post_status ) {
+			return array_merge( [ $status->label ], $post_states );
+		} else {
 			return $post_states;
+		}
 	}
 
 	/**

--- a/modules/custom-status/lib/custom-status.css
+++ b/modules/custom-status/lib/custom-status.css
@@ -1,7 +1,0 @@
-/* Hide the post-state (status) span since we display a custom column with post status */
-span.post-state {
-	display: none;
-}
-.show + span.post-state {
-	display: inline-block;
-}

--- a/modules/custom-status/lib/custom-status.js
+++ b/modules/custom-status/lib/custom-status.js
@@ -176,19 +176,4 @@ jQuery(document).ready(function() {
 		
 		return name;
 	}
-
-	// If we're on the Manage Posts screen, remove the trailing dashes left behind once we hide the post-state span (the status).
-	// We do this since we already add a custom column for post status on the screen since custom statuses are a core part of EF.
-	if ( jQuery('.post-state').length > 0 ) {
-		ef_remove_post_title_trailing_dashes();
-	}
-
-	// Remove the " - " in between a post title and the post-state span (separately hidden via CSS).
-	// This will not affect the dash before post-state-format spans.
-	function ef_remove_post_title_trailing_dashes() {
-		jQuery('.post-title.column-title strong').each(function() {
-			jQuery(this).html(jQuery(this).html().replace(/(.*) - (<span class="post-state".*<\/span>)$/g, "$1$2"));
-		});
-	}
-	
 });


### PR DESCRIPTION
I started to put together some end-to-end testing to test whether the "&mdash;" was being removed correctly on the post and post types lists (see screenshot below for reference on the "&mdash;" I'm talking about) by the [piece of JS we use to do that removal](https://github.com/Automattic/Edit-Flow/blob/master/modules/custom-status/lib/custom-status.js#L188)

<img width="603" alt="Screen Shot 2019-12-03 at 2 48 02 PM" src="https://user-images.githubusercontent.com/1888152/70084506-62a21800-15dc-11ea-96a3-bad2be98a19b.png">

But it doesn't seem worth the hassle, and instead I'm thinking we should just leverage the existing status labels. Moving the statuses to a separate column makes the statuses harder to differentiate. And by moving back to using the status labels, we can get rid of the hacks/workarounds we have in place. So it would look like:

<img width="1093" alt="Screen Shot 2019-12-03 at 3 00 42 PM" src="https://user-images.githubusercontent.com/1888152/70085220-cf69e200-15dd-11ea-863f-5ef5fa6a3105.png">
