### PR TITLE
Prevent multiple custom fields from being created

### DIFF
--- a/modules/editorial-comments/editorial-comments.php
+++ b/modules/editorial-comments/editorial-comments.php
@@ -84,7 +84,7 @@ class EF_Editorial_Comments extends EF_Module
 		if ( !in_array( $pagenow, array( 'post.php', 'page.php', 'post-new.php', 'page-new.php' ) ) )
 			return;
 
-		wp_enqueue_script( 'edit_flow-post_comment', $this->module_url . 'lib/editorial-comments.js', array( 'jquery','post' ), EDIT_FLOW_VERSION, true );
+		wp_enqueue_script( 'edit_flow-post_comment', $this->module_url . 'lib/editorial-comments.js', array( 'jquery', 'wp-ajax-response' ), EDIT_FLOW_VERSION, true );
 		wp_localize_script( 'edit_flow-post_comment', '__ef_localize_post_comment', array(
 			'and'           => esc_html__( 'and', 'edit-flow' ),
 			'none_notified' => esc_html__( 'No one will be notified.', 'edit-flow' ),

--- a/tests/e2e/specs/editorial-comments.test.js
+++ b/tests/e2e/specs/editorial-comments.test.js
@@ -1,0 +1,35 @@
+/**
+ * WordPress dependencies
+ */
+
+import { createNewPost, saveDraft } from "@wordpress/e2e-test-utils";
+
+describe("Editorial Comments", () => {
+
+  it("expects a user can create an editorial comment on a post", async () => {
+    await createNewPost({title: 'Title'});
+    await saveDraft();
+
+    // todo: Eventually, we should show the "Respond to post" button when a post is saved in Gutenberg
+    // without having to reload the page
+    await page.reload({ waitUntil: ["networkidle0", "domcontentloaded"] });
+
+    const COMMENT_TEXT = 'Hello';
+
+    const respondButton = await page.$('#ef-comment_respond');
+    await respondButton.click();
+
+    await page.type('#ef-replycontent', COMMENT_TEXT);
+
+    const saveReplyButton = await page.$('.ef-replysave');
+    await saveReplyButton.click();
+
+    const commentNodes = await page.waitFor('#ef-comments .comment-content');
+
+    const comments = await commentNodes.$$eval('p', nodes => nodes.map(n => {
+      return n.innerText
+    }));
+
+    expect(comments).toContain(COMMENT_TEXT);
+  });
+});


### PR DESCRIPTION
A fix for #588

For some reason, when `post` is a dependency of the Editorial Comment js, the custom fields get duplicated. Not sure why we have `post` as a dependency in the first place since all we use is `wpAjax`. 

Also, created a quick e2e test to validate the creation of an editorial comment