### PR TITLE
Fix WP 5.9 deprecation notice with `who` in WP_User_Query

### DIFF
--- a/common/php/class-module.php
+++ b/common/php/class-module.php
@@ -461,7 +461,7 @@ class EF_Module {
 		extract($parsed_args, EXTR_SKIP);
 
 		$args = array(
-			'who' => 'authors',
+			'capability' => 'publish_posts',
 			'fields' => array(
 				'ID',
 				'display_name',
@@ -478,7 +478,7 @@ class EF_Module {
 
 		<?php if( !empty($users) ) : ?>
 			<ul class="<?php echo esc_attr( $list_class ) ?>">
-				<?php foreach( $users as $user ) : 
+				<?php foreach( $users as $user ) :
 					$checked = ( in_array($user->ID, $selected) ) ? 'checked="checked"' : '';
 					// Add a class to checkbox of current user so we know not to add them in notified list during notifiedMessage() js function
 					$current_user_class = ( get_current_user_id() == $user->ID ) ? 'class="post_following_list-current_user" ' : '';


### PR DESCRIPTION
## Description

Fixes deprecation notice `Deprecated: WP_User_Query was called with an argument that is deprecated since version 5.9.0! who is deprecated. Use capability instead.`

Uses `publish_posts` cap since that's the one granted to authors and above.

## Steps to Test

Go to wp-admin > Posts > Add New Post and see if it triggers in PHP logs/QM