### PR TITLE
Fixes non-variable being passed by reference

### DIFF
--- a/common/php/screen-options.php
+++ b/common/php/screen-options.php
@@ -166,7 +166,8 @@ class wsScreenOptions10 {
 		}
 		
 		//The 'action' argument is in the form "save_settings-panel_id"
-		$id = end(explode('-', $_POST['action'], 2));
+		$ids = explode( '-', $_POST['action'], 2 );
+		$id = end( $ids );
 		
 		//Basic security check.
 		check_ajax_referer('save_settings-' . $id, '_wpnonce-' . $id);


### PR DESCRIPTION
## Description

Fixes https://github.com/Automattic/Edit-Flow/issues/656

Currently there's a PHP Notice happening when you save screen option changes:
`[07-Jun-2021 18:36:16 UTC] PHP Notice:  Only variables should be passed by reference in wp-content/plugins/Edit-Flow/common/php/screen-options.php on line 169`

## Steps to Test

1. Go to `wp-admin/index.php?page=story-budget`
2. Click on Screen Options at the top
3. Change the number of columns
4. Refresh the page to make sure the setting was saved
