### PR TITLE
Fix: updating post slugs in Quick Edit and Classic Editor

### DIFF
--- a/modules/custom-status/custom-status.php
+++ b/modules/custom-status/custom-status.php
@@ -1373,10 +1373,9 @@ class EF_Custom_Status extends EF_Module {
 	 * @since 0.9.4
 	 *
 	 * If the post_name is set, set it, otherwise keep it empty
-	 * 
-	 * @see https://github.com/Automattic/Edit-Flow/issues/123
-	 * @see http://core.trac.wordpress.org/browser/tags/3.4.2/wp-includes/post.php#L2530
-	 * @see http://core.trac.wordpress.org/browser/tags/3.4.2/wp-includes/post.php#L2646
+	 *
+	 * @see https://github.com/Automattic/Edit-Flow/issues/523
+	 * @see https://github.com/Automattic/Edit-Flow/issues/633
 	 */
 	public function maybe_keep_post_name_empty( $data, $postarr ) {
 		$status_slugs = wp_list_pluck( $this->get_custom_statuses(), 'slug' );
@@ -1389,7 +1388,7 @@ class EF_Custom_Status extends EF_Module {
 
 		// If the post_name was intentionally set, set the post_name
 		if ( ! empty( $postarr['post_name'] ) ) {
-			$data['post_name'] = $postarr['post_name'];
+			$data['post_name'] = sanitize_title( $postarr['post_name'] );
 			return $data;
 		}
 
@@ -1406,7 +1405,7 @@ class EF_Custom_Status extends EF_Module {
 	 *
 	 * `wp_unique_post_slug` is used to set the `post_name`. When a custom status is used, WordPress will try
 	 * really hard to set `post_name`, and we leverage `wp_unique_post_slug` to prevent it being set
-	 * 
+	 *
 	 * @see: https://github.com/WordPress/WordPress/blob/396647666faebb109d9cd4aada7bb0c7d0fb8aca/wp-includes/post.php#L3932
 	 */
 	public function fix_unique_post_slug( $override_slug, $slug, $post_ID, $post_status, $post_type, $post_parent ) {


### PR DESCRIPTION
Fix #633 

## Description

This is to address the issue as mentioned in issue #633. It was introduced from this PR https://github.com/Automattic/Edit-Flow/pull/575 that fixes a relevant issue with post slug in Gutenberg https://github.com/Automattic/Edit-Flow/issues/523. 

The issue is happening around these lines:

http://github.com/Automattic/Edit-Flow/blob/124c3cde900c22abe15c04b0b2bd11e306b2aef4/modules/custom-status/custom-status.php#L1390-L1394

In this PR, I am just running [sanitize_title](https://developer.wordpress.org/reference/functions/sanitize_title/) to fix this issue. 

It's not an issue with Gutenberg as Gutenberg itself tries to convert the slug in the front-end before sending it to the back-end: 
- See the screenshot below
- Relevant code: [one](https://github.com/WordPress/gutenberg/blob/848949d057bce0374f04e33d1dfbeab209eef7aa/packages/editor/src/store/selectors.js#L1064-L1079) - [two](https://github.com/WordPress/gutenberg/blob/848949d057bce0374f04e33d1dfbeab209eef7aa/packages/editor/src/utils/url.js#L25-L52)

## Steps to Test

### Case 1 - Quick Edit 

1. Apply this PR
2. Add a new post with a custom status.
3. Go to wp-admin/edit.php, and try to edit the post above with `Quick Edit`.
4. Try to change the slug to something like `MY-post-slug`.
5. Reload wp-admin/edit.php, the slug will be `my-post-slug`. 

### Case 2 - Classic Editor 

1. Activate only Edit Flow and Classic Editor plugins, and apply this PR.
2. Add a new post with any status rather than "Published".
3. Try to edit the post above in the Classic Editor.
4. Try to change the slug to something like `MY-post-slug`, and save this post.
5. Though the Classic Editor, it's showing all lower cases `my-post-slug`. 
6. In the DB, it's still showing the correct value `my-post-slug`. 

### Case 3 - Gutenberg editor 

1. Apply this PR
2. Add a new post in Gutenberg with a custom status.
4. Try to change the slug to something like `MY-post-slug`.
5. Move around, the slug will be `my-post-slug`. 
5. Reload the editor, the slug will be still `my-post-slug`. 

## Screenshot 

Gutenberg sanitizes post slugs in the front-end: 

![Screen Capture on 2021-05-17 at 15-37-17](https://user-images.githubusercontent.com/10045087/118459326-d929cb80-b725-11eb-99e3-1b8c98a6a9e6.gif)
