### PR TITLE
Remove redundant jQuery selector #toggle_details

### DIFF
--- a/modules/story-budget/lib/story-budget.js
+++ b/modules/story-budget/lib/story-budget.js
@@ -1,17 +1,12 @@
 // Story Budget specific JS, assumes that ef_date.js has already been included
 
 jQuery(document).ready(function($) {
-	// Hide all post details when directed
-	$("#toggle_details").on( 'click', function() {
-		$(".post-title > p").toggle('hidden');
-	});
-	
 	// Make print link open up print dialog
 	$("#print_link").on( 'click', function() {
 		window.print();
 		return false;
 	});
-	
+
 	// Hide a single section when directed
 	$("h3.hndle,div.handlediv").on( 'click', function() {
 		$(this).parent().children("div.inside").toggle();


### PR DESCRIPTION
Fix https://github.com/Automattic/Edit-Flow/issues/663

---

## Description

All research has been done in https://github.com/Automattic/Edit-Flow/issues/663

## Steps to Test

1. Apply this PR.
2. Apply the diff in the **Note** section for `edit_flow.php` to avoid caching issue for JS files https://github.com/Automattic/Edit-Flow/pull/649
3. Visit wp-admin > Dashboard > Story Budget. 

✅ if we can change `Screen Options`, click actions for posts, etc without any issue. 