### PR TITLE
Remove Travis mentions in the repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@ Redefining your editorial workflow.
 
 ## Description
 
-[![Build Status](https://travis-ci.org/Automattic/Edit-Flow.svg?branch=master)](https://travis-ci.org/Automattic/Edit-Flow)
-
 Edit Flow empowers you to collaborate with your editorial team inside WordPress. We've made it modular so you can customize it to your needs:
 
 * [Calendar](http://editflow.org/features/calendar/) - A convenient month-by-month look at your content.

--- a/documentation/ru_RU/README.md
+++ b/documentation/ru_RU/README.md
@@ -10,8 +10,6 @@
 
 ## Описание
 
-[![Статус сборки](https://travis-ci.org/Automattic/Edit-Flow.svg?branch=master)](https://travis-ci.org/Automattic/Edit-Flow)
-
 Edit Flow позволяет организовать взаимодействие с командой редакции прямо в WordPress. Мы сделали его модульным, чтобы вы могли подстроить Edit Flow под свои нужжы:
 
 * [Календарь](http://editflow.org/features/calendar/) - Удобный помесячный взгляд на материалы.

--- a/documentation/ru_RU/readme.txt
+++ b/documentation/ru_RU/readme.txt
@@ -10,8 +10,6 @@
 
 == Описание ==
 
-[![Статус сборки](https://travis-ci.org/Automattic/Edit-Flow.svg?branch=master)](https://travis-ci.org/Automattic/Edit-Flow)
-
 Edit Flow позволяет организовать взаимодействие с командой редакции прямо в WordPress. Мы сделали его модульным, чтобы вы могли подстроить Edit Flow под свои нужжы:
 
 * [Календарь](http://editflow.org/features/calendar/) - Удобный помесячный взгляд на материалы.


### PR DESCRIPTION


## Description

This simply removes all mentions of "travis" in the repo after we moved to GitHub Actions https://github.com/Automattic/Edit-Flow/pull/635

Note: I did not remove any mention of Travis in the changelog. 