### PR TITLE
PHP 8.0 and PHPCS: partly fix compatibility with composer packages

### DIFF
--- a/.github/workflows/php-tests.yml
+++ b/.github/workflows/php-tests.yml
@@ -24,10 +24,7 @@ jobs:
           - php: '8.0'
             wp: '5.7'
             allowed_failure: true
-          # PHP nightly.
-          - php: '8.1'
-            wp: '5.7'
-            allowed_failure: true
+
     steps:
       - name: Checkout code
         uses: actions/checkout@master

--- a/.github/workflows/php-tests.yml
+++ b/.github/workflows/php-tests.yml
@@ -57,6 +57,9 @@ jobs:
         run: bash bin/install-wp-tests.sh wordpress_test root root localhost ${{ matrix.wp }}
 
       - name: Run PHPCS diff tests
+        # TODO: remove this condition when a new version of WPCS is released
+        # @see https://github.com/Automattic/Edit-Flow/issues/638#issuecomment-825511819
+        if: ${{ matrix.php < 8.0 }}
         run: bash bin/phpcs-diff.sh
 
       - name: Run PHPUnit tests (single site)

--- a/bin/phpcs-diff.sh
+++ b/bin/phpcs-diff.sh
@@ -5,9 +5,9 @@ DIFF_FILE=$(mktemp)
 PHPCS_FILE=$(mktemp)
 
 git remote set-branches --add origin master
-git fetch
+git fetch origin master
 git diff origin/master > $DIFF_FILE
 
-$DIR/../vendor/bin/phpcs --extensions=php --standard=phpcs.xml.dist --report=json > $PHPCS_FILE || true 
+$DIR/../vendor/bin/phpcs --extensions=php --standard=phpcs.xml.dist --report=json > $PHPCS_FILE || true
 
-$DIR/../vendor/bin/diffFilter --phpcs $DIFF_FILE $PHPCS_FILE 0
+$DIR/../vendor/bin/diffFilter --phpcs $DIFF_FILE $PHPCS_FILE 100

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "require-dev": {
         "automattic/vipwpcs": "^2.0",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.4.1 || ^0.5 || ^0.6.2 || ^0.7",
-        "exussum12/coverage-checker": "^0.11.2",
+        "exussum12/coverage-checker": "^0.11.2 || ^1.0.0",
         "phpunit/phpunit": "^4 || ^5 || ^6 || ^7"
     },
     "scripts": {


### PR DESCRIPTION
Partly fix #638
Close #647

## Description

- Update "coverage-checker" so that it can support PHP 8.0.
- Stop running PHPCS for PHP 8.0 as WPCS is not ready as mentioned here https://github.com/Automattic/Edit-Flow/issues/638#issuecomment-825511819.
- Update bin/phpcs-diff.sh then (1) it will not fetch all branches (we just need `master` branch), and (2) it will show errors when diff lines do not conform with PHPCS. Currently, it does not exit with any error. 
- Remove tests for PHP 8.1 - [see here](https://github.com/Parsely/wp-parsely/blob/152c1dd9b288f9ae66e2c521171194df5f7170b8/.github/workflows/integration-tests.yml#L33).

## Steps to Test

Mainly check the relevant GitHub Actions for PHP Tests here. 

Note: for PHP 8.0 test failure, it will be addressed in another PR as the solution is here https://github.com/Automattic/Edit-Flow/issues/639#issuecomment-836384914