### PR TITLE
Scope module assets for custom status

### DIFF
--- a/common/php/trait-module-with-view.php
+++ b/common/php/trait-module-with-view.php
@@ -1,0 +1,109 @@
+<?php
+
+trait EF_Module_With_View {
+
+	/**
+	 * Whether or not the current page is an Edit Flow settings view (either main or module)
+	 * Determination is based on $pagenow, $_GET['page'], and the module's $settings_slug
+	 * If there's no module name specified, it will return true against all Edit Flow settings views
+	 *
+	 * @since 0.8.3
+	 *
+	 * @param string $slug (Optional) Module name to check against
+	 * @return bool true if is module settings view
+	 */
+	public function is_module_settings_view( $slug = false ) {
+		global $pagenow, $edit_flow;
+
+		// All of the settings views are based on admin.php and a $_GET['page'] parameter
+		if ( 'admin.php' !== $pagenow || ! isset( $_GET['page'] ) )
+			return false;
+
+		$settings_view_slugs = array();
+		// Load all of the modules that have a settings slug/ callback for the settings page
+		foreach ( $edit_flow->modules as $mod_name => $mod_data ) {
+			if ( isset( $mod_data->options->enabled ) 
+				&& 'on' === $mod_data->options->enabled 
+				&& $mod_data->configure_page_cb )
+				$settings_view_slugs[] = $mod_data->settings_slug;
+		}
+
+		// The current page better be in the array of registered settings view slugs
+		if ( empty( $settings_view_slugs ) || ! in_array( $_GET['page'], $settings_view_slugs ) ) {
+			return false;
+		}
+
+		if ( $slug && $edit_flow->modules->{$slug}->settings_slug !== $_GET['page'] ) {
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Check whether if we're at module settings view
+	 * for the current module based on `is_module_settings_view` method
+	 *
+	 * @return bool
+	 */
+	public function is_current_module_settings_view() {
+		return $this->is_module_settings_view( $this->module->name );
+	}
+
+	/**
+	 * Check for admin page
+	 * @param array $allowed_pages
+	 *
+	 * @return bool
+	 */
+	public function is_active_view( $allowed_pages = array( 'edit.php', 'post.php', 'post-new.php' ) ) {
+		return ( $this->is_admin_page( $allowed_pages ) );
+	}
+
+	/**
+	 * Check whether the current post type is supported for $this module
+	 *
+	 * @return bool
+	 */
+	public function is_supported_post_type( ) {
+		$post_type = $this->get_current_post_type();
+		return (
+			$post_type
+			&&
+			in_array( $post_type, $this->get_post_types_for_module( $this->module ), true )
+		);
+	}
+
+	/**
+	 * Check whether currently viewing the desired admin page
+	 *
+	 * @param array $allowed_pages
+	 *
+	 * @return bool
+	 */
+	public function is_admin_page( $allowed_pages = array( 'edit.php', 'post.php', 'post-new.php' ) ) {
+		global $pagenow;
+
+		return ( $pagenow && in_array( $pagenow, $allowed_pages, true ) );
+	}
+
+	/**
+	 * Shorthand for `is_active_view` to check for list type views ( list of posts pages, custom post types )
+	 *
+	 * @see is_active_view
+	 * @return bool
+	 */
+	public function is_active_list_view() {
+		return $this->is_active_view( array( 'edit.php' ) );
+	}
+
+	/**
+	 * Shorthand for `is_active_view` to check for editor mode
+	 *
+	 * @see is_active_view
+	 * @return bool
+	 */
+	public function is_active_editor_view() {
+		return $this->is_active_view( array( 'post.php', 'posts-new.php' ) );
+	}
+}

--- a/edit_flow.php
+++ b/edit_flow.php
@@ -111,6 +111,8 @@ class edit_flow {
 		// Edit Flow base module
 		require_once( EDIT_FLOW_ROOT . '/common/php/class-module.php' );
 
+		require_once( EDIT_FLOW_ROOT . '/common/php/trait-module-with-view.php' );
+
 		// Edit Flow Block Editor Compat trait
 		require_once( EDIT_FLOW_ROOT . '/common/php/trait-block-editor-compatible.php' );
 

--- a/modules/custom-status/custom-status.php
+++ b/modules/custom-status/custom-status.php
@@ -14,6 +14,7 @@
 
 class EF_Custom_Status extends EF_Module {
 	use Block_Editor_Compatible;
+	use EF_Module_With_View;
 
 	var $module;
 
@@ -80,7 +81,8 @@ class EF_Custom_Status extends EF_Module {
 		add_action( 'admin_init', array( $this, 'register_settings' ) );
 
 		// Load CSS and JS resources that we probably need
-		add_action( 'admin_enqueue_scripts', array( $this, 'action_admin_enqueue_scripts' ) );
+		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_admin_scripts' ) );
+		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_admin_styles' ) );
 		add_action( 'admin_notices', array( $this, 'no_js_notice' ) );
 		add_action( 'admin_print_scripts', array( $this, 'post_admin_header' ) );
 
@@ -282,7 +284,7 @@ class EF_Custom_Status extends EF_Module {
 	 * - jQuery Sortable plugin is used for drag and dropping custom statuses
 	 * - We have other custom code for Quick Edit and JS niceties
 	 */
-	function action_admin_enqueue_scripts() {
+	function enqueue_admin_scripts() {
 		if ( $this->disable_custom_statuses_for_post_type() ) {
 			return;
 		}
@@ -301,13 +303,13 @@ class EF_Custom_Status extends EF_Module {
 		}
 
 		// Load Javascript we need to use on the configuration views (jQuery Sortable and Quick Edit)
-		if ( $this->is_whitelisted_settings_view( $this->module->name ) ) {
+		if ( $this->is_current_module_settings_view() ) {
 			wp_enqueue_script( 'jquery-ui-sortable' );
 			wp_enqueue_script( 'edit-flow-custom-status-configure', $this->module_url . 'lib/custom-status-configure.js', array( 'jquery', 'jquery-ui-sortable', 'edit-flow-settings-js' ), EDIT_FLOW_VERSION, true );
 		}
 
 		// Custom javascript to modify the post status dropdown where it shows up
-		if ( $this->is_whitelisted_page() ) {
+		if ( $this->is_custom_status_view() ) {
 			wp_enqueue_script( 'edit_flow-custom_status', $this->module_url . 'lib/custom-status.js', array( 'jquery','post' ), EDIT_FLOW_VERSION, true );
 			wp_localize_script('edit_flow-custom_status', '__ef_localize_custom_status', array(
 				'no_change' => esc_html__( "&mdash; No Change &mdash;", 'edit-flow' ),
@@ -319,8 +321,12 @@ class EF_Custom_Status extends EF_Module {
 				'cancel'    => esc_html__( 'Cancel', 'edit-flow' ),
 			));
 		}
+	}
 
-
+	public function enqueue_admin_styles() {
+		if ( $this->is_custom_status_view() ) {
+			wp_enqueue_style( 'edit_flow-custom_status', $this->module_url . 'lib/custom-status.css', false, EDIT_FLOW_VERSION, 'all' );
+		}
 	}
 
 	/**
@@ -328,7 +334,7 @@ class EF_Custom_Status extends EF_Module {
 	 * Javascript is needed for custom statuses to be fully functional
 	 */
 	function no_js_notice() {
-		if( $this->is_whitelisted_page() ) :
+		if ( $this->is_custom_status_view() ) :
 			?>
 			<style type="text/css">
 			/* Hide post status dropdown by default in case of JS issues **/
@@ -346,12 +352,14 @@ class EF_Custom_Status extends EF_Module {
 		endif;
 	}
 
-	/**
+		/**
 	 * Check whether custom status stuff should be loaded on this page
 	 *
 	 * @todo migrate this to the base module class
 	 */
 	function is_whitelisted_page() {
+		_deprecated_function( 'is_whitelisted_page', '0.9.4', 'is_custom_status_view' );
+
 		global $pagenow;
 
 		if ( !in_array( $this->get_current_post_type(), $this->get_post_types_for_module( $this->module ) ) )
@@ -381,7 +389,7 @@ class EF_Custom_Status extends EF_Module {
 		wp_get_current_user() ;
 
 		// Only add the script to Edit Post and Edit Page pages -- don't want to bog down the rest of the admin with unnecessary javascript
-		if ( $this->is_whitelisted_page() ) {
+		if ( $this->is_custom_status_view() ) {
 
 			$custom_statuses = $this->get_custom_statuses();
 
@@ -1747,6 +1755,33 @@ class EF_Custom_Status extends EF_Module {
 		$actions['view'] = '<a href="' . esc_url( $preview_link ) . '" title="' . esc_attr( sprintf( __( 'Preview &#8220;%s&#8221;' ), $post->post_title ) ) . '" rel="permalink">' . __( 'Preview' ) . '</a>';
 		return $actions;
 	}
+
+	/**
+	 * Check whether current view is relavant to this module and whether the user has access to it
+	 *
+	 * @return bool
+	 */
+	public function is_custom_status_view() {
+
+		if ( $this->is_current_module_settings_view() ) {
+			return true;
+		}
+
+		if ( ! $this->is_active_view( array( 'post.php', 'edit.php', 'post-new.php', 'page.php', 'edit-pages.php', 'page-new.php' ) ) ) {
+			return false;
+		}
+
+		$post_type_obj = get_post_type_object( $this->get_current_post_type() );
+		
+		if ( $post_type_obj 
+			&& ( ! current_user_can( $post_type_obj->cap->edit_posts ) 
+					|| ! $this->is_supported_post_type() ) ) {
+			return false;
+		}
+
+		return true;
+	}
+
 }
 
 }


### PR DESCRIPTION
This is based on work from @justnorris in #487.

It continues the work of scoping module assets. It reintroduces the  `EF_Module_With_View` class from #487, but holds off on deprecating `is_whitelisted_functional_view` and `is_whitelisted_settings_view` (which will be deprecated once all modules have been migrated).

It also introduces a small change to `Block_Editor_Compatible`, enabling the [registering/de-registering of multiple actions for the same hook](https://github.com/Automattic/Edit-Flow/compare/scope-module-assets-custom-status?expand=1#diff-228291de10e40133681b1ff8414a9a54R26)

Also, holding off on altering any usages of `disable_custom_statuses_for_post_type` for this PR, as it [caused issues with the original PR](https://github.com/Automattic/Edit-Flow/pull/487#issuecomment-449443659)