### PR TITLE
Display custom statuses in post states

### DIFF
--- a/modules/custom-status/custom-status.php
+++ b/modules/custom-status/custom-status.php
@@ -702,7 +702,7 @@ class EF_Custom_Status extends EF_Module {
 	 *
 	 * @return array $post_states
 	 */
-	function add_status_to_post_states( $post_states, $post ) {
+	public function add_status_to_post_states( $post_states, $post ) {
 		if ( ! in_array( $post->post_type, $this->get_post_types_for_module( $this->module ), true ) ) {
 			// Return early if this post type doesn't support custom statuses.
 			return $post_states;
@@ -716,7 +716,7 @@ class EF_Custom_Status extends EF_Module {
 			return $post_states;
 		}
 
-		$statuses_to_ignore = [ 'future', 'trash', 'publish' ];
+		$statuses_to_ignore = array( 'future', 'trash', 'publish' );
 		if ( in_array( $post_status->name, $statuses_to_ignore, true ) ) {
 			// Let WP core handle these more gracefully.
 			return $post_states;
@@ -1487,7 +1487,7 @@ class EF_Custom_Status extends EF_Module {
 		        }
 		   }
 		}
-		return remove_query_arg( [ 'preview_nonce' ], $preview_link );
+		return remove_query_arg( array( 'preview_nonce' ), $preview_link );
 	}
 
 	/**

--- a/modules/custom-status/custom-status.php
+++ b/modules/custom-status/custom-status.php
@@ -125,9 +125,6 @@ class EF_Custom_Status extends EF_Module {
 
 		// Pagination for custom post statuses when previewing posts
 		add_filter( 'wp_link_pages_link', array( $this, 'modify_preview_link_pagination_url' ), 10, 2 );
-
-		// Filter through Post States and run a function to check if they are also a Status
-		add_filter( 'display_post_states', array( $this, 'check_if_post_state_is_status' ), 10, 2 );
 	}
 
 	/**
@@ -315,7 +312,6 @@ class EF_Custom_Status extends EF_Module {
 		// Custom javascript to modify the post status dropdown where it shows up
 		if ( $this->is_whitelisted_page() ) {
 			wp_enqueue_script( 'edit_flow-custom_status', $this->module_url . 'lib/custom-status.js', array( 'jquery','post' ), EDIT_FLOW_VERSION, true );
-			wp_enqueue_style( 'edit_flow-custom_status', $this->module_url . 'lib/custom-status.css', false, EDIT_FLOW_VERSION, 'all' );
 			wp_localize_script('edit_flow-custom_status', '__ef_localize_custom_status', array(
 				'no_change' => esc_html__( "&mdash; No Change &mdash;", 'edit-flow' ),
 				'published' => esc_html__( 'Published', 'edit-flow' ),
@@ -743,22 +739,6 @@ class EF_Custom_Status extends EF_Module {
 			$post_status_obj = get_post_status_object( get_post_status( $post->ID ) );
 			echo esc_html( $post_status_obj->label );
 		}
-	}
-	/**
-	 * Check if Post State is a Status and display if it is not.
-	 *
-	 * @param array $post_states An array of post display states.
-	 */
-	function check_if_post_state_is_status( $post_states, $post ) {
-
-		$statuses = get_post_status_object( get_post_status( $post->ID ) );
-		foreach ( $post_states as $state ) {
-			if ( $state !== $statuses->label ) {
-				echo '<span class="show"></span>';
-			}
-		}
-			
-		return $post_states;
 	}
 
 	/**
@@ -1520,7 +1500,7 @@ class EF_Custom_Status extends EF_Module {
 		        }
 		   }
 		}
-		return remove_query_arg( [ 'preview_nonce' ], $preview_link );  
+		return remove_query_arg( [ 'preview_nonce' ], $preview_link );
 	}
 
 	/**

--- a/modules/custom-status/custom-status.php
+++ b/modules/custom-status/custom-status.php
@@ -92,6 +92,9 @@ class EF_Custom_Status extends EF_Module {
 		add_action( 'admin_notices', array( $this, 'no_js_notice' ) );
 		add_action( 'admin_print_scripts', array( $this, 'post_admin_header' ) );
 
+		// Add custom statuses to the post states.
+		add_filter( 'display_post_states', array( $this, 'add_status_to_post_states' ), 10, 2 );
+
 		// Methods for handling the actions of creating, making default, and deleting post stati
 		add_action( 'admin_init', array( $this, 'handle_add_custom_status' ) );
 		add_action( 'admin_init', array( $this, 'handle_edit_custom_status' ) );
@@ -689,6 +692,26 @@ class EF_Custom_Status extends EF_Module {
 
 		// Make the database call
 		$result = $wpdb->update( $wpdb->posts, array( 'post_status' => $new_status ), array( 'post_status' => $old_status ), array( '%s' ));
+	}
+
+	/**
+	 * Display our custom post statuses in post listings when needed.
+	 *
+	 * @param array   $post_states An array of post display states.
+	 * @param WP_Post $post The current post object.
+	 *
+	 * @return array $post_states
+	 */
+	function add_status_to_post_states( $post_states, $post ) {
+		// Return early if this post type doesn't support custom statuses.
+		if ( ! in_array( $this->get_current_post_type(), $this->get_post_types_for_module( $this->module ) ) ) {
+			return $post_states;
+		}
+
+		$post_status = get_post_status_object( get_post_status( $post->ID ) );
+		$post_states[ $post_status->name ] = $post_status->label;
+
+		return $post_states;
 	}
 
 	/**

--- a/modules/custom-status/custom-status.php
+++ b/modules/custom-status/custom-status.php
@@ -703,12 +703,26 @@ class EF_Custom_Status extends EF_Module {
 	 * @return array $post_states
 	 */
 	function add_status_to_post_states( $post_states, $post ) {
-		// Return early if this post type doesn't support custom statuses.
 		if ( ! in_array( $this->get_current_post_type(), $this->get_post_types_for_module( $this->module ) ) ) {
+			// Return early if this post type doesn't support custom statuses.
 			return $post_states;
 		}
 
 		$post_status = get_post_status_object( get_post_status( $post->ID ) );
+
+		$filtered_status = isset( $_REQUEST['post_status'] ) ? $_REQUEST['post_status'] : '';
+		if ( $filtered_status === $post_status->name ) {
+			// No need to display the post status if a specific status was already requested.
+			return $post_states;
+		}
+
+		$statuses_to_ignore = [ 'future', 'trash', 'publish' ];
+		if ( in_array( $post_status->name, $statuses_to_ignore, true ) ) {
+			// Let WP core handle these more gracefully.
+			return $post_states;
+		}
+
+		// Add the post status to display. Will also ensure the same status isn't shown twice.
 		$post_states[ $post_status->name ] = $post_status->label;
 
 		return $post_states;

--- a/modules/custom-status/custom-status.php
+++ b/modules/custom-status/custom-status.php
@@ -703,7 +703,7 @@ class EF_Custom_Status extends EF_Module {
 	 * @return array $post_states
 	 */
 	function add_status_to_post_states( $post_states, $post ) {
-		if ( ! in_array( $this->get_current_post_type(), $this->get_post_types_for_module( $this->module ) ) ) {
+		if ( ! in_array( $post->post_type, $this->get_post_types_for_module( $this->module ), true ) ) {
 			// Return early if this post type doesn't support custom statuses.
 			return $post_states;
 		}

--- a/modules/custom-status/lib/custom-status.css
+++ b/modules/custom-status/lib/custom-status.css
@@ -1,7 +1,0 @@
-/* Hide the post-state (status) span since we display a custom column with post status */
-span.post-state {
-	display: none;
-}
-.show + span.post-state {
-	display: inline-block;
-}

--- a/tests/test-edit-flow-custom-status.php
+++ b/tests/test-edit-flow-custom-status.php
@@ -211,7 +211,7 @@ class WP_Test_Edit_Flow_Custom_Status extends WP_UnitTestCase {
 
 		$p = self::factory()->post->create( array(
 			'post_status' => 'pitch',
-			'post_author' => self::$admin_user_id
+			'post_author' => self::$admin_user_id,
 		) );
 
 		$pagenow = 'index.php';
@@ -259,7 +259,7 @@ class WP_Test_Edit_Flow_Custom_Status extends WP_UnitTestCase {
 		$p = self::factory()->post->create( array(
 			'post_status' => 'publish',
 			'post_name' => 'foo-صورة',
-			'post_author' => self::$admin_user_id
+			'post_author' => self::$admin_user_id,
 		) );
 
 		wp_set_current_user( self::$admin_user_id );
@@ -342,7 +342,7 @@ class WP_Test_Edit_Flow_Custom_Status extends WP_UnitTestCase {
 			'post_author' => self::$admin_user_id
 		) );
 
-		$post_states = apply_filters( 'display_post_states', [], get_post( $post ) );
+		$post_states = apply_filters( 'display_post_states', array(), get_post( $post ) );
 		$this->assertArrayHasKey( 'pitch', $post_states );
 	}
 
@@ -351,10 +351,10 @@ class WP_Test_Edit_Flow_Custom_Status extends WP_UnitTestCase {
 			'post_type'   => 'customposttype',
 			'post_title'  => 'Post',
 			'post_status' => 'pitch',
-			'post_author' => self::$admin_user_id
+			'post_author' => self::$admin_user_id,
 		) );
 
-		$post_states = apply_filters( 'display_post_states', [], get_post( $post ) );
+		$post_states = apply_filters( 'display_post_states', array(), get_post( $post ) );
 		$this->assertFalse( array_key_exists( 'pitch', $post_states ) );
 	}
 
@@ -369,7 +369,7 @@ class WP_Test_Edit_Flow_Custom_Status extends WP_UnitTestCase {
 		// Act like the status has been filtered.
 		$_REQUEST['post_status'] = 'pitch';
 
-		$post_states = apply_filters( 'display_post_states', [], get_post( $post ) );
+		$post_states = apply_filters( 'display_post_states', array(), get_post( $post ) );
 		$this->assertFalse( array_key_exists( 'pitch', $post_states ) );
 	}
 }


### PR DESCRIPTION
Closes https://github.com/Automattic/Edit-Flow/issues/395

Custom post statuses has enough hacks as-is, let's adhere to core APIs and standards when we can :)

Instead of adding an extra column to the post list that takes up valuable space, let's follow core's UI and display custom statuses just like other statuses are shown in WP.

For some context, here is what is done in WP core: https://github.com/WordPress/WordPress/blob/dd4d98a368ca1d617adfaaef9b2937c60464ac4a/wp-admin/includes/template.php#L2100-L2170. Of note, I followed the same rules by letting core continue to handle some statuses specially, and by not showing the status when a specific post status is filtered.

It will also smartly handle cases where EF has changed a core statuses name (like pending). Thanks to the use of array keys, it'll override the default status display name with our custom ones.

## Testing

Apply the patch and try out different post statuses, post types, etc.

_____

## Preview

<img width="575" alt="post-states" src="https://user-images.githubusercontent.com/8536129/72503027-c12bfa00-3808-11ea-96dc-31fdb8d7645a.png">
