### PR TITLE
Add back unpublish status, small css tweak for statuses

### DIFF
--- a/modules/calendar/calendar.php
+++ b/modules/calendar/calendar.php
@@ -1837,14 +1837,22 @@ class EF_Calendar extends EF_Module {
 		$all_post_types = get_post_types( null, 'objects' );
 
 		$config = array(
-			'POST_STATI' => array_map( 
-				function( $item ) {
-					return array( 
-						'name' => $item->name, 
-						'label' => $item->label,
-					);
-				}, 
-				$this->get_calendar_post_stati() 
+			'POST_STATI' => array_merge(
+				array( 
+					array(
+						'label' => 'Unpublish',
+						'name' => 'unpublish'
+					)
+				),
+				array_map( 
+					function( $item ) {
+						return array( 
+							'name' => $item->name, 
+							'label' => $item->label,
+						);
+					}, 
+					$this->get_calendar_post_stati() 
+				)
 			),
 			'USERS' => array_map( 
 				function( $item ) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8490,6 +8490,12 @@
             "find-up": "^3.0.0"
           }
         },
+        "prettier": {
+          "version": "npm:wp-prettier@1.19.1",
+          "resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-1.19.1.tgz",
+          "integrity": "sha512-mqAC2r1NDmRjG+z3KCJ/i61tycKlmADIjxnDhQab+KBxSAGbF/W7/zwB2guy/ypIeKrrftNsIYkNZZQKf3vJcg==",
+          "dev": true
+        },
         "punycode": {
           "version": "1.4.1",
           "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
@@ -25711,12 +25717,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
-      "dev": true
-    },
-    "prettier": {
-      "version": "npm:wp-prettier@1.19.1",
-      "resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-1.19.1.tgz",
-      "integrity": "sha512-mqAC2r1NDmRjG+z3KCJ/i61tycKlmADIjxnDhQab+KBxSAGbF/W7/zwB2guy/ypIeKrrftNsIYkNZZQKf3vJcg==",
       "dev": true
     },
     "prettier-linter-helpers": {


### PR DESCRIPTION
The "Unpublish" status for calendar was dropped with the recent Gutenberg changes. Reintroduce this status