### PR TITLE
Statuses for Story Budget and Calendar should be Edit Flow specific s…

### DIFF
--- a/modules/calendar/calendar.php
+++ b/modules/calendar/calendar.php
@@ -651,7 +651,7 @@ class EF_Calendar extends EF_Module {
 		}
 		
 		// we sort by post statuses....... eventually
-		$post_statuses = $this->get_post_statuses();
+		$post_statuses = $this->get_calendar_post_stati();
 		?>
 		<div class="wrap">
 			<div id="ef-calendar-title"><!-- Calendar Title -->
@@ -746,7 +746,7 @@ class EF_Calendar extends EF_Module {
 					if ( !empty( $week_posts[$week_single_date] ) ) {
 						$week_posts_by_status = array();
 						foreach( $post_statuses as $post_status ) {
-							$week_posts_by_status[$post_status->slug] = array();
+							$week_posts_by_status[$post_status->name] = array();
 						}
 						// These statuses aren't handled by custom statuses or post statuses
 						$week_posts_by_status['private'] = array();
@@ -1231,14 +1231,13 @@ class EF_Calendar extends EF_Module {
 		// Unpublished as a status is just an array of everything but 'publish'.
 		if ( 'unpublish' == $args['post_status'] ) {
 			$args['post_status'] = '';
-			$post_stati = get_post_stati();
-			unset($post_stati['inherit'], $post_stati['auto-draft'], $post_stati['trash'], $post_stati['publish'] );
+			$post_stati = wp_filter_object_list( $this->get_calendar_post_stati(), array( 'name' => 'publish' ), 'not' );
+
 			if ( ! apply_filters( 'ef_show_scheduled_as_unpublished', false ) ) {
-				unset( $post_stati['future'] );
+				$post_stati = wp_filter_object_list( $post_stati, array( 'name' => 'future' ), 'not' );
 			}
-			foreach ( $post_stati as $post_status ) {
-				$args['post_status'] .= $post_status . ', ';
-			}
+
+			$args['post_status'] .= join( wp_list_pluck( $post_stati, 'name' ), ',' );
 		}
 		// The WP functions for printing the category and author assign a value of 0 to the default
 		// options, but passing this to the query is bad (trashed and auto-draft posts appear!), so
@@ -1698,9 +1697,9 @@ class EF_Calendar extends EF_Module {
 		switch( $key ) {
 			case 'post_status':
 				// Whitelist-based validation for this parameter
-				$valid_statuses = get_post_stati();
+				$valid_statuses = wp_list_pluck( $this->get_calendar_post_stati(), 'name' );
 				$valid_statuses[] = 'unpublish';
-				unset( $valid_statuses['inherit'], $valid_statuses['auto-draft'], $valid_statuses['trash'] );
+
 				if ( in_array( $dirty_value, $valid_statuses ) )
 					return $dirty_value;
 				else
@@ -1730,16 +1729,13 @@ class EF_Calendar extends EF_Module {
 	function calendar_filter_options( $select_id, $select_name, $filters ) {
 		switch( $select_id ){ 
 			case 'post_status':
-				$post_stati = get_post_stati();
-				unset( $post_stati['inherit'], $post_stati['auto-draft'], $post_stati['trash'] );
+				$post_stati = $this->get_calendar_post_stati();
 			?>
 				<select id="<?php echo $select_id; ?>" name="<?php echo $select_name; ?>" >
 					<option value=""><?php _e( 'View all statuses', 'edit-flow' ); ?></option>
 					<?php 
-						foreach ( $post_stati as $post_status ) { 
-							$value = $post_status;
-							$status = get_post_status_object($post_status);
-							echo "<option value='" . esc_attr( $value ) . "' " . selected( $value, $filters['post_status'] ) . ">" . esc_html( $status->label ) . "</option>";
+						foreach ( $post_stati as $status ) { 
+							echo "<option value='" . esc_attr( $status->name ) . "' " . selected( $status->name, $filters['post_status'] ) . ">" . esc_html( $status->label ) . "</option>";
 						}
 					?>
 					<option value="unpublish" <?php selected( 'unpublish', $filters['post_status'] ) ?> > <?php echo __( 'Unpublished', 'edit-flow' ) ?> </option>
@@ -1850,6 +1846,30 @@ class EF_Calendar extends EF_Module {
 		unset( $this->post_date_cache[ $post_ID ] );
 		$wpdb->update( $wpdb->posts, array( 'post_date' => $post_date ), array( 'ID' => $post_ID ) );
 		clean_post_cache( $post_ID );
+	}
+
+	/**
+	 * Returns a list of custom status objects used by the calendar
+	 * 
+	 * @return array An array of StdClass objects representing statuses
+	 */
+	public function get_calendar_post_stati() {
+		$post_stati = get_post_stati( array(), 'object' );
+		$custom_status_slugs = wp_list_pluck( $this->get_post_statuses(), 'slug' );
+		$custom_status_slugs[] = 'future';	
+		$custom_status_slugs[] = 'publish';
+
+		$custom_status_slug_keys = array_flip( $custom_status_slugs );
+
+		$final_statuses = [];
+
+		foreach( $post_stati as $status ) {
+			if ( !empty( $custom_status_slug_keys[ $status->name ] ) ) {
+				$final_statuses[] = $status;
+			}
+		}
+
+		return apply_filters( 'ef_calendar_post_stati', $final_statuses );
 	}
 	
 } // EF_Calendar

--- a/modules/story-budget/story-budget.php
+++ b/modules/story-budget/story-budget.php
@@ -405,14 +405,13 @@ class EF_Story_Budget extends EF_Module {
 		// Unpublished as a status is just an array of everything but 'publish'.
 		if ( 'unpublish' == $args['post_status'] ) {
 			$args['post_status'] = '';
-			$post_stati = get_post_stati();
-			unset( $post_stati['inherit'], $post_stati['auto-draft'], $post_stati['trash'], $post_stati['publish'] );
+			$post_stati = wp_filter_object_list( $this->get_budget_post_stati(), array( 'name' => 'publish' ), 'not' );
+
 			if ( ! apply_filters( 'ef_show_scheduled_as_unpublished', false ) ) {
-				unset( $post_stati['future'] );
+				$post_stati = wp_filter_object_list( $post_stati, array( 'name' => 'future' ), 'not' );
 			}
-			foreach ( $post_stati as $post_status ) {
-				$args['post_status'] .= $post_status . ', ';
-			}
+
+			$args['post_status'] .= join( wp_list_pluck( $post_stati, 'name' ), ',' );
 		}
 
 		// Filter by post_author if it's set
@@ -748,16 +747,13 @@ class EF_Story_Budget extends EF_Module {
 	function story_budget_filter_options( $select_id, $select_name, $filters ) {
 		switch( $select_id ) {
 			case 'post_status': 
-			$post_stati = get_post_stati();
-			unset( $post_stati['inherit'], $post_stati['auto-draft'], $post_stati['trash'] );
+			$post_stati = $this->get_budget_post_stati();
 			?>
 				<select id="post_status" name="post_status"><!-- Status selectors -->
 						<option value=""><?php _e( 'View all statuses', 'edit-flow' ); ?></option>
 						<?php
-							foreach ( $post_stati as $post_status ) {
-								$value = $post_status;
-								$status = get_post_status_object($post_status)->label;
-								echo '<option value="' . esc_attr( $value ) . '" ' . selected( $value, $filters['post_status'] ) . '>' . esc_html( $status ) . '</option>';
+							foreach ( $post_stati as $status ) { 
+								echo '<option value="' . esc_attr( $status->name ) . '" ' . selected( $status->name, $filters['post_status'] ) . '>' . esc_html( $status->label ) . '</option>';
 							}
 							echo '<option value="unpublish"' . selected('unpublish', $filters['post_status']) . '>' . __( 'Unpublished', 'edit-flow' ) . '</option>';
 						?>
@@ -792,6 +788,30 @@ class EF_Story_Budget extends EF_Module {
 				do_action( 'ef_story_budget_filter_display', $select_id, $select_name, $filters);
 			break;
 		}
+	}
+
+	/**
+	 * Returns a list of custom status objects used by the story budget
+	 * 
+	 * @return array An array of StdClass objects representing statuses
+	 */
+	public function get_budget_post_stati() {
+		$post_stati = get_post_stati( array(), 'object' );
+		$custom_status_slugs = wp_list_pluck( $this->get_post_statuses(), 'slug' );
+		$custom_status_slugs[] = 'future';	
+		$custom_status_slugs[] = 'publish';
+
+		$custom_status_slug_keys = array_flip( $custom_status_slugs );
+
+		$final_statuses = [];
+
+		foreach( $post_stati as $status ) {
+			if ( !empty( $custom_status_slug_keys[ $status->name ] ) ) {
+				$final_statuses[] = $status;
+			}
+		}
+
+		return apply_filters( 'ef_budget_post_stati', $final_statuses );
 	}
 	
 }

--- a/tests/test-edit-flow-calendar.php
+++ b/tests/test-edit-flow-calendar.php
@@ -1,0 +1,67 @@
+<?php
+
+class WP_Test_Edit_Flow_Calendar extends WP_UnitTestCase {
+
+	protected static $admin_user_id;
+	protected static $EF_Calendar;
+
+	public static function wpSetUpBeforeClass( $factory ) {
+		global $edit_flow;
+
+		self::$admin_user_id = $factory->user->create( array( 'role' => 'administrator' ) );
+
+		$edit_flow->custom_status->install();
+		$edit_flow->custom_status->init();
+
+		$edit_flow->calendar->install();
+		$edit_flow->calendar->init();
+	}
+
+	public static function wpTearDownAfterClass() {
+		self::delete_user( self::$admin_user_id );
+	}
+
+	/**
+	* Test that calendar has default custom statuses
+	*/
+	public function test_calendar_custom_statuses() {
+		global $edit_flow;
+
+        $statuses = array_map( 
+            function( $status ) {
+                return $status->name;
+            }, 
+            $edit_flow->calendar->get_calendar_post_stati() 
+        );
+
+		$this->assertContains( 'future', $statuses );
+		$this->assertContains( 'pitch', $statuses );
+	}
+
+	/**
+	 * Test that calendar can show registered status
+	 */
+	public function test_calendar_custom_statuses_registered() {
+		global $edit_flow;
+
+		$new_custom_status = array(
+			'term' => __( 'New Custom Status' ),
+			'args' => array(
+				'slug'        => 'new-custom-status',
+				'description' => 'description',
+				'position'    => 6,
+			),
+        );
+        
+        $edit_flow->custom_status->add_custom_status( $new_custom_status['term'], $new_custom_status['args'] );
+
+        $statuses = array_map( 
+            function( $status ) {
+                return $status->name;
+            }, 
+            $edit_flow->calendar->get_calendar_post_stati() 
+        );
+        
+        $this->assertContains( 'future', $statuses );
+	}
+}

--- a/tests/test-edit-flow-story-budget.php
+++ b/tests/test-edit-flow-story-budget.php
@@ -112,5 +112,49 @@ class WP_Test_Edit_Flow_Story_Budget extends WP_UnitTestCase {
 
     $this->assertEquals( 10, $users_filters['number_days'] );
     $this->assertEquals( '2019-12-01', $users_filters['start_date'] );
+  }
+  
+  /**
+	* Test that calendar has default custom statuses
+	*/
+	public function test_calendar_custom_statuses() {
+		global $edit_flow;
+
+        $statuses = array_map( 
+            function( $status ) {
+                return $status->name;
+            }, 
+            $edit_flow->calendar->get_calendar_post_stati() 
+        );
+
+		$this->assertContains( 'future', $statuses );
+		$this->assertContains( 'pitch', $statuses );
+	}
+
+	/**
+	 * Test that calendar can show registered status
+	 */
+	public function test_calendar_custom_statuses_registered() {
+		global $edit_flow;
+
+		$new_custom_status = array(
+			'term' => __( 'New Custom Status' ),
+			'args' => array(
+				'slug'        => 'new-custom-status',
+				'description' => 'description',
+				'position'    => 6,
+			),
+        );
+        
+        $edit_flow->custom_status->add_custom_status( $new_custom_status['term'], $new_custom_status['args'] );
+
+        $statuses = array_map( 
+            function( $status ) {
+                return $status->name;
+            }, 
+            $edit_flow->calendar->get_calendar_post_stati() 
+        );
+        
+        $this->assertContains( 'future', $statuses );
 	}
 }


### PR DESCRIPTION
(https://github.com/Automattic/Edit-Flow/pull/446) fixed an issue where Edit Flow was preventing other custom statuses from appearing in the status column for a post type, which makes sense.

However, for Calendar and Story Budget, you can end up with the following:

<img width="1496" alt="Screen Shot 2020-02-19 at 11 17 12 PM" src="https://user-images.githubusercontent.com/1888152/74900617-66893f00-536e-11ea-90a3-13f737354dfa.png">

These are statuses from WooCommerce in the Story Budget dropdown, and they persist even after the WooCommerce plugin is disabled. This makes the dropdown a little confusing (in this case, for folks who might have an e-commerce site with a content marketing arm that uses Edit Flow).

This PR cleans up some logic around the post status filters for Calendar and Story Budget, and also provides a way for folks to hook into Calendar and Story Budget status filers so folks can provide their own