### PR TITLE
Fix: Give each attribute in Edit Flow settings page a different id

### DIFF
--- a/modules/settings/lib/settings.js
+++ b/modules/settings/lib/settings.js
@@ -26,7 +26,7 @@ jQuery(document).ready(function(){
 			var module_action = 'disable';
 		
 		var slug = jQuery(this).closest('.edit-flow-module').attr('id');
-		var change_module_nonce = jQuery('#' + slug + ' #change-module-nonce').val();
+		var change_module_nonce = jQuery('#' + slug + ' #change-module-nonce-' + slug).val();
 		var data = {
 			action: 'change_edit_flow_module_state',
 			module_action: module_action,

--- a/modules/settings/settings.php
+++ b/modules/settings/settings.php
@@ -269,7 +269,7 @@ class EF_Settings extends EF_Module {
 				if ( $mod_data->options->enabled == 'off' ) echo ' style="display:none;"';				
 				echo ' value="' . __( 'Disable', 'edit-flow' ) . '" />';
 				echo '</p>';
-				wp_nonce_field( 'change-edit-flow-module-nonce', 'change-module-nonce', false );
+				wp_nonce_field( 'change-edit-flow-module-nonce', 'change-module-nonce-' . $mod_data->slug, false );
 				echo '</form>';
 				echo '</div>';
 			}


### PR DESCRIPTION
Fix #631 

---

## Description

This PR is pretty simple. It's simply to use `slug` of each module and append it to the current name/id. 

## Steps to Test

1. Apply this PR.
2. Visit wp-admin/admin.php?page=ef-settings
3. No longer see `Found 8 elements with non-unique id #change-module-nonce` error in your browser console.
4. See this page's HTML source, search `change-module-nonce`, there will be 8 results with a different suffix. 