### PR TITLE
Small change to phpcs-diff

### DIFF
--- a/bin/phpcs-diff.sh
+++ b/bin/phpcs-diff.sh
@@ -6,7 +6,7 @@ PHPCS_FILE=$(mktemp)
 
 git remote set-branches --add origin master
 git fetch
-git diff -- '*.php' origin/master.. > $DIFF_FILE
+git diff origin/master > $DIFF_FILE
 
 $DIR/../vendor/bin/phpcs --extensions=php --standard=phpcs.xml.dist --report=json > $PHPCS_FILE || true 
 


### PR DESCRIPTION
The filtering of the diff `-- '*.php'` is resulting in an empty file. With the usage of `--extensions=php` [in PHPCS should](https://github.com/Automattic/Edit-Flow/compare/fix/phpcs-diff?expand=1#diff-219bf2a45ce55a542f916415298efd7eR11) we should be able to avoid having to figure out how to filter on the diff