### PR TITLE
Fix bug preventing previewing posts authored by other users

### DIFF
--- a/modules/custom-status/custom-status.php
+++ b/modules/custom-status/custom-status.php
@@ -1508,7 +1508,7 @@ class EF_Custom_Status extends EF_Module {
 	 * @see https://github.com/Automattic/Edit-Flow/issues/513
 	 */
 	public function fix_preview_link_part_three( $preview_link, $query_args ) {
-		if ( $autosave = wp_get_post_autosave( $query_args->ID, $query_args->post_author ) ) {
+		if ( $autosave = wp_get_post_autosave( $query_args->ID, get_current_user_id() ) ) {
 		    foreach ( array_intersect( array_keys( _wp_post_revision_fields( $query_args ) ), array_keys( _wp_post_revision_fields( $autosave ) ) ) as $field ) {
 		        if ( normalize_whitespace( $query_args->$field ) != normalize_whitespace( $autosave->$field ) ) {
 		        	// Pass through, it's a personal preview.


### PR DESCRIPTION
Bug description:

The author of a post can preview changes to their own published posts,
but other users see the content of the published post when previewing.

This is due to checking for the autosaves of `$query_args->post_author`
instead of the autosaves of `get_current_user_id()`.

Steps to reproduce:

1. Log in as user A
2. Create a new post, press "Publish"
3. Log in as user B
4. Visit the edit page for the post that was just created
5. Add to the post's content (without pressing "Update")
6. Click "Preview"

Expected behaviour:

The content added by user B appears in the preview.

Actual behaviour:

The content added by user B doesn't appear in the preview of the post.