### PR TITLE
Scope module assets for calendar

### DIFF
--- a/common/php/class-module.php
+++ b/common/php/class-module.php
@@ -215,15 +215,15 @@ class EF_Module {
 	 */
 	function enqueue_datepicker_resources() {
 
-		// Add the first day of the week as an available variable to wp_head
-		echo "<script type=\"text/javascript\">var ef_week_first_day=\"" . get_option( 'start_of_week' ) . "\";</script>";
-
 		wp_enqueue_script( 'jquery-ui-datepicker' );
 
 		//Timepicker needs to come after jquery-ui-datepicker and jquery
 		wp_enqueue_script( 'edit_flow-timepicker', EDIT_FLOW_URL . 'common/js/jquery-ui-timepicker-addon.js', array( 'jquery', 'jquery-ui-datepicker' ), EDIT_FLOW_VERSION, true );
 		wp_enqueue_script( 'edit_flow-date_picker', EDIT_FLOW_URL . 'common/js/ef_date.js', array( 'jquery', 'jquery-ui-datepicker', 'edit_flow-timepicker' ), EDIT_FLOW_VERSION, true );
 
+		// Add the first day of the week as an available variable
+		wp_add_inline_script( 'edit_flow-date_picker', 'var ef_week_first_day = ' . wp_json_encode( get_option( 'start_of_week' ) ) . ';' );
+		
 		// Now styles
 		wp_enqueue_style( 'jquery-ui-datepicker', EDIT_FLOW_URL . 'common/css/jquery.ui.datepicker.css', array( 'wp-jquery-ui-dialog' ), EDIT_FLOW_VERSION, 'screen' );
 		wp_enqueue_style( 'jquery-ui-theme', EDIT_FLOW_URL . 'common/css/jquery.ui.theme.css', false, EDIT_FLOW_VERSION, 'screen' );

--- a/modules/calendar/calendar.php
+++ b/modules/calendar/calendar.php
@@ -91,7 +91,7 @@ class EF_Calendar extends EF_Module {
 		
 		add_action( 'admin_init', array( $this, 'register_settings' ) );
 		add_action( 'admin_menu', array( $this, 'action_admin_menu' ) );
-		add_action( 'admin_print_styles', array( $this, 'add_admin_styles' ) );
+		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_admin_styles' ) );
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_admin_scripts' ) );
 		
 		// Ajax manipulation for the calendar
@@ -173,11 +173,12 @@ class EF_Calendar extends EF_Module {
 	 *
 	 * @uses wp_enqueue_style()
 	 */
-	function add_admin_styles() {
-		global $pagenow;
-		// Only load calendar styles on the calendar page
-		if ( $pagenow == 'index.php' && isset( $_GET['page'] ) && $_GET['page'] == 'calendar' )
-			wp_enqueue_style( 'edit-flow-calendar-css', $this->module_url . 'lib/calendar.css', false, EDIT_FLOW_VERSION );
+	function enqueue_admin_styles() {
+		if ( ! $this->is_calendar_view() ) {
+			return;
+		}
+
+		wp_enqueue_style( 'edit-flow-calendar-css', $this->module_url . 'lib/calendar.css', false, EDIT_FLOW_VERSION );
 	}
 	
 	/**
@@ -188,24 +189,28 @@ class EF_Calendar extends EF_Module {
 	 */
 	function enqueue_admin_scripts() {
 
+		if ( ! $this->is_calendar_view() ) {
+			return;
+		}
+
 		$this->enqueue_datepicker_resources();
 		
-		if ( $this->is_whitelisted_functional_view() ) {
-			$js_libraries = array(
-				'jquery',
-				'jquery-ui-core',
-				'jquery-ui-sortable',
-				'jquery-ui-draggable',
-				'jquery-ui-droppable',
-			);
-			foreach( $js_libraries as $js_library ) {
-				wp_enqueue_script( $js_library );
-			}
-			wp_enqueue_script( 'edit-flow-calendar-js', $this->module_url . 'lib/calendar.js', $js_libraries, EDIT_FLOW_VERSION, true );
-			
-			$ef_cal_js_params = array( 'can_add_posts' => current_user_can( $this->create_post_cap ) ? 'true' : 'false' );
-			wp_localize_script( 'edit-flow-calendar-js', 'ef_calendar_params', $ef_cal_js_params );
+		$js_libraries = array(
+			'jquery',
+			'jquery-ui-core',
+			'jquery-ui-sortable',
+			'jquery-ui-draggable',
+			'jquery-ui-droppable',
+		);
+
+		foreach( $js_libraries as $js_library ) {
+			wp_enqueue_script( $js_library );
 		}
+
+		wp_enqueue_script( 'edit-flow-calendar-js', $this->module_url . 'lib/calendar.js', $js_libraries, EDIT_FLOW_VERSION, true );
+		
+		$ef_cal_js_params = array( 'can_add_posts' => current_user_can( $this->create_post_cap ) ? 'true' : 'false' );
+		wp_localize_script( 'edit-flow-calendar-js', 'ef_calendar_params', $ef_cal_js_params );
 		
 	}
 	
@@ -1851,7 +1856,12 @@ class EF_Calendar extends EF_Module {
 		$wpdb->update( $wpdb->posts, array( 'post_date' => $post_date ), array( 'ID' => $post_ID ) );
 		clean_post_cache( $post_ID );
 	}
-	
+
+	public function is_calendar_view() {
+		global $pagenow;
+		
+		return ( 'index.php' === $pagenow && isset( $_GET['page'] ) && $_GET['page'] === 'calendar' );
+	}	
 } // EF_Calendar
 	
 } // class_exists('EF_Calendar')

--- a/tests/test-edit-flow-calendar.php
+++ b/tests/test-edit-flow-calendar.php
@@ -1,0 +1,100 @@
+<?php
+
+class WP_Test_Edit_Flow_Calendar extends WP_UnitTestCase {
+
+	protected static $admin_user_id;
+	protected $old_wp_scripts;
+		
+	public static function wpSetUpBeforeClass( $factory ) {
+		global $edit_flow;
+
+		self::$admin_user_id = $factory->user->create( array( 'role' => 'administrator' ) );
+
+		/**
+		 * There's a capability's check in EF_Calendar `init` that will prevent embedding of assets
+		 * and setting of the `create_post_cap` property, so we set that capability here
+		 * 
+		 * @see https://github.com/Automattic/Edit-Flow/blob/b4430c5d652b1c87736c3980ab8cf032bf49b6ad/modules/calendar/calendar.php#L84
+		 * @see https://github.com/Automattic/Edit-Flow/blob/b4430c5d652b1c87736c3980ab8cf032bf49b6ad/modules/calendar/calendar.php#L87
+		 */
+		$edit_flow->calendar->create_post_cap = 'edit_posts';
+		
+		$edit_flow->calendar->install();
+		$edit_flow->calendar->init();
+	}
+
+	public static function wpTearDownAfterClass() {
+		self::delete_user( self::$admin_user_id );
+	}
+
+	function setUp() {
+		parent::setUp();
+
+		$this->old_wp_scripts = isset( $GLOBALS['wp_scripts'] ) ? $GLOBALS['wp_scripts'] : null;
+		remove_action( 'wp_default_scripts', 'wp_default_scripts' );
+		remove_action( 'wp_default_scripts', 'wp_default_packages' );
+		$GLOBALS['wp_scripts']                  = new WP_Scripts();
+		$GLOBALS['wp_scripts']->default_version = get_bloginfo( 'version' );
+
+		global $pagenow;
+		$pagenow = 'post.php';
+	}
+
+	function tearDown() {
+		$GLOBALS['wp_scripts'] = $this->old_wp_scripts;
+		add_action( 'wp_default_scripts', 'wp_default_scripts' );
+		
+		global $pagenow;
+		$pagenow = 'index.php';
+
+		parent::tearDown();
+	}
+
+	/**
+	 * The calendar js should be enqueued on pages like post.php with a valid post type
+	 */
+	public function test_scripts_enqueued_calendar_admin() {
+		global $edit_flow, $pagenow, $wp_scripts;
+
+		set_current_screen( 'admin' );
+
+		wp_default_scripts( $wp_scripts );
+		wp_default_packages( $wp_scripts );
+
+		$pagenow      = 'index.php';
+		$_GET['page'] = 'calendar';
+
+		wp_set_current_user( self::$admin_user_id );
+
+		$edit_flow->calendar->enqueue_admin_scripts();
+
+		$expected = "<script type='text/javascript' src='" . $edit_flow->calendar->module_url . 'lib/calendar.js?ver=' . EDIT_FLOW_VERSION . "'></script>";
+
+		$footer = get_echo( 'wp_print_footer_scripts' );
+
+		$this->assertContains( $expected, $footer );
+	}
+	/**
+	 * The custom status js should not be enqueued on pages like admin.php
+	 */
+	public function test_scripts_not_enqueued_calendar_admin() {
+		global $edit_flow, $pagenow, $wp_scripts;
+
+		set_current_screen( 'admin' );
+
+		wp_default_scripts( $wp_scripts );
+		wp_default_packages( $wp_scripts );
+
+		$pagenow = 'admin.php';
+
+		wp_set_current_user( self::$admin_user_id );
+
+		$edit_flow->calendar->enqueue_admin_scripts();
+
+		$expected = "<script type='text/javascript' src='" . $edit_flow->calendar->module_url . 'lib/calendar.js?ver=' . EDIT_FLOW_VERSION . "'></script>";
+
+		$footer = get_echo( 'wp_print_footer_scripts' );
+
+		$this->assertNotContains( $expected, $footer );
+	}
+}


### PR DESCRIPTION
This is based on work from @justnorris in #487.

Instead of trying to tackle scoping assets across all of Edit Flow at once, we'll create a series of PR's to bring different modules into alignment and then introduce stricter guardrails once all the modules are in better shape.