### PR TITLE
Run PHPCS on php files only

### DIFF
--- a/bin/phpcs-diff.sh
+++ b/bin/phpcs-diff.sh
@@ -6,7 +6,7 @@ PHPCS_FILE=$(mktemp)
 
 git remote set-branches --add origin master
 git fetch
-git diff origin/master... > $DIFF_FILE
+git diff -- '*.php' origin/master... > $DIFF_FILE
 
 $DIR/../vendor/bin/phpcs --standard=phpcs.xml.dist --report=json > $PHPCS_FILE || true 
 


### PR DESCRIPTION
On Travis, PHPCS is being run on all files (PHP, JS, etc). This will limit PHPCS to be run only on *.php files.