### PR TITLE
Deprecate ef_get_comments_plus()

### DIFF
--- a/modules/editorial-comments/editorial-comments.php
+++ b/modules/editorial-comments/editorial-comments.php
@@ -114,20 +114,6 @@ class EF_Editorial_Comments extends EF_Module
 
 	}
 
-	/**
-	 * Get the total number of editorial comments for a post
-	 *
-	 * @param int $id Unique post ID
-	 * @return int $comment_count Number of editorial comments for a post
-	 */
-	function get_editorial_comment_count( $id ) {
-		global $wpdb;
-		$comment_count = $wpdb->get_var($wpdb->prepare("SELECT COUNT(*) FROM $wpdb->comments WHERE comment_post_ID = %d AND comment_type = %s", $id, self::comment_type));
-		if ( !$comment_count )
-			$comment_count = 0;
-		return $comment_count;
-	}
-
 	function editorial_comments_meta_box( ) {
 		global $post, $post_ID;
 		?>
@@ -444,32 +430,6 @@ class EF_Editorial_Comments extends EF_Module
 
 		</form>
 		<?php
-	}
-
-	/**
-	 * If the Edit Flow Calendar is enabled, add the editorial comment count to the post overlay.
-	 *
-	 * @since 0.7
-	 * @uses apply_filters( 'ef_calendar_item_information_fields' )
-	 *
-	 * @param array $calendar_fields Additional data fields to include on the calendar
-	 * @param int $post_id Unique ID for the post data we're building
-	 * @return array $calendar_fields Calendar fields with our viewable Editorial Metadata added
-	 */
-	function filter_calendar_item_fields( $calendar_fields, $post_id ) {
-		// Make sure we respect which post type we're on
-		if ( !in_array( get_post_type( $post_id ), $this->get_post_types_for_module( $this->module ) ) )
-			return $calendar_fields;
-
-		// Name/value for the field to add
-		$comment_count_data = array(
-			'label' => $this->module->title,
-			'value' => $this->get_editorial_comment_count( $post_id ),
-		);
-
-		$calendar_fields[$this->module->slug] = $comment_count_data;
-
-		return $calendar_fields;
 	}
 
 }

--- a/modules/editorial-comments/editorial-comments.php
+++ b/modules/editorial-comments/editorial-comments.php
@@ -48,17 +48,10 @@ class EF_Editorial_Comments extends EF_Module
 	 * Initialize the rest of the stuff in the class if the module is active
 	 */
 	function init() {
-
 		add_action( 'add_meta_boxes', array ( $this, 'add_post_meta_box' ) );
 		add_action( 'admin_init', array( $this, 'register_settings' ) );
 		add_action( 'admin_enqueue_scripts', array( $this, 'add_admin_scripts' ) );
 		add_action( 'wp_ajax_editflow_ajax_insert_comment', array( $this, 'ajax_insert_comment' ) );
-
-		// Add Editorial Comments to the calendar if the calendar is activated
-		if ( $this->module_enabled( 'calendar' ) ) {
-			// Still in progress. See: https://www.pivotaltracker.com/story/show/5930884 and https://www.pivotaltracker.com/story/show/5930895
-			//add_filter( 'ef_calendar_item_information_fields', array( $this, 'filter_calendar_item_fields' ), null, 2 );
-		}
 	}
 
 	/**
@@ -231,7 +224,7 @@ class EF_Editorial_Comments extends EF_Module
 
 	/**
 	 * Maybe display who was notified underneath an editorial comment.
-	 * 
+	 *
 	 * @param int $comment_id
 	 * @return void
 	 */
@@ -261,11 +254,6 @@ class EF_Editorial_Comments extends EF_Module
 		wp_get_current_user() ;
 
 		$GLOBALS['comment'] = $comment;
-
-		// Deleting editorial comments is not enabled for now for the sake of transparency. However, we could consider
-		// EF comment edits (with history, if possible). P2 already allows for edits without history, so even that might work.
-		// Pivotal ticket: https://www.pivotaltracker.com/story/show/18483757
-		//$delete_url = esc_url( wp_nonce_url( "comment.php?action=deletecomment&p=$comment->comment_post_ID&c=$comment->comment_ID", "delete-comment_$comment->comment_ID" ) );
 
 		$actions = array();
 

--- a/modules/editorial-comments/editorial-comments.php
+++ b/modules/editorial-comments/editorial-comments.php
@@ -136,18 +136,18 @@ class EF_Editorial_Comments extends EF_Module
 
 			<?php
 			// Show comments only if not a new post
-			if( ! in_array( $post->post_status, array( 'new', 'auto-draft' ) ) ) :
+			if ( ! in_array( $post->post_status, array( 'new', 'auto-draft' ) ) ) :
 
 				// Unused since switched to wp_list_comments
-				$editorial_comments = ef_get_comments_plus (
-								array(
-									'post_id' => $post->ID,
-									'comment_type' => self::comment_type,
-									'orderby' => 'comment_date',
-									'order' => 'ASC',
-									'status' => self::comment_type
-								)
-							);
+				$editorial_comments = get_comments(
+					array(
+						'post_id' => $post->ID,
+						'comment_type' => self::comment_type,
+						'orderby' => 'comment_date',
+						'order' => 'ASC',
+						'status' => self::comment_type
+					)
+				);
 				?>
 
 				<ul id="ef-comments">
