### PR TITLE
Remove redundant jQuery selector `#posts-filter input[type="submit"]`

### DIFF
--- a/modules/custom-status/lib/custom-status-configure.js
+++ b/modules/custom-status/lib/custom-status-configure.js
@@ -18,10 +18,6 @@ inlineEditCustomStatus = {
 		$('a.cancel', row).on( 'click', function() { return inlineEditCustomStatus.revert(); });
 		$('a.save', row).on( 'click', function() { return inlineEditCustomStatus.save(this); });
 		$('input, select', row).on( 'keydown', function(e) { if(e.which == 13) return inlineEditCustomStatus.save(this); });
-
-		$('#posts-filter input[type="submit"]').on( 'mousedown', function(e){
-			t.revert();
-		});
 	},
 
 	toggle : function(el) {

--- a/modules/editorial-metadata/editorial-metadata.php
+++ b/modules/editorial-metadata/editorial-metadata.php
@@ -1395,7 +1395,7 @@ class EF_Editorial_Metadata extends EF_Module {
 		<?php if ( !isset( $_GET['action'] ) || ( isset( $_GET['action'] ) && $_GET['action'] != 'edit-term' ) ): ?>
 		<div id="col-right">
 		<div class="col-wrap">
-		<form id="posts-filter" action="" method="post">
+		<form action="" method="post">
 			<?php $wp_list_table->display(); ?>
 			<?php wp_nonce_field( 'editorial-metadata-sortable', 'editorial-metadata-sortable' ); ?>
 		</form>

--- a/modules/editorial-metadata/lib/editorial-metadata-configure.js
+++ b/modules/editorial-metadata/lib/editorial-metadata-configure.js
@@ -18,10 +18,6 @@ inlineEditMetadataTerm = {
 		$('a.cancel', row).on( 'click', function() { return inlineEditMetadataTerm.revert(); });
 		$('a.save', row).on( 'click', function() { return inlineEditMetadataTerm.save(this); });
 		$('input, select', row).on( 'keydown', function(e) { if(e.which == 13) return inlineEditMetadataTerm.save(this); });
-
-		$('#posts-filter input[type="submit"]').on( 'mousedown', function(e){
-			t.revert();
-		});
 	},
 
 	toggle : function(el) {

--- a/modules/user-groups/lib/user-groups-configure.js
+++ b/modules/user-groups/lib/user-groups-configure.js
@@ -17,10 +17,6 @@ inlineEditUsergroup = {
 		$('a.cancel', row).on( 'click', function() { return inlineEditUsergroup.revert(); });
 		$('a.save', row).on( 'click', function() { return inlineEditUsergroup.save(this); });
 		$('input, select', row).on( 'keydown', function(e) { if(e.which == 13) return inlineEditUsergroup.save(this); });
-
-		$('#posts-filter input[type="submit"]').on( 'mousedown', function(e){
-			t.revert();
-		});
 	},
 
 	toggle : function(el) {


### PR DESCRIPTION
Fix #664 

## Description

See the research on #664 

## Steps to Test

- Apply this PR.
- Apply the diff in the `Note` section in this PR https://github.com/Automattic/Edit-Flow/pull/649
- Open the browser console and watch for errors. 
- Visit wp-admin > Edit Flow.
- Then visit three setting pages: Editorial Metadata, User Groups, Custom Statuses

✅ if we can change, update, and use "Quick Update" for items in these setting pages without any error. 