### PR TITLE
Allow author email addresses to stay private

### DIFF
--- a/common/php/class-module.php
+++ b/common/php/class-module.php
@@ -489,6 +489,7 @@ if ( ! class_exists( 'EF_Module' ) ) {
 				'fields' => array(
 					'ID',
 					'display_name',
+					'user_nicename',
 					'user_email',
 				),
 				'orderby' => 'display_name',
@@ -523,7 +524,23 @@ if ( ! class_exists( 'EF_Module' ) ) {
 							</div>
 
 							<span class="ef-user_displayname"><?php echo esc_html( $user->display_name ); ?></span>
-							<span class="ef-user_useremail"><?php echo esc_html( $user->user_email ); ?></span>
+							<?php
+							/**
+							 * Filters the secondary user identifier shown in the notifications list.
+							 *
+							 * By default, shows user_nicename for unique identification without exposing email.
+							 * Return user_email to show email addresses, or empty string to hide.
+							 *
+							 * @since 0.10.1
+							 *
+							 * @param string $identifier The secondary identifier to display.
+							 * @param object $user       The user object.
+							 */
+							$secondary_identifier = apply_filters( 'ef_user_secondary_identifier', $user->user_nicename, $user );
+							if ( ! empty( $secondary_identifier ) ) :
+								?>
+								<span class="ef-user_useremail"><?php echo esc_html( $secondary_identifier ); ?></span>
+							<?php endif; ?>
 						</label>
 					</li>
 				<?php endforeach; ?>

--- a/modules/editorial-comments/editorial-comments.php
+++ b/modules/editorial-comments/editorial-comments.php
@@ -276,9 +276,25 @@ if ( ! class_exists( 'EF_Editorial_Comments' ) ) {
 			<div class="post-comment-wrap">
 				<h5 class="comment-meta">
 					<?php
-					/* translators: 1: HTML email link to the author of the current comment, 2: the date of the comment, 3: the time of the comment */
+					/**
+					 * Filters whether to show the email link for editorial comment authors.
+					 *
+					 * By default, email addresses are hidden for privacy.
+					 * Return true to show a mailto: link for the comment author.
+					 *
+					 * @since 0.10.1
+					 *
+					 * @param bool $show_email Whether to show the email link. Default false.
+					 * @param int  $user_id    The comment author's user ID.
+					 */
+					$show_email_link = apply_filters( 'ef_editorial_comment_show_email_link', false, $comment->user_id );
+					$comment_author  = $show_email_link
+						? comment_author_email_link( $comment->comment_author )
+						: esc_html( $comment->comment_author );
+
+					/* translators: 1: comment author name (or email link), 2: the date of the comment, 3: the time of the comment */
 					printf( wp_kses_post( __( '<span class="comment-author">%1$s</span><span class="meta"> said on %2$s at %3$s</span>', 'edit-flow' ) ),
-						wp_kses_post( comment_author_email_link( $comment->comment_author ) ),
+						wp_kses_post( $comment_author ),
 						esc_attr( get_comment_date( get_option( 'date_format' ) ) ),
 					esc_attr( get_comment_time() ) );
 					?>

--- a/tests/Integration/UserPrivacyTest.php
+++ b/tests/Integration/UserPrivacyTest.php
@@ -1,0 +1,112 @@
+<?php
+/**
+ * Tests for user email privacy features.
+ *
+ * @package EditFlow
+ * @subpackage Tests
+ */
+
+declare( strict_types=1 );
+
+namespace Automattic\EditFlow\Tests\Integration;
+
+use Yoast\WPTestUtils\WPIntegration\TestCase;
+
+/**
+ * Test class for user email privacy.
+ *
+ * @covers EF_Module::users_select_form
+ * @covers EF_Editorial_Comments::the_comment
+ */
+class UserPrivacyTest extends TestCase {
+
+	/**
+	 * Test user for assertions.
+	 *
+	 * @var \WP_User
+	 */
+	private static $test_user;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public static function set_up_before_class(): void {
+		parent::set_up_before_class();
+
+		self::$test_user = self::factory()->user->create_and_get(
+			[
+				'role'         => 'editor',
+				'display_name' => 'Test Editor',
+				'user_login'   => 'testeditor',
+				'user_email'   => 'testeditor@example.com',
+			]
+		);
+	}
+
+	/**
+	 * Test that users_select_form shows user_nicename by default instead of email.
+	 */
+	public function test_users_select_form_shows_nicename_by_default(): void {
+		global $edit_flow;
+
+		// Capture the output of users_select_form.
+		ob_start();
+		$edit_flow->notifications->users_select_form();
+		$output = ob_get_clean();
+
+		// Should contain the user's nicename.
+		$this->assertStringContainsString( self::$test_user->user_nicename, $output );
+
+		// Should NOT contain the user's email.
+		$this->assertStringNotContainsString( self::$test_user->user_email, $output );
+	}
+
+	/**
+	 * Test that ef_user_secondary_identifier filter can restore email display.
+	 */
+	public function test_users_select_form_filter_can_show_email(): void {
+		global $edit_flow;
+
+		// Add filter to show email instead of nicename.
+		add_filter(
+			'ef_user_secondary_identifier',
+			function ( $identifier, $user ) {
+				return $user->user_email;
+			},
+			10,
+			2
+		);
+
+		// Capture the output.
+		ob_start();
+		$edit_flow->notifications->users_select_form();
+		$output = ob_get_clean();
+
+		// Should contain the user's email.
+		$this->assertStringContainsString( self::$test_user->user_email, $output );
+
+		// Clean up.
+		remove_all_filters( 'ef_user_secondary_identifier' );
+	}
+
+	/**
+	 * Test that ef_user_secondary_identifier filter can hide all secondary info.
+	 */
+	public function test_users_select_form_filter_can_hide_identifier(): void {
+		global $edit_flow;
+
+		// Add filter to hide secondary identifier.
+		add_filter( 'ef_user_secondary_identifier', '__return_empty_string' );
+
+		// Capture the output.
+		ob_start();
+		$edit_flow->notifications->users_select_form();
+		$output = ob_get_clean();
+
+		// Should NOT contain the ef-user_useremail span at all.
+		$this->assertStringNotContainsString( 'ef-user_useremail', $output );
+
+		// Clean up.
+		remove_all_filters( 'ef_user_secondary_identifier' );
+	}
+}


### PR DESCRIPTION
## Summary

Improve user privacy by hiding email addresses by default in the notifications subscriber list and editorial comments.

**Problem:** Any user with post editing access could discover email addresses of all users who can publish posts via the notifications panel. As noted in the original discussion: "If Beyoncé contributed to my site, everyone who is a contributor or higher can find her email."

**Solution:**
- Show `user_nicename` instead of email in notifications list (provides unique identification without exposing email)
- Remove `mailto:` link from editorial comment author names
- Add filters to customise behaviour or restore emails if needed

## Changes

- **Notifications list**: Now shows `user_nicename` (e.g., `john-smith`) below the display name instead of email
- **Editorial comments**: Author name is now plain text instead of a mailto: link
- **New filter `ef_user_secondary_identifier`**: Customise what's shown below the display name
- **New filter `ef_editorial_comment_show_email_link`**: Restore mailto: links in comments

## Restoring previous behaviour

```php
// Show email in notifications list
add_filter( 'ef_user_secondary_identifier', function( $identifier, $user ) {
    return $user->user_email;
}, 10, 2 );

// Show email links in editorial comments  
add_filter( 'ef_editorial_comment_show_email_link', '__return_true' );
```

## Test plan

- [x] PHP integration tests added (3 tests)
- [ ] View notifications metabox on a post - should show nicename, not email
- [ ] View editorial comments - author should not be a mailto: link
- [ ] Verify filters work to restore previous behaviour

Fixes #264

---

_This is a fresh reimplementation based on the discussion in PR #577. The original PR was 5 years old and needed rebasing. This implementation follows the consensus from @cojennin and @jerclarke to hide emails by default and show an alternative unique identifier._

🤖 Generated with [Claude Code](https://claude.com/claude-code)