### PR TITLE
Add `ef_week_first_day` as script data to prevent echoing script tags

### DIFF
--- a/common/php/class-module.php
+++ b/common/php/class-module.php
@@ -210,7 +210,7 @@ class EF_Module {
 		//Timepicker needs to come after jquery-ui-datepicker and jquery
 		wp_enqueue_script( 'edit_flow-timepicker', EDIT_FLOW_URL . 'common/js/jquery-ui-timepicker-addon.js', array( 'jquery', 'jquery-ui-datepicker' ), EDIT_FLOW_VERSION, true );
 		wp_enqueue_script( 'edit_flow-date_picker', EDIT_FLOW_URL . 'common/js/ef_date.js', array( 'jquery', 'jquery-ui-datepicker', 'edit_flow-timepicker' ), EDIT_FLOW_VERSION, true );
-		wp_add_inline_script( 'edit_flow-date_picker', sprintf( 'var ef_week_first_day =  \'%s\';', esc_attr( get_option( 'start_of_week' ) ) ), 'before' );
+		wp_add_inline_script( 'edit_flow-date_picker', sprintf( 'var ef_week_first_day =  %s;', wp_json_encode( get_option( 'start_of_week' ) ) ), 'before' );
 
 		// Now styles
 		wp_enqueue_style( 'jquery-ui-datepicker', EDIT_FLOW_URL . 'common/css/jquery.ui.datepicker.css', array( 'wp-jquery-ui-dialog' ), EDIT_FLOW_VERSION, 'screen' );

--- a/common/php/class-module.php
+++ b/common/php/class-module.php
@@ -205,14 +205,12 @@ class EF_Module {
 	 */
 	function enqueue_datepicker_resources() {
 
-		// Add the first day of the week as an available variable to wp_head
-		echo "<script type=\"text/javascript\">var ef_week_first_day=\"" . get_option( 'start_of_week' ) . "\";</script>";
-
 		wp_enqueue_script( 'jquery-ui-datepicker' );
 
 		//Timepicker needs to come after jquery-ui-datepicker and jquery
 		wp_enqueue_script( 'edit_flow-timepicker', EDIT_FLOW_URL . 'common/js/jquery-ui-timepicker-addon.js', array( 'jquery', 'jquery-ui-datepicker' ), EDIT_FLOW_VERSION, true );
 		wp_enqueue_script( 'edit_flow-date_picker', EDIT_FLOW_URL . 'common/js/ef_date.js', array( 'jquery', 'jquery-ui-datepicker', 'edit_flow-timepicker' ), EDIT_FLOW_VERSION, true );
+		wp_add_inline_script( 'edit_flow-date_picker', sprintf( 'var ef_week_first_day =  \'%s\';', esc_attr( get_option( 'start_of_week' ) ) ), 'before' );
 
 		// Now styles
 		wp_enqueue_style( 'jquery-ui-datepicker', EDIT_FLOW_URL . 'common/css/jquery.ui.datepicker.css', array( 'wp-jquery-ui-dialog' ), EDIT_FLOW_VERSION, 'screen' );


### PR DESCRIPTION
This attaches the `var` definition to the script itself, so it will only output when the script tag is actually printed, rather than just enqueued.

 If you only call `wp_enqueue_scripts`, this just registers & enqueues the scripts, but doesn't necessarily print them. This was causing a conflict when the [PWA](https://github.com/xwp/pwa-wp) plugin is active. [It calls `admin_enqueue_scripts` to set up scripts for caching,](https://github.com/xwp/pwa-wp/blob/90767479119a06c544c659778c46c7c6a6768baa/wp-includes/class-wp-service-workers.php#L124) but it never outputs the script. See https://github.com/WordPress/wordcamp.org/pull/328 for my (hopefully temporary 😁) workaround.

## Steps to Test

1. Check out PR.
2. View source on a page, see that the variable is defined immediately before the script tag now
3. Check that the calendar still renders correctly

To be honest I don't know if more testing is necessary, but that's what I did ^