### PR TITLE
Fix jQuery warnings as WordPress upgraded it from 1.12.4-wp to 3.5.1

### DIFF
--- a/common/js/jquery-ui-timepicker-addon.js
+++ b/common/js/jquery-ui-timepicker-addon.js
@@ -251,7 +251,7 @@
 			if (o.altField) {
 				tp_inst.$altInput = $(o.altField).css({
 					cursor: 'pointer'
-				}).focus(function() {
+				}).on ( 'focus', function() {
 					$input.trigger("focus");
 				});
 			}
@@ -276,7 +276,7 @@
 			if (tp_inst._defaults.maxDateTime !== undefined && tp_inst._defaults.maxDateTime instanceof Date) {
 				tp_inst._defaults.maxDate = new Date(tp_inst._defaults.maxDateTime.getTime());
 			}
-			tp_inst.$input.bind('focus', function() {
+			tp_inst.$input.on( 'focus', function() {
 				tp_inst._onFocus();
 			});
 
@@ -412,7 +412,7 @@
 							marginLeft: o.isRTL? '0' : ((size / (-2 * gridSize[litem])) + "%"),
 							marginRight: o.isRTL? ((size / (-2 * gridSize[litem])) + "%") : '0',
 							borderCollapse: 'collapse'
-						}).find("td").click(function(e){
+						}).find("td").on( 'click', function(e){
 								var $t = $(this),
 									h = $t.html(),
 									n = parseInt(h.replace(/[^0-9]/g),10),

--- a/common/js/jquery.listfilterizer.js
+++ b/common/js/jquery.listfilterizer.js
@@ -14,7 +14,7 @@
 	
 	// We need :contains to be case insensitive so lets redefine it as containsi (i for case insensitive)
 	// http://stackoverflow.com/questions/187537/is-there-a-case-insensitive-jquery-contains-selector
-	jQuery.expr[':'].containsi = function(a, i, m){
+	jQuery.expr.pseudos.containsi = function(a, i, m){
 		return (a.textContent || a.innerText || '').toLowerCase().indexOf(m[3].toLowerCase()) >= 0;
 	};
 	
@@ -50,7 +50,7 @@
 						var $filterTab = $('<li/>')
 							.text(filter.label)
 							.attr(options._filterIdAttr, i)
-							.bind('click', _filterTabEvent)
+							.on('click', _filterTabEvent)
 							;
 						$tabs.append($filterTab);
 					}
@@ -65,9 +65,9 @@
 					.attr('type', inputType)
 					.attr(options.inputAttrs)
 					.addClass(options.inputClass)
-					.bind('search', _filterInputSearch)
-					.bind('keydown', _filterInputKeydown)
-					.bind('keyup', _filterInputKeyup)
+					.on('search', _filterInputSearch)
+					.on('keydown', _filterInputKeydown)
+					.on('keyup', _filterInputKeyup)
 					.attr('placeholder', options.inputPlaceholder)
 					;
 				
@@ -76,7 +76,7 @@
 					$input
 						.addClass(options.inputPlaceholderClass)
 						.val(options.inputPlaceholder)
-						.focus(function() {
+						.on( 'focus', function() {
 							var $this = $(this);
 							if($this.val() == options.inputPlaceholder) {
 								$this

--- a/common/js/jquery.quicksearch.js
+++ b/common/js/jquery.quicksearch.js
@@ -169,11 +169,11 @@ jQuery(function ($) {
 			
 		function focus_on_load()
 		{
-			$('input[rel="' + options.randomElement + '"]').get(0).focus();
+			$('input[rel="' + options.randomElement + '"]').get(0).trigger( 'focus' );
 		}
 		
 		function toggle_text() {
-			$('input[rel="' + options.randomElement + '"]').focus(function () {
+			$('input[rel="' + options.randomElement + '"]').on( 'focus', function () {
 				if ($(this).val() === options.inputText) {
 					$(this).val('');
 				}
@@ -312,17 +312,17 @@ jQuery(function ($) {
 		});
 		
 		init();
-		
-		$('input[rel="' + options.randomElement + '"]').keydown(function (e) {
+
+		$('input[rel="' + options.randomElement + '"]').on( 'keydown', function (e) {
 			var keycode = e.keyCode;
 			if (!(keycode === 9 || keycode === 13 || keycode === 16 || keycode === 17 || keycode === 18 || keycode === 38 || keycode === 40 || keycode === 224))
 			{
 				qs();
 			}
 		});
-		
-		$('form.quicksearch, fieldset.quicksearch').submit( function () { return false; });
-		
+
+		$('form.quicksearch, fieldset.quicksearch').on( 'submit', function () { return false; });
+
 		return this;
 	};
 });

--- a/common/js/screen-options.js
+++ b/common/js/screen-options.js
@@ -8,6 +8,6 @@ jQuery(function($){
 			params
 		);
 	}
-	
-	$('#screen-options-wrap div.requires-autosave').find('input, select, textarea').change(performAutosave);
+
+	$('#screen-options-wrap div.requires-autosave').find('input, select, textarea').on( 'change', performAutosave);
 });

--- a/modules/calendar/lib/calendar.js
+++ b/modules/calendar/lib/calendar.js
@@ -1,8 +1,8 @@
 var dispatch = wp.data.dispatch;
 
 jQuery(document).ready(function ($) {
-	
-	$('a.show-more').click(function(){
+
+	$('a.show-more').on( 'click', function(){
 		var parent = $(this).closest('td.day-unit');
 		$('ul li', parent).removeClass('hidden');
 		$(this).hide();
@@ -109,7 +109,7 @@ jQuery(document).ready(function ($) {
 	
 	// Close out all of the overlays with your escape key,
 	// or by clicking anywhere other than inside an existing overlay
-	$(document).keydown(function(event) {
+	$(document).on( 'keydown', function(event) {
 		if (event.keyCode == '27') {
 			edit_flow_calendar_close_overlays();
 		}
@@ -118,7 +118,7 @@ jQuery(document).ready(function ($) {
 	/**
 	 * Somewhat hackish way to close overlays automagically when you click outside an overlay
 	 */
-	$(document).click(function(event){
+	$(document).on( 'click', function(event){
 		//Did we click on a list item? How do we figure that out?
 		//First let's see if we directly clicked on a .day-item
 		var target = $(event.target);
@@ -259,7 +259,7 @@ jQuery(document).ready(function ($) {
 			// or to a double click on the calendar square
 			$day_units.find('.schedule-new-post-button').on('click.editFlow.quickPublish', EFQuickPublish.open_quickpost_dialogue );
 			$day_units.on('dblclick.editFlow.quickPublish', EFQuickPublish.open_quickpost_dialogue );
-			$day_units.hover(
+			$day_units.on( 'hover',
 				function(){ $(this).find('.schedule-new-post-button').stop().delay(500).fadeIn(100);},
 				function(){ $(this).find('.schedule-new-post-button').stop().hide();}
 			);

--- a/modules/calendar/lib/calendar.js
+++ b/modules/calendar/lib/calendar.js
@@ -259,10 +259,8 @@ jQuery(document).ready(function ($) {
 			// or to a double click on the calendar square
 			$day_units.find('.schedule-new-post-button').on('click.editFlow.quickPublish', EFQuickPublish.open_quickpost_dialogue );
 			$day_units.on('dblclick.editFlow.quickPublish', EFQuickPublish.open_quickpost_dialogue );
-			$day_units.on( 'hover',
-				function(){ $(this).find('.schedule-new-post-button').stop().delay(500).fadeIn(100);},
-				function(){ $(this).find('.schedule-new-post-button').stop().hide();}
-			);
+			$day_units.on( 'mouseenter', function(){ $(this).find('.schedule-new-post-button').stop().delay(500).fadeIn(100);});
+			$day_units.on( 'mouseleave', function(){ $(this).find('.schedule-new-post-button').stop().hide();});
 		}, // init
 
 		/**

--- a/modules/custom-status/lib/custom-status-configure.js
+++ b/modules/custom-status/lib/custom-status-configure.js
@@ -7,7 +7,7 @@ inlineEditCustomStatus = {
 
 		t.what = '#term-';
 
-		$('.editinline').on( 'click', function(){
+		$( document ).on( 'click', '.editinline', function(){
 			inlineEditCustomStatus.edit(this);
 			return false;
 		});

--- a/modules/custom-status/lib/custom-status-configure.js
+++ b/modules/custom-status/lib/custom-status-configure.js
@@ -7,19 +7,19 @@ inlineEditCustomStatus = {
 
 		t.what = '#term-';
 
-		$('.editinline').live('click', function(){
+		$('.editinline').on( 'click', function(){
 			inlineEditCustomStatus.edit(this);
 			return false;
 		});
 
 		// prepare the edit row
-		row.keyup(function(e) { if(e.which == 27) return inlineEditCustomStatus.revert(); });
+		row.on( 'keyup', function(e) { if(e.which == 27) return inlineEditCustomStatus.revert(); });
 
-		$('a.cancel', row).click(function() { return inlineEditCustomStatus.revert(); });
-		$('a.save', row).click(function() { return inlineEditCustomStatus.save(this); });
-		$('input, select', row).keydown(function(e) { if(e.which == 13) return inlineEditCustomStatus.save(this); });
+		$('a.cancel', row).on( 'click', function() { return inlineEditCustomStatus.revert(); });
+		$('a.save', row).on( 'click', function() { return inlineEditCustomStatus.save(this); });
+		$('input, select', row).on( 'keydown', function(e) { if(e.which == 13) return inlineEditCustomStatus.save(this); });
 
-		$('#posts-filter input[type="submit"]').mousedown(function(e){
+		$('#posts-filter input[type="submit"]').on( 'mousedown', function(e){
 			t.revert();
 		});
 	},
@@ -125,7 +125,7 @@ $(document).ready(function(){inlineEditCustomStatus.init();});
 
 jQuery(document).ready(function(){
 
-	jQuery('.delete-status a').click(function(){
+	jQuery('.delete-status a').on( 'click', function(){
 		if ( !confirm( ef_confirm_delete_status_string ) )
 			return false;
 	});

--- a/modules/custom-status/lib/custom-status.js
+++ b/modules/custom-status/lib/custom-status.js
@@ -25,18 +25,18 @@ jQuery(document).ready(function() {
 				jQuery('#post-status-select').hide();
 				jQuery('.edit-post-status').show();
 			}
-		
-			jQuery('.edit-post-status').click(function() {
+
+			jQuery('.edit-post-status').on( 'click', function() {
 				jQuery('#post-status-select').slideDown();
 				jQuery('.edit-post-status').hide();
 				return false;
 			});
-			jQuery('.cancel-post-status, .save-post-status').click(function() {
+			jQuery('.cancel-post-status, .save-post-status').on( 'click', function() {
 				jQuery('#post-status-select').slideUp();
 				jQuery('.edit-post-status').show();
 				return false;
 			});
-			jQuery('.save-post-status').click(function() {
+			jQuery('.save-post-status').on( 'click', function() {
 				jQuery('#post-status-display').text(jQuery('select[name="post_status"] :selected').text());
 				return false;
 			});
@@ -52,7 +52,7 @@ jQuery(document).ready(function() {
 		ef_update_save_button(i18n.save);
 		
 		// Bind event when OK button is clicked
-		jQuery('.save-post-status').bind('click', function() {	
+		jQuery('.save-post-status').on( 'click', function() {
 			ef_update_save_button();
 		});
 		
@@ -82,12 +82,12 @@ jQuery(document).ready(function() {
 	} else if ( jQuery('select[name="_status"]').length > 0 ) {
 		ef_append_to_dropdown('select[name="_status"]');
 		// Refresh the custom status dropdowns everytime Quick Edit is loaded
-		jQuery('#the-list a.editinline').bind( 'click', function() {
+		jQuery('#the-list a.editinline').on( 'click', function() {
 			ef_append_to_dropdown('#the-list select[name="_status"]');
 		} );
 		// Clean up the bulk edit selector because it's non-standard
 		jQuery( '#bulk-edit' ).find( 'select[name="_status"]' ).prepend( '<option value="">' + i18n.no_change + '</option>' );
-		jQuery( '#bulk-edit' ).find( 'select[name="_status"] option' ).removeAttr('selected');
+		jQuery( '#bulk-edit' ).find( 'select[name="_status"] option' ).prop( 'selected', false );
 		jQuery( '#bulk-edit' ).find( 'select[name="_status"] option[value="future"]').remove();
 	} else {
 

--- a/modules/editorial-comments/lib/editorial-comments.js
+++ b/modules/editorial-comments/lib/editorial-comments.js
@@ -19,8 +19,8 @@ editorialCommentReply = {
 		var row = jQuery('#ef-replyrow');
 		
 		// Bind click events to cancel and submit buttons
-		jQuery('a.ef-replycancel', row).click(function() { return editorialCommentReply.revert(); });
-		jQuery('a.ef-replysave', row).click(function() { return editorialCommentReply.send(); });
+		jQuery('a.ef-replycancel', row).on( 'click', function() { return editorialCommentReply.revert(); });
+		jQuery('a.ef-replysave', row).on( 'click', function() { return editorialCommentReply.send(); });
 
 		// Watch for changes to the subscribed users.
 		jQuery( '#ef-post_following_box' ).on( 'following_list_updated', function() {

--- a/modules/editorial-metadata/lib/editorial-metadata-configure.js
+++ b/modules/editorial-metadata/lib/editorial-metadata-configure.js
@@ -13,13 +13,13 @@ inlineEditMetadataTerm = {
 		});
 
 		// prepare the edit row
-		row.keyup(function(e) { if(e.which == 27) return inlineEditMetadataTerm.revert(); });
+		row.on( 'keyup', function(e) { if(e.which == 27) return inlineEditMetadataTerm.revert(); });
 
-		$('a.cancel', row).click(function() { return inlineEditMetadataTerm.revert(); });
-		$('a.save', row).click(function() { return inlineEditMetadataTerm.save(this); });
-		$('input, select', row).keydown(function(e) { if(e.which == 13) return inlineEditMetadataTerm.save(this); });
+		$('a.cancel', row).on( 'click', function() { return inlineEditMetadataTerm.revert(); });
+		$('a.save', row).on( 'click', function() { return inlineEditMetadataTerm.save(this); });
+		$('input, select', row).on( 'keydown', function(e) { if(e.which == 13) return inlineEditMetadataTerm.save(this); });
 
-		$('#posts-filter input[type="submit"]').mousedown(function(e){
+		$('#posts-filter input[type="submit"]').on( 'mousedown', function(e){
 			t.revert();
 		});
 	},
@@ -116,8 +116,8 @@ $(document).ready(function(){inlineEditMetadataTerm.init();});
 })(jQuery);
 
 jQuery(document).ready(function(){
-	
-	jQuery('.delete-status a').click(function(){
+
+	jQuery('.delete-status a').on( 'click', function(){
 		if ( !confirm( ef_confirm_delete_term_string ) )
 			return false;
 	});

--- a/modules/editorial-metadata/lib/editorial-metadata-configure.js
+++ b/modules/editorial-metadata/lib/editorial-metadata-configure.js
@@ -7,7 +7,7 @@ inlineEditMetadataTerm = {
 
 		t.what = '#term-';
 
-		$('.editinline').live('click', function(){
+		$( document ).on( 'click', '.editinline', function(){
 			inlineEditMetadataTerm.edit(this);
 			return false;
 		});

--- a/modules/settings/lib/settings.js
+++ b/modules/settings/lib/settings.js
@@ -19,7 +19,7 @@ jQuery(document).ready(function(){
 		setTimeout( edit_flow_hide_message, 8000 );
 	}
 
-	jQuery('.enable-disable-edit-flow-module').click(function(){
+	jQuery('.enable-disable-edit-flow-module').on( 'click', function(){
 		if ( jQuery(this).hasClass('button-primary') )
 			var module_action = 'enable';
 		else if ( jQuery(this).hasClass('button-remove') )

--- a/modules/story-budget/lib/story-budget.js
+++ b/modules/story-budget/lib/story-budget.js
@@ -2,25 +2,25 @@
 
 jQuery(document).ready(function($) {
 	// Hide all post details when directed
-	$("#toggle_details").click(function() {
-		$(".post-title > p").toggle('hidden'); 
+	$("#toggle_details").on( 'click', function() {
+		$(".post-title > p").toggle('hidden');
 	});
 	
 	// Make print link open up print dialog
-	$("#print_link").click(function() {
+	$("#print_link").on( 'click', function() {
 		window.print();
 		return false;
 	});
 	
 	// Hide a single section when directed
-	$("h3.hndle,div.handlediv").click(function() {
+	$("h3.hndle,div.handlediv").on( 'click', function() {
 		$(this).parent().children("div.inside").toggle();
 	});
 
 	// Change number of columns when choosing a new number from Screen Options
 
 	var columnsSwitch = $("input[name=ef_story_budget_screen_columns]");
-	columnsSwitch.click(function() {
+	columnsSwitch.on( 'click', function() {
 		var numColumns = parseInt($(this).val());
 		var classPrefix = 'columns-number-';
 		$(".postbox-container").removeClass(function() {
@@ -31,16 +31,16 @@ jQuery(document).ready(function($) {
 		}).addClass(classPrefix + numColumns);
 	});
 
-	
-	$('h2 a.change-date').click(function(){
+
+	$('h2 a.change-date').on( 'click', function(){
 		$(this).hide();
 		$('h2 form .form-value').hide();
 		$('h2 form input').show();
 		$('h2 form a.change-date-cancel').show();
 		return false;
 	});
-	
-	$('h2 form a.change-date-cancel').click(function(){
+
+	$('h2 form a.change-date-cancel').on( 'click', function(){
 		$(this).hide();
 		$('h2 form .form-value').show();
 		$('h2 form input').hide();

--- a/modules/user-groups/lib/user-groups-configure.js
+++ b/modules/user-groups/lib/user-groups-configure.js
@@ -6,19 +6,19 @@ inlineEditUsergroup = {
 
 		t.what = '#usergroup-';
 
-		$('.editinline').live('click', function(){
+		$('.editinline').on( 'click', function(){
 			inlineEditUsergroup.edit(this);
 			return false;
 		});
 
 		// prepare the edit row
-		row.keyup(function(e) { if(e.which == 27) return inlineEditUsergroup.revert(); });
+		row.on( 'keyup', function(e) { if(e.which == 27) return inlineEditUsergroup.revert(); });
 
-		$('a.cancel', row).click(function() { return inlineEditUsergroup.revert(); });
-		$('a.save', row).click(function() { return inlineEditUsergroup.save(this); });
-		$('input, select', row).keydown(function(e) { if(e.which == 13) return inlineEditUsergroup.save(this); });
+		$('a.cancel', row).on( 'click', function() { return inlineEditUsergroup.revert(); });
+		$('a.save', row).on( 'click', function() { return inlineEditUsergroup.save(this); });
+		$('input, select', row).on( 'keydown', function(e) { if(e.which == 13) return inlineEditUsergroup.save(this); });
 
-		$('#posts-filter input[type="submit"]').mousedown(function(e){
+		$('#posts-filter input[type="submit"]').on( 'mousedown', function(e){
 			t.revert();
 		});
 	},

--- a/modules/user-groups/lib/user-groups-configure.js
+++ b/modules/user-groups/lib/user-groups-configure.js
@@ -6,7 +6,7 @@ inlineEditUsergroup = {
 
 		t.what = '#usergroup-';
 
-		$('.editinline').on( 'click', function(){
+		$( document ).on( 'click', '.editinline', function(){
 			inlineEditUsergroup.edit(this);
 			return false;
 		});


### PR DESCRIPTION
Fix #632 

---

## Description

This PR has done these changes to fix all warnings: 

| Old      | New | Ref | 
| ----------- | ----------- | ----------- |
| jQuery.expr[':']      | jQuery.expr.pseudos       |
| .click(fn)   | .on("click", fn)       | [Reference](https://github.com/jquery/jquery-migrate/blob/main/warnings.md#jqmigrate-jqueryfnclick-event-shorthand-is-deprecated)
| .click()   | .trigger("click")      | [Reference](https://github.com/jquery/jquery-migrate/blob/main/warnings.md#jqmigrate-jqueryfnclick-event-shorthand-is-deprecated)
| .hover(fn1, fn2)   | .on("mouseenter", fn1).on("mouseleave", fn2)  | [Reference](https://github.com/jquery/jquery-migrate/blob/main/warnings.md#jqmigrate-jqueryfnhover-is-deprecated) | 
| removeAttr('selected'); | prop( 'selected', false ); | [Reference](https://jquery.com/upgrade-guide/3.0/#breaking-change-removeattr-no-longer-sets-properties-to-false) |
| .attr('selected'); | .prop( 'selected', true ); | [Reference](https://api.jquery.com/prop/#prop-propertyName-value) |
| .bind   | .on      | [Reference](https://jquery.com/upgrade-guide/3.0/#deprecated-bind-and-delegate) |
| $('.myButton').live('click', function) | $( document ).on('click', '.myButton', function) | [Reference](https://stackoverflow.com/a/14354091) | 

The following events are changed similarly to `click` above: `blur, focus, focusin, focusout, resize, scroll, dblclick, mousedown, mouseup, mousemove, mouseover, mouseout, mouseenter, mouseleave, change, select, submit, keydown, keypress, keyup, and contextmenu.` - [ref](https://github.com/jquery/jquery-migrate/blob/main/warnings.md#jqmigrate-jqueryfnclick-event-shorthand-is-deprecated)

## Steps to Test

- Do not apply this PR yet. 
- Install https://wordpress.org/plugins/enable-jquery-migrate-helper/ and activate it.
- Visit http://site.test/wp-admin/tools.php?page=jqmh and set it up like the following: 

![Markup on 2021-06-03 at 13:58:07](https://user-images.githubusercontent.com/10045087/120601134-c4fb0380-c473-11eb-8226-2e4f175a68c1.png)

- Visit the following pages to see the issue: 

1. http://site.test/wp-admin/index.php?page=calendar
2. http://site.test/wp-admin/index.php?page=story-budget
3. All pages under `Edit Flow` menu in wp-admin http://site.test/wp-admin/admin.php?page=ef-settings
4. Page listing all posts http://site.test/wp-admin/edit.php
5. Block and Classic editor pages for a post 

- **Apply this PR.**
- Open tab `Console` in your browser.
- Vist all pages above
- **Expect that there is no more warning regarding Edit Flow in wp-admin, and no errors in `Console` tab.** 

## Note 

You may apply this diff so that we can avoid the cache busting issue in browsers.  

```diff
Index: edit_flow.php
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
--- edit_flow.php	(revision 883e80484e860bbd12aced41c4d4eca733344027)
+++ edit_flow.php	(date 1621319608357)
@@ -46,7 +46,7 @@
 }
 
 // Define contants
-define( 'EDIT_FLOW_VERSION' , '0.9.6' );
+define( 'EDIT_FLOW_VERSION' , '0.9.7-dev-' . time() );
 define( 'EDIT_FLOW_ROOT' , dirname(__FILE__) );
 define( 'EDIT_FLOW_FILE_PATH' , EDIT_FLOW_ROOT . '/' . basename(__FILE__) );
 define( 'EDIT_FLOW_URL' , plugins_url( '/', __FILE__ ) );
``` 