### PR TITLE
Update Travis test extras

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,8 @@ matrix:
     - php: "7.3"
       env: WP_VERSION=latest WP_MULTISITE=0
     - php: "7.4"
-      env: RUN_PHPCS=1 WP_VERSION=latest WP_MULTISITE=0
-      # Only need to run PHPCS on one test
+      env: RUN_EXTRA=1 WP_VERSION=latest WP_MULTISITE=0
+      # Only need to run extras on one test
     - php: "7.4"
       env: WP_VERSION=latest WP_MULTISITE=1
     # n-1 major release
@@ -102,9 +102,9 @@ install:
 
 script:
   - npm run test-unit-php
-  - $( npm bin )/wp-scripts test-e2e --config=./tests/e2e/jest.config.js
   - |
-    if [[ ${TRAVIS_PHP_VERSION:0:2} == "7." ]] && [[ ${RUN_PHPCS} == "1" ]]; then
+    if [[ ${RUN_EXTRA} == "1" ]]; then
+      $( npm bin )/wp-scripts test-e2e --config=./tests/e2e/jest.config.js
       bash bin/phpcs-diff.sh
       npm run lint
     fi

--- a/bin/phpcs-diff.sh
+++ b/bin/phpcs-diff.sh
@@ -6,8 +6,8 @@ PHPCS_FILE=$(mktemp)
 
 git remote set-branches --add origin master
 git fetch
-git diff -- '*.php' origin/master... > $DIFF_FILE
+git diff -- '*.php' origin/master.. > $DIFF_FILE
 
-$DIR/../vendor/bin/phpcs --standard=phpcs.xml.dist --report=json > $PHPCS_FILE || true 
+$DIR/../vendor/bin/phpcs --extensions=php --standard=phpcs.xml.dist --report=json > $PHPCS_FILE || true 
 
 $DIR/../vendor/bin/diffFilter --phpcs $DIFF_FILE $PHPCS_FILE 0

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -9,4 +9,5 @@
 	<exclude-pattern>*/node_modules/*</exclude-pattern>
 	<exclude-pattern>*/nodeapp/*</exclude-pattern>
 	<exclude-pattern>*/vendor/*</exclude-pattern>
+	<exclude-pattern>*/wordpress/*</exclude-pattern>
 </ruleset>


### PR DESCRIPTION
## Description

Quick update to the Travis yaml to run extras (PHPCS diff, lint and e2e tests) only on certain conditions (when `RUN_EXTRAS` environment variable is set).

Also, actually limit PHPCS to run over only PHP files (was previously just limiting the diff output).

Making sure to exclude the new `wordpress` [directory that gets included](https://github.com/Automattic/Edit-Flow/pull/573/files#diff-6758ef1f416bd888bd1a5cad8f97cc2bR12) by e2e tests