### PR TITLE
Remove redundant jQuery selector #the-list a.editinline

### DIFF
--- a/modules/custom-status/lib/custom-status.js
+++ b/modules/custom-status/lib/custom-status.js
@@ -81,10 +81,6 @@ jQuery(document).ready(function() {
 
 	} else if ( jQuery('select[name="_status"]').length > 0 ) {
 		ef_append_to_dropdown('select[name="_status"]');
-		// Refresh the custom status dropdowns everytime Quick Edit is loaded
-		jQuery('#the-list a.editinline').on( 'click', function() {
-			ef_append_to_dropdown('#the-list select[name="_status"]');
-		} );
 		// Clean up the bulk edit selector because it's non-standard
 		jQuery( '#bulk-edit' ).find( 'select[name="_status"]' ).prepend( '<option value="">' + i18n.no_change + '</option>' );
 		jQuery( '#bulk-edit' ).find( 'select[name="_status"] option' ).prop( 'selected', false );


### PR DESCRIPTION
Fix https://github.com/Automattic/Edit-Flow/issues/662

---

## Description

This is pretty straightforward as all research has been done in https://github.com/Automattic/Edit-Flow/issues/662

## Steps to Test

1. Apply this PR.
2. Apply the diff in the **Note** section for `edit_flow.php` to avoid caching issue for JS files https://github.com/Automattic/Edit-Flow/pull/649
3. Visit wp-admin > Posts

✅ if we can use `Quick Edit` and change custom status without any issue. 