@@ -477,120 +477,13 @@ class EF_Editorial_Comments extends EF_Module
 }
 
 /**
- * Retrieve a list of comments -- overloaded from get_comments and with mods by filosofo (SVN Ticket #10668)
+ * Deprecated. Used to retrieve a list of comments.
+ * Was needed before https://core.trac.wordpress.org/ticket/10668 was available.
  *
- * @param mixed $args Optional. Array or string of options to override defaults.
+ * @param mixed $args Optional. Array or string of options.
  * @return array List of comments.
  */
 function ef_get_comments_plus( $args = '' ) {
-	global $wpdb;
-
-	$defaults = array(
-	                'author_email' => '',
-	                'ID' => '',
-	                'karma' => '',
-	                'number' => '',
-	                'offset' => '',
-	                'orderby' => '',
-	                'order' => 'DESC',
-	                'parent' => '',
-	                'post_ID' => '',
-	                'post_id' => 0,
-	                'status' => '',
-	                'type' => '',
-	                'user_id' => '',
-	        );
-
-	$args = wp_parse_args( $args, $defaults );
-	extract( $args, EXTR_SKIP );
-
-	// $args can be whatever, only use the args defined in defaults to compute the key
-	$key = md5( serialize( compact(array_keys($defaults)) )  );
-	$last_changed = wp_cache_get('last_changed', 'comment');
-	if ( !$last_changed ) {
-		$last_changed = time();
-		wp_cache_set('last_changed', $last_changed, 'comment');
-	}
-	$cache_key = "get_comments:$key:$last_changed";
-
-	if ( $cache = wp_cache_get( $cache_key, 'comment' ) ) {
-		return $cache;
-	}
-
-	$post_id = absint($post_id);
-
-	if ( 'hold' == $status )
-		$approved = "comment_approved = '0'";
-	elseif ( 'approve' == $status )
-		$approved = "comment_approved = '1'";
-	elseif ( 'spam' == $status )
-		$approved = "comment_approved = 'spam'";
-	elseif( ! empty( $status ) )
-		$approved = $wpdb->prepare( "comment_approved = %s", $status );
-	else
-		$approved = "( comment_approved = '0' OR comment_approved = '1' )";
-
-	$order = ( 'ASC' == $order ) ? 'ASC' : 'DESC';
-
-	if ( ! empty( $orderby ) ) {
-            $ordersby = is_array($orderby) ? $orderby : preg_split('/[,\s]/', $orderby);
-            $ordersby = array_intersect(
-                    $ordersby,
-                    array(
-                            'comment_agent',
-                            'comment_approved',
-                            'comment_author',
-                            'comment_author_email',
-                            'comment_author_IP',
-                            'comment_author_url',
-                            'comment_content',
-                            'comment_date',
-                            'comment_date_gmt',
-                            'comment_ID',
-                            'comment_karma',
-                            'comment_parent',
-                            'comment_post_ID',
-                            'comment_type',
-                            'user_id',
-                    )
-            );
-            $orderby = empty( $ordersby ) ? 'comment_date_gmt' : implode(', ', $ordersby);
-    } else {
-            $orderby = 'comment_date_gmt';
-    }
-
-	$number = absint($number);
-	$offset = absint($offset);
-
-	if ( !empty($number) ) {
-		if ( $offset )
-			$number = 'LIMIT ' . $offset . ',' . $number;
-		else
-			$number = 'LIMIT ' . $number;
-
-	} else {
-		$number = '';
-	}
-
-	$post_where = '';
-
-	if ( ! empty($post_id) )
-		$post_where .= $wpdb->prepare( 'comment_post_ID = %d AND ', $post_id );
-    if ( '' !== $author_email )
-            $post_where .= $wpdb->prepare( 'comment_author_email = %s AND ', $author_email );
-    if ( '' !== $karma )
-            $post_where .= $wpdb->prepare( 'comment_karma = %d AND ', $karma );
-    if ( 'comment' == $type )
-            $post_where .= "comment_type = '' AND ";
-    elseif ( ! empty( $type ) )
-            $post_where .= $wpdb->prepare( 'comment_type = %s AND ', $type );
-    if ( '' !== $parent )
-            $post_where .= $wpdb->prepare( 'comment_parent = %d AND ', $parent );
-    if ( '' !== $user_id )
-            $post_where .= $wpdb->prepare( 'user_id = %d AND ', $user_id );
-
-	$comments = $wpdb->get_results( "SELECT * FROM $wpdb->comments WHERE $post_where $approved ORDER BY $orderby $order $number" );
-	wp_cache_add( $cache_key, $comments, 'comment' );
-
-	return $comments;
+	_deprecated_function( 'ef_get_comments_plus', '1.0', 'get_comments' );
+	return get_comments( $args );
 }


### PR DESCRIPTION
This function was created as a placeholder while waiting for https://core.trac.wordpress.org/ticket/10668

It's been a decade now, and core's `get_comments()` does what we need now 🙂. I did search around some though and can confirm that `ef_get_comments_plus()` is actually used outside EF in a few scenarios. So I've left it there and added a deprecation notice (version TBD).

Also removed some commented-out code. It's probably been a decade for these poor souls as well, and we can rely on version control if they were ever missed.