### PR TITLE
Fix test_story_budget_set_number_days_filter_invalid in PHP 8.0

### DIFF
--- a/modules/story-budget/story-budget.php
+++ b/modules/story-budget/story-budget.php
@@ -229,6 +229,7 @@ class EF_Story_Budget extends EF_Module {
 		}
 
 		if ( isset( $new_filters['number_days'] ) ) {
+			$new_filters['number_days'] = intval( $new_filters['number_days'] );
 			if ( $new_filters['number_days'] <= 1 ) {
 				$existing_filters['number_days'] = 1;
 			} else {


### PR DESCRIPTION
Fix #639 

## Description

Details here https://github.com/Automattic/Edit-Flow/issues/639#issuecomment-836384914
This PR should be merged after this PR https://github.com/Automattic/Edit-Flow/pull/643 - actually, this PR is rebased on PR 643. 

## Steps to Test

1. Check out PR.
1. Set up WP test site `bash bin/install-wp-tests.sh wordpress_test root root`.
2. Run PHPUnit tests in PHP 8.0.x `composer integration`.
3. Confirm that all tests pass. 