### PR TITLE
Clean up dashboard-note logic

### DIFF
--- a/modules/dashboard/widgets/dashboard-notepad.php
+++ b/modules/dashboard/widgets/dashboard-notepad.php
@@ -18,7 +18,7 @@ class EF_Dashboard_Notepad_Widget {
 		register_post_type( self::notepad_post_type, array(
 				'rewrite' => false,
 				'label' => __( 'Dashboard Note', 'edit-flow' )
-			) 
+			)
 		);
 
 		$this->edit_cap = apply_filters( 'ef_dashboard_notepad_edit_cap', $this->edit_cap );
@@ -45,13 +45,13 @@ class EF_Dashboard_Notepad_Widget {
 		}
 
 		$note_data = array(
-			'post_content' => wp_filter_nohtml_kses( $_POST['note'] ),
+			'post_content' => isset( $_POST['note'] ) ? wp_filter_nohtml_kses( $_POST['note'] ) : '',
 			'post_type'    => self::notepad_post_type,
 			'post_status'  => 'draft',
 			'post_author'  => get_current_user_id(),
 		);
 
-		$existing_notepad = get_post( absint( $_POST['notepad-id'] ) );
+		$existing_notepad = isset( $_POST['notepad-id'] ) ? get_post( absint( $_POST['notepad-id'] ) ) : null;
 		if ( isset( $existing_notepad->post_type ) && self::notepad_post_type === $existing_notepad->post_type ) {
 			$note_data['ID'] = $existing_notepad->ID;
 		}

--- a/modules/dashboard/widgets/dashboard-notepad.php
+++ b/modules/dashboard/widgets/dashboard-notepad.php
@@ -34,31 +34,29 @@ class EF_Dashboard_Notepad_Widget {
 	public function handle_notepad_update() {
 		global $pagenow;
 
-		if ( 'index.php' != $pagenow
-		|| ( empty( $_POST['action'] ) || 'dashboard-notepad' != $_POST['action'] ) )
+		if ( 'index.php' !== $pagenow || empty( $_POST['action'] ) || 'dashboard-notepad' !== $_POST['action'] ) {
 			return;
+		}
 
 		check_admin_referer( 'dashboard-notepad' );
 
-		if ( ! current_user_can( $this->edit_cap ) )
+		if ( ! current_user_can( $this->edit_cap ) ) {
 			wp_die( EditFlow()->dashboard->messages['invalid-permissions'] );
-
-		$current_id = (int) $_POST['notepad-id'];
-		$current_notepad = get_post( $current_id );
-		$new_note = array(
-				'post_content'           => wp_filter_nohtml_kses( $_POST['note'] ),
-				'post_type'              => self::notepad_post_type,
-				'post_status'            => 'draft',
-				'post_author'            => get_current_user_id(),
-			);
-		if ( $current_notepad
-			&& self::notepad_post_type == $current_notepad->post_type
-			&& ! isset ( $_POST['create-note'] ) ) {
-			$new_note['ID'] = $current_id;
-			wp_update_post( $new_note );
-		} else {
-			wp_insert_post( $new_note );
 		}
+
+		$note_data = array(
+			'post_content' => wp_filter_nohtml_kses( $_POST['note'] ),
+			'post_type'    => self::notepad_post_type,
+			'post_status'  => 'draft',
+			'post_author'  => get_current_user_id(),
+		);
+
+		$existing_notepad = get_post( absint( $_POST['notepad-id'] ) );
+		if ( isset( $existing_notepad->post_type ) && self::notepad_post_type === $existing_notepad->post_type ) {
+			$note_data['ID'] = $existing_notepad->ID;
+		}
+
+		wp_insert_post( $note_data );
 	}
 
 	/**


### PR DESCRIPTION
Fixes https://github.com/Automattic/Edit-Flow/issues/471

The else clause was actually necessary for the first time a note was created. It was a bit confusing though, so I've cleaned up the logic to make a single path of execution. `wp_insert_post()` will handle updating the post if the ID is passed.

## Testing

Checkout the PR and update the dashboard note. Can also delete the post from the database manually and then ensure you're still able to create a note.