### PR TITLE
Travis: drop WP 5.1 and add PHP 7.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ php:
     - "5.6"
     - "7.2"
     - "7.3"
+    - "7.4"
 
 services:
     - mysql
@@ -11,34 +12,28 @@ services:
 env:
     - WP_VERSION=latest WP_MULTISITE=0 #Current stable release
 
-# Test WP 5.1 and 5.2 and on PHP 5.6, 7.2 and 7.3 (w and w/o multisite enabled)
+# Test WP 5.2 and on PHP 5.6, 7.2, 7.3, and 7.4 (w/ and w/o multisite enabled)
 
 matrix:
   include:
     # current stable release w/ multisite
-    - php: "5.6"
-      env: WP_VERSION=5.1 WP_MULTISITE=0
-    - php: "7.2"
-      env: WP_VERSION=5.1 WP_MULTISITE=0
-    - php: "7.3"
-      env: WP_VERSION=5.1 WP_MULTISITE=0
-    - php: "5.6"
-      env: WP_VERSION=5.1 WP_MULTISITE=1
-    - php: "7.2"
-      env: WP_VERSION=5.1 WP_MULTISITE=1
-    - php: "7.3"
-      env: WP_VERSION=5.1 WP_MULTISITE=1
+    - env: WP_VERSION=latest WP_MULTISITE=1
+    # n-1 major release
     - php: "5.6"
       env: WP_VERSION=5.2 WP_MULTISITE=0
     - php: "7.2"
       env: WP_VERSION=5.2 WP_MULTISITE=0
     - php: "7.3"
+      env: WP_VERSION=5.2 WP_MULTISITE=0
+    - php: "7.4"
       env: WP_VERSION=5.2 WP_MULTISITE=0
     - php: "5.6"
       env: WP_VERSION=5.2 WP_MULTISITE=1
     - php: "7.2"
       env: WP_VERSION=5.2 WP_MULTISITE=1
     - php: "7.3"
+      env: WP_VERSION=5.2 WP_MULTISITE=1
+    - php: "7.4"
       env: WP_VERSION=5.2 WP_MULTISITE=1
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,16 +25,14 @@ matrix:
       env: WP_VERSION=5.2 WP_MULTISITE=0
     - php: "7.3"
       env: WP_VERSION=5.2 WP_MULTISITE=0
-    - php: "7.4"
-      env: WP_VERSION=5.2 WP_MULTISITE=0
+    # - skip PHP 7.4 and WP 5.2 (not compatible)
     - php: "5.6"
       env: WP_VERSION=5.2 WP_MULTISITE=1
     - php: "7.2"
       env: WP_VERSION=5.2 WP_MULTISITE=1
     - php: "7.3"
       env: WP_VERSION=5.2 WP_MULTISITE=1
-    - php: "7.4"
-      env: WP_VERSION=5.2 WP_MULTISITE=1
+    # - skip PHP 7.4 and WP 5.2 (not compatible)
 
 before_script:
     - bash bin/install-wp-tests.sh wordpress_test root '' localhost $WP_VERSION


### PR DESCRIPTION
- WP 5.3 was released recently and we only care about n-1 major releases.
- PHP 7.4 was released recently.

## Steps to Test

Make sure Travis is testing the right matrix envs and looks happy.