### PR TITLE
Update the way selecting a future date for schedulePost 

### DIFF
--- a/tests/e2e/utils/index.js
+++ b/tests/e2e/utils/index.js
@@ -59,24 +59,32 @@ const schedulePost = async() => {
     // wait for popout animation
     await page.waitFor(200);
 
-    // Get the date after four weeks since today
-    const today = new Date();
-    const futureDate = new Date();
-    futureDate.setDate( today.getDate() + 14 );
-    const [month, day, year] = futureDate.toLocaleDateString("en-US").split("/")
+	// Get the date after four weeks since today
+	const today = new Date();
+	const futureDate = new Date();
+	futureDate.setDate( today.getDate() + 14 );
+	const [ month, day, year ] = futureDate
+		.toLocaleDateString( 'en-US' )
+		.split( '/' );
 
-    // Set the future date in the post editing screen
-    await page.$eval('.components-datetime__time-field-day-input', (el, day) => {
-        return el.value = day;
-    }, day );
+	// Set the future date in the post editing screen
+	await page.$eval(
+		'.components-datetime__time-field-day-input',
+		( el, day ) => el.value = day,
+		day
+	);
 
-    await page.$eval('.components-datetime__time-field-month-select', (el, month) => {
-        return el.value = month.length === 1 ? '0' + month : month;
-    }, month);
+	await page.$eval(
+		'.components-datetime__time-field-month-select',
+		( el, month ) => el.value = month.length === 1 ? '0' + month : month,
+		month
+	);
 
-    await page.$eval('.components-datetime__time-field-year-input', (el, year) => {
-        return el.value = year;
-    }, year );
+	await page.$eval(
+		'.components-datetime__time-field-year-input',
+		( el, year ) => el.value = year,
+		year
+	);
 
     await publishPost();
 

--- a/tests/e2e/utils/index.js
+++ b/tests/e2e/utils/index.js
@@ -59,7 +59,7 @@ const schedulePost = async() => {
     // wait for popout animation
     await page.waitFor(200);
 
-    // Get the date after four weeks since today
+    // Get the date after two weeks since today
     const today = new Date();
     const futureDate = new Date();
     futureDate.setDate( today.getDate() + 14 );

--- a/tests/e2e/utils/index.js
+++ b/tests/e2e/utils/index.js
@@ -59,9 +59,24 @@ const schedulePost = async() => {
     // wait for popout animation
     await page.waitFor(200);
 
-    await page.click( 'div[aria-label="Move forward to switch to the next month."]' );
+    // Get the date after four weeks since today
+    const today = new Date();
+    const futureDate = new Date();
+    futureDate.setDate( today.getDate() + 14 );
+    const [month, day, year] = futureDate.toLocaleDateString("en-US").split("/")
 
-    await page.click( '.CalendarDay_1' );
+    // Set the future date in the post editing screen
+    await page.$eval('.components-datetime__time-field-day-input', (el, day) => {
+        return el.value = day;
+    }, day );
+
+    await page.$eval('.components-datetime__time-field-month-select', (el, month) => {
+        return el.value = month.length === 1 ? '0' + month : month;
+    }, month);
+
+    await page.$eval('.components-datetime__time-field-year-input', (el, year) => {
+        return el.value = year;
+    }, year );
 
     await publishPost();
 

--- a/tests/e2e/utils/index.js
+++ b/tests/e2e/utils/index.js
@@ -59,32 +59,32 @@ const schedulePost = async() => {
     // wait for popout animation
     await page.waitFor(200);
 
-	// Get the date after four weeks since today
-	const today = new Date();
-	const futureDate = new Date();
-	futureDate.setDate( today.getDate() + 14 );
-	const [ month, day, year ] = futureDate
-		.toLocaleDateString( 'en-US' )
-		.split( '/' );
+    // Get the date after four weeks since today
+    const today = new Date();
+    const futureDate = new Date();
+    futureDate.setDate( today.getDate() + 14 );
+    const [ month, day, year ] = futureDate
+        .toLocaleDateString( 'en-US' )
+        .split( '/' );
 
-	// Set the future date in the post editing screen
-	await page.$eval(
-		'.components-datetime__time-field-day-input',
-		( el, day ) => el.value = day,
-		day
-	);
+    // Set the future date in the post editing screen
+    await page.$eval(
+        '.components-datetime__time-field-day-input',
+        ( el, day ) => el.value = day,
+        day
+    );
 
-	await page.$eval(
-		'.components-datetime__time-field-month-select',
-		( el, month ) => el.value = month.length === 1 ? '0' + month : month,
-		month
-	);
+    await page.$eval(
+        '.components-datetime__time-field-month-select',
+        ( el, month ) => el.value = month.length === 1 ? '0' + month : month,
+        month
+    );
 
-	await page.$eval(
-		'.components-datetime__time-field-year-input',
-		( el, year ) => el.value = year,
-		year
-	);
+    await page.$eval(
+        '.components-datetime__time-field-year-input',
+        ( el, year ) => el.value = year,
+        year
+    );
 
     await publishPost();
 


### PR DESCRIPTION
Fix #652 

## Description

The root cause is described here https://github.com/Automattic/Edit-Flow/issues/652#issuecomment-857577431

To fix this issue, I am changing the way selecting a future date for schedulePost: 

- Calculate the date in 2 weeks since today. 
- Use DOM selector and update the respective values for day, month, year. 

### Some notes: 

- I researched how Gutenberg approaches this issue and at the moment, there is no support for creating schedule posts in package `e2e-test-utils`. I pulled Gutenberg and searched on this specific folder `packages/e2e-test-utils/src`, which hosts this package.
- Instead, here is how a similar issue (updating date and time of a post) is handled in Gutenberg. That's basically the same method I am using here https://github.com/WordPress/gutenberg/pull/27558/files#diff-3836a6db831ccfe3af87b4c80a7fa67c44eb8d4239cff2dbfe3025924cd4e991R78-R79
 - We can not set a date too far in the future as it will not display when viewing wp-admin/index.php?page=calendar by default. 

## Steps to Test

- Check out this PR.
- Run E2E tests and verify the issue in #652 is no longer.

If possible, we can use the diff in this comment https://github.com/Automattic/Edit-Flow/issues/652#issuecomment-857577431 to generate new screenshots with this fix.

With this fix, the date of the post is expected now: 

- [schedulePost_before-choosing-date](https://user-images.githubusercontent.com/10045087/121340563-f8450300-c949-11eb-8983-14c31b5886fd.png): date is today - June 09. 
- [schedulePost_after-choosing-date](https://user-images.githubusercontent.com/10045087/121340567-f9763000-c949-11eb-837b-a230b4a7cd87.png): date is the date after 14 days: June 23. 
- [calendar_before-drag-drop](https://user-images.githubusercontent.com/10045087/121340571-fa0ec680-c949-11eb-8095-869f47c7cdbd.png): date is show the expected scheduled post date: June 23 
- [calendar_after-drag-drop](https://user-images.githubusercontent.com/10045087/121340573-faa75d00-c949-11eb-9890-3175e94ceef6.png): after the drag and drop, it is moved up to June 16. 
