### PR TITLE
Fix undefined hook_suffix

### DIFF
--- a/modules/custom-status/custom-status.php
+++ b/modules/custom-status/custom-status.php
@@ -1730,7 +1730,7 @@ class EF_Custom_Status_List_Table extends WP_List_Table
 			'plural' => 'custom statuses',
 			'singular' => 'custom status',
 			'ajax' => true,
-            'screen' => 'ef-custom-status-settings'
+            'screen' => 'ef-custom-status-settings',
 		) );
 
 	}

--- a/modules/custom-status/custom-status.php
+++ b/modules/custom-status/custom-status.php
@@ -1730,7 +1730,7 @@ class EF_Custom_Status_List_Table extends WP_List_Table
 			'plural' => 'custom statuses',
 			'singular' => 'custom status',
 			'ajax' => true,
-            'screen' => 'ef-custom-status-settings',
+			'screen' => 'ef-custom-status-settings',
 		) );
 
 	}

--- a/modules/custom-status/custom-status.php
+++ b/modules/custom-status/custom-status.php
@@ -1729,7 +1729,8 @@ class EF_Custom_Status_List_Table extends WP_List_Table
 		parent::__construct( array(
 			'plural' => 'custom statuses',
 			'singular' => 'custom status',
-			'ajax' => true
+			'ajax' => true,
+            'screen' => 'ef-custom-status-settings'
 		) );
 
 	}

--- a/modules/editorial-metadata/editorial-metadata.php
+++ b/modules/editorial-metadata/editorial-metadata.php
@@ -1600,7 +1600,7 @@ class EF_Editorial_Metadata_List_Table extends WP_List_Table {
 		parent::__construct( array(
 			'plural' => 'editorial metadata',
 			'singular' => 'editorial metadata',
-			'screen'   =>   'ef-editorial-metadata-settings'
+			'screen' => 'ef-editorial-metadata-settings'
 		) );
 	}
 

--- a/modules/editorial-metadata/editorial-metadata.php
+++ b/modules/editorial-metadata/editorial-metadata.php
@@ -1600,6 +1600,7 @@ class EF_Editorial_Metadata_List_Table extends WP_List_Table {
 		parent::__construct( array(
 			'plural' => 'editorial metadata',
 			'singular' => 'editorial metadata',
+			'screen'   =>   'ef-editorial-metadata-settings'
 		) );
 	}
 

--- a/modules/editorial-metadata/editorial-metadata.php
+++ b/modules/editorial-metadata/editorial-metadata.php
@@ -1600,7 +1600,7 @@ class EF_Editorial_Metadata_List_Table extends WP_List_Table {
 		parent::__construct( array(
 			'plural' => 'editorial metadata',
 			'singular' => 'editorial metadata',
-			'screen' => 'ef-editorial-metadata-settings'
+			'screen' => 'ef-editorial-metadata-settings',
 		) );
 	}
 

--- a/modules/user-groups/user-groups.php
+++ b/modules/user-groups/user-groups.php
@@ -1100,7 +1100,7 @@ class EF_Usergroups_List_Table extends WP_List_Table
 			'plural' => 'user groups',
 			'singular' => 'user group',
 			'ajax' => true,
-			'screen' => 'ef-user-groups-settings'
+			'screen' => 'ef-user-groups-settings',
 		) );
 		
 	}

--- a/modules/user-groups/user-groups.php
+++ b/modules/user-groups/user-groups.php
@@ -1099,7 +1099,8 @@ class EF_Usergroups_List_Table extends WP_List_Table
 		parent::__construct( array(
 			'plural' => 'user groups',
 			'singular' => 'user group',
-			'ajax' => true
+			'ajax' => true,
+			'screen' => 'ef-user-groups-settings'
 		) );
 		
 	}


### PR DESCRIPTION
## Description

Fixes https://github.com/Automattic/Edit-Flow/issues/654

Without a specified `screen` when extending `WP_List_Table` - the function `convert_to_screen` will return a PHP Warning due to an undefined hook suffix which is needed to identify the current screen

## Steps to Test

1. Go to Edit Flow -> User Groups
2. Click Quick Edit
3. Make a change
4. Click "Update User Group"
5. You should see a PHP Warning like this:  `[07-Jun-2021 17:34:31 UTC] PHP Warning:  Undefined array key "hook_suffix" in /wp-admin/includes/class-wp-screen.php on line 223`

Apply this PR and then do the steps again and you won't see the PHP Warning any longer.