### PR TITLE
Add the ability to expire content on a date

### DIFF
--- a/edit_flow.php
+++ b/edit_flow.php
@@ -46,7 +46,7 @@ if ( version_compare( phpversion(), '5.6', '<' ) ) {
 }
 
 // Define contants
-define( 'EDIT_FLOW_VERSION' , '0.9.8' );
+define( 'EDIT_FLOW_VERSION' , '0.9.9' );
 define( 'EDIT_FLOW_ROOT' , dirname(__FILE__) );
 define( 'EDIT_FLOW_FILE_PATH' , EDIT_FLOW_ROOT . '/' . basename(__FILE__) );
 define( 'EDIT_FLOW_URL' , plugins_url( '/', __FILE__ ) );

--- a/modules/custom-status/custom-status.php
+++ b/modules/custom-status/custom-status.php
@@ -166,7 +166,7 @@ class EF_Custom_Status extends EF_Module {
 				'term' => __( 'Expired', 'edit-flow' ),
 				'args' => array(
 					'slug' => 'expired',
-					'description' => __( 'Post has expired, and it has to bew updated an editor.', 'edit-flow' ),
+					'description' => __( 'Post has expired and requires updates .', 'edit-flow' ),
 					'position' => 6,
 				),
 			),

--- a/modules/custom-status/custom-status.php
+++ b/modules/custom-status/custom-status.php
@@ -162,6 +162,14 @@ class EF_Custom_Status extends EF_Module {
 					'position' => 5,
 				),
 			),
+			array(
+				'term' => __( 'Expired', 'edit-flow' ),
+				'args' => array(
+					'slug' => 'expired',
+					'description' => __( 'Post has expired, and it has to bew updated an editor.', 'edit-flow' ),
+					'position' => 6,
+				),
+			),
 		);
 
 		// Okay, now add the default statuses to the db if they don't already exist
@@ -201,6 +209,20 @@ class EF_Custom_Status extends EF_Module {
 		if ( version_compare( $previous_version, '0.7.4', '<' ) ) {
 			// Custom status descriptions become base64_encoded, instead of maybe json_encoded.
 			$this->upgrade_074_term_descriptions( self::taxonomy_key );
+		}
+		// Upgrade path to v0.9.9
+		if ( version_compare( $previous_version, '0.9.9', '<' ) ) {
+			$expiry_custom_status = array(
+				'term' => __( 'Expired', 'edit-flow' ),
+				'args' => array(
+					'slug' => 'expired',
+					'description' => __( 'Post has expired, and it has to bew updated an editor.', 'edit-flow' ),
+					'position' => 6,
+				),
+			);
+
+			if( !term_exists( $expiry_custom_status['term'], self::taxonomy_key ) )
+				$this->add_custom_status( $expiry_custom_status['term'], $expiry_custom_status['args'] );
 		}
 
 	}

--- a/modules/editorial-metadata/editorial-metadata.php
+++ b/modules/editorial-metadata/editorial-metadata.php
@@ -152,6 +152,12 @@ class EF_Editorial_Metadata extends EF_Module {
 				'type' => 'number',
 				'description' => __( 'Required post length in words.', 'edit-flow' ),
 			),
+			array(
+				'name' => __( 'Expiry Date', 'edit-flow' ),
+				'slug' => 'content-expiry-date',
+				'type' => 'date',
+				'description' => __( 'When the content expires and needs to be updated.', 'edit-flow' ),
+			),
 		);
 		// Load the metadata fields if the slugs don't conflict
 		foreach ( $default_metadata as $args ) {
@@ -487,6 +493,8 @@ class EF_Editorial_Metadata extends EF_Module {
 			// Get the current editorial metadata
 			// TODO: do we care about the current_metadata at all?
 			//$current_metadata = get_post_meta( $id, $key, true );
+
+			// Bistro ToDo: Prevent the content-expiry-date from being edited if it's being saved already.
 			
 			$new_metadata = isset( $_POST[$key] ) ? $_POST[$key] : '';
 
@@ -525,6 +533,8 @@ class EF_Editorial_Metadata extends EF_Module {
 		// TODO: Core only correlates posts with terms if the post_status is publish. Do we care what it is?
 		if ( $post->post_status === 'publish' ) {
 			wp_set_object_terms( $id, $term_slugs, self::metadata_taxonomy );
+
+			// Bistro ToDo: Kick off a scheduled task in the future to change the status of the post to pending_review instead, using the content-expiry-date as the date to match against.
 		}
 	}
 	

--- a/modules/editorial-metadata/editorial-metadata.php
+++ b/modules/editorial-metadata/editorial-metadata.php
@@ -560,14 +560,20 @@ class EF_Editorial_Metadata extends EF_Module {
 	}
 
 	function unpublish_post_task( $post_id ) {
+		$post_status_to_set = 'pending';
+
+		if ( $this->module_enabled( 'custom-status' ) ) {
+			$post_status_to_set	= 'expired';
+		}
+
 		// Bistro ToDo: Cancel the scheduled task to change the status of the post to pending_review.
 		$success_value = wp_update_post( array(
             'ID'          => $post_id,
-            'post_status' => 'pending'
+            'post_status' => $post_status_to_set
         ), true );
 
 		if ( is_wp_error( $success_value ) ) {
-			error_log( 'Error updating post status to pending: ' . $success_value->get_error_message() );
+			error_log( 'Error updating post status to ' . $post_status_to_set . ': ' . $success_value->get_error_message() );
 		}
 	}
 	

--- a/modules/editorial-metadata/editorial-metadata.php
+++ b/modules/editorial-metadata/editorial-metadata.php
@@ -14,7 +14,7 @@
  * 6) Clear the metadata for a single term in a post and watch the count go down!
  * 6) Delete a term and note the metadata disappears from posts
  * 7) Re-add the term (same slug) and the metadata returns!
- *
+ * 
  * Improvements to make:
  * @todo Abstract the permissions check for management to class level
  */
@@ -27,16 +27,16 @@ class EF_Editorial_Metadata extends EF_Module {
 	 */
 	const metadata_taxonomy = 'ef_editorial_meta';
 	const metadata_postmeta_key = "_ef_editorial_meta";
-
+	
 	var $module_name = 'editorial_metadata';
 
 	private $editorial_metadata_terms_cache = array();
-
+	
 	/**
 	 * Construct the EF_Editorial_Metadata class
 	 */
 	function __construct() {
-
+		
 		$this->module_url = $this->get_module_url( __FILE__ );
 		// Register the module with Edit Flow
 		$args = array(
@@ -71,55 +71,55 @@ class EF_Editorial_Metadata extends EF_Module {
 		);
 		EditFlow()->register_module( $this->module_name, $args );
 	}
-
+	
 	/**
 	 * Initialize the module. Conditionally loads if the module is enabled
 	 */
 	function init() {
-
+		
 		// Register the taxonomy we use for Editorial Metadata with WordPress core
 		$this->register_taxonomy();
 
 		// Anything that needs to happen in the admin
 		add_action( 'admin_init', array( $this, 'action_admin_init' ) );
-
+		
 		// Register our settings
-		add_action( 'admin_init', array( $this, 'register_settings' ) );
-
+		add_action( 'admin_init', array( $this, 'register_settings' ) );		
+		
 		// Actions relevant to the configuration view (adding, editing, or sorting existing Editorial Metadata)
 		add_action( 'admin_init', array( $this, 'handle_add_editorial_metadata' ) );
 		add_action( 'admin_init', array( $this, 'handle_edit_editorial_metadata' ) );
-		add_action( 'admin_init', array( $this, 'handle_change_editorial_metadata_visibility' ) );
+		add_action( 'admin_init', array( $this, 'handle_change_editorial_metadata_visibility' ) );	
 		add_action( 'admin_init', array( $this, 'handle_delete_editorial_metadata' ) );
 		add_action( 'wp_ajax_inline_save_term', array( $this, 'handle_ajax_inline_save_term' ) );
 		add_action( 'wp_ajax_update_term_positions', array( $this, 'handle_ajax_update_term_positions' ) );
-
+		
 		add_action( 'add_meta_boxes', array( $this, 'handle_post_metaboxes' ) );
 		add_action( 'save_post', array( $this, 'save_meta_box' ), 10, 2 );
-
+		
 		// Add Editorial Metadata columns to the Manage Posts view
 		$supported_post_types = $this->get_post_types_for_module( $this->module );
 		foreach( $supported_post_types as $post_type ) {
 			add_filter( "manage_{$post_type}_posts_columns", array( $this, 'filter_manage_posts_columns' ) );
 			add_action( "manage_{$post_type}_posts_custom_column", array( $this, 'action_manage_posts_custom_column' ), 10, 2 );
 		}
-
+		
 		// Add Editorial Metadata to the calendar if the calendar is activated
 		if ( $this->module_enabled( 'calendar' ) )
 			add_filter( 'ef_calendar_item_information_fields', array( $this, 'filter_calendar_item_fields' ), 10, 2 );
-
+		
 		// Add Editorial Metadata columns to the Story Budget if it exists
 		if ( $this->module_enabled( 'story_budget' ) ) {
 			add_filter( 'ef_story_budget_term_columns', array( $this, 'filter_story_budget_term_columns' ) );
 			// Register an action to handle this data later
 			add_filter( 'ef_story_budget_term_column_value', array( $this, 'filter_story_budget_term_column_values' ), 10, 3 );
-		}
-
+		}		
+		
 		// Load necessary scripts and stylesheets
-		add_action( 'admin_enqueue_scripts', array( $this, 'add_admin_scripts' ) );
-
+		add_action( 'admin_enqueue_scripts', array( $this, 'add_admin_scripts' ) );	
+		
 	}
-
+	
 	/**
 	 * Load default editorial metadata the first time the module is loaded
 	 *
@@ -152,12 +152,6 @@ class EF_Editorial_Metadata extends EF_Module {
 				'type' => 'number',
 				'description' => __( 'Required post length in words.', 'edit-flow' ),
 			),
-			array(
-				'name' => __( 'Expiry Date', 'edit-flow' ),
-				'slug' => 'content-expiry-date',
-				'type' => 'date',
-				'description' => __( 'When the content expires and needs to be updated.', 'edit-flow' ),
-			),
 		);
 		// Load the metadata fields if the slugs don't conflict
 		foreach ( $default_metadata as $args ) {
@@ -185,7 +179,7 @@ class EF_Editorial_Metadata extends EF_Module {
 			// Editorial metadata descriptions become base64_encoded, instead of maybe json_encoded.
 			$this->upgrade_074_term_descriptions( self::metadata_taxonomy );
 		}
-
+		
 	}
 
 	/**
@@ -198,7 +192,7 @@ class EF_Editorial_Metadata extends EF_Module {
 		// Parse the query when we're ordering by an editorial metadata term
 		add_action( 'parse_query', array( $this, 'action_parse_query' ) );
 	}
-
+	
 	/**
 	 * Generate <select> HTML for all of the metadata types
 	 */
@@ -213,7 +207,7 @@ class EF_Editorial_Metadata extends EF_Module {
 		</select>
 	<?php
 	}
-
+	
 	/**
 	 * Prepare an array of supported editorial metadata types
 	 *
@@ -231,13 +225,13 @@ class EF_Editorial_Metadata extends EF_Module {
 		);
 		return $supported_metadata_types;
 	}
-
+	
 	/**
 	 * Enqueue relevant admin Javascript
-	 */
+	 */ 
 	function add_admin_scripts() {
 		global $current_screen, $pagenow;
-
+		
 		// Add the metabox date picker JS and CSS
 		$current_post_type = $this->get_current_post_type();
 		$supported_post_types = $this->get_post_types_for_module( $this->module );
@@ -252,7 +246,7 @@ class EF_Editorial_Metadata extends EF_Module {
 			$terms = $this->get_editorial_metadata_terms();
 			$viewable_terms = array();
 			foreach( $terms as $term ) {
-				if ( $term->viewable )
+				if ( $term->viewable ) 
 					$viewable_terms[] = $term;
 			}
 			if ( !empty( $viewable_terms ) ) {
@@ -301,16 +295,16 @@ class EF_Editorial_Metadata extends EF_Module {
 				}
 				echo '</style>';
 			}
-
+			
 		}
-
+		
 		// Load Javascript specific to the editorial metadata configuration view
 		if ( $this->is_whitelisted_settings_view( $this->module->name ) ) {
-			wp_enqueue_script( 'jquery-ui-sortable' );
+			wp_enqueue_script( 'jquery-ui-sortable' );			
 			wp_enqueue_script( 'edit-flow-editorial-metadata-configure', EDIT_FLOW_URL . 'modules/editorial-metadata/lib/editorial-metadata-configure.js', array( 'jquery', 'jquery-ui-sortable', 'edit-flow-settings-js' ), EDIT_FLOW_VERSION, true );
 		}
 	}
-
+	
 	/**
 	 * Register the post metadata taxonomy
 	 */
@@ -318,7 +312,7 @@ class EF_Editorial_Metadata extends EF_Module {
 
 		// We need to make sure taxonomy is registered for all of the post types that support it
 		$supported_post_types = $this->get_post_types_for_module( $this->module );
-
+	
 		register_taxonomy( self::metadata_taxonomy, $supported_post_types,
 			array(
 				'public' => false,
@@ -337,11 +331,11 @@ class EF_Editorial_Metadata extends EF_Module {
 			)
 		);
 	}
-
+	
 	/*****************************************************
 	 * Post meta box generation and processing
 	 ****************************************************/
-
+	
 	/**
 	 * Load the post metaboxes for all of the post types that are supported
 	 */
@@ -353,7 +347,7 @@ class EF_Editorial_Metadata extends EF_Module {
 			add_meta_box( self::metadata_taxonomy, $title, array( $this, 'display_meta_box' ), $post_type, 'side' );
 		}
 	}
-
+	
 	/**
 	 * Displays HTML output for Editorial Metadata post meta box
 	 *
@@ -369,13 +363,13 @@ class EF_Editorial_Metadata extends EF_Module {
 			$url = add_query_arg( 'page', 'ef-editorial-metadata-settings', get_admin_url( null, 'admin.php' ) );
 			echo '<p><a href="'. esc_url( $url ) . '">' . __( 'Configure', 'edit-flow' ) . '</a></p>';
 		}
-
+	
 		$terms = $this->get_editorial_metadata_terms();
 		if ( !count( $terms ) ) {
 			$message = __( 'No editorial metadata available.' );
 			if ( current_user_can( 'manage_options' ) )
 				$message .= sprintf( __( ' <a href="%s">Add fields to get started</a>.' ), $this->get_link() );
-			else
+			else 
 				$message .= __( ' Encourage your site administrator to configure your editorial workflow by adding editorial metadata.' );
 			echo '<p>' . $message . '</p>';
 		} else {
@@ -394,7 +388,7 @@ class EF_Editorial_Metadata extends EF_Module {
 						// TODO: Move this to a function
 						if ( !empty( $current_metadata ) ) {
 							// Turn timestamp into a human-readable date
-							$current_metadata = $this->show_date_or_datetime( intval( $current_metadata ) );
+							$current_metadata = $this->show_date_or_datetime( intval( $current_metadata ) );	
 						}
 						echo "<label for='$postmeta_key'>{$term->name}</label>";
 						if ( $description_span )
@@ -422,12 +416,12 @@ class EF_Editorial_Metadata extends EF_Module {
 						echo "<label for='$postmeta_key'>{$term->name}$description_span</label>";
 						echo "<input id='$postmeta_key' name='$postmeta_key' type='checkbox' value='1' " . checked($current_metadata, 1, false) . " />";
 						break;
-					case "user":
+					case "user": 
 						echo "<label for='$postmeta_key'>{$term->name}$description_span</label>";
-						$user_dropdown_args = array(
-								'show_option_all' => __( '-- Select a user --', 'edit-flow' ),
+						$user_dropdown_args = array( 
+								'show_option_all' => __( '-- Select a user --', 'edit-flow' ), 
 								'name'     => $postmeta_key,
-								'selected' => $current_metadata
+								'selected' => $current_metadata 
 							);
 						$user_dropdown_args = apply_filters( 'ef_editorial_metadata_user_dropdown_args', $user_dropdown_args );
 						wp_dropdown_users( $user_dropdown_args );
@@ -435,17 +429,17 @@ class EF_Editorial_Metadata extends EF_Module {
 					case "number":
 						echo "<label for='$postmeta_key'>{$term->name}$description_span</label>";
 						echo "<input id='$postmeta_key' name='$postmeta_key' type='text' value='$current_metadata' />";
-						break;
+						break;					
 					default:
 						echo "<p>" . __( 'This editorial metadata type is not yet supported.', 'edit-flow' ) . "</p>";
 				}
 			echo "</div>";
 			echo "<div class='clear'></div>";
 		} // Done iterating through metadata terms
-		}
+		}		
 		echo "</div>";
 	}
-
+	
 	/**
 	 * Show date or datetime
 	 * @param  int $current_date
@@ -462,7 +456,7 @@ class EF_Editorial_Metadata extends EF_Module {
 
 	/**
 	 * Save any values in the editorial metadata post meta box
-	 *
+	 * 
 	 * @param int $id Unique ID for the post being saved
 	 * @param object $post Post object
 	 */
@@ -474,28 +468,26 @@ class EF_Editorial_Metadata extends EF_Module {
 			|| ! wp_verify_nonce( $_POST[self::metadata_taxonomy . "_nonce"], 'ef-save-metabox' ) ) {
 			return $id;
 		}
-
+		
 		if( ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE )
 			|| ! in_array( $post->post_type, $this->get_post_types_for_module( $this->module ) )
 			|| $post->post_type == 'post' && !current_user_can( 'edit_post', $id )
 			|| $post->post_type == 'page' && !current_user_can( 'edit_page', $id ) ) {
 			return $id;
 		}
-
-		// Authentication passed, let's save the data
+		
+		// Authentication passed, let's save the data		
 		$terms = $this->get_editorial_metadata_terms();
 		$term_slugs = array();
-
+				
 		foreach ( $terms as $term ) {
 			// Setup the key for this editorial metadata term (same as what's in $_POST)
 			$key = $this->get_postmeta_key( $term );
-
+			
 			// Get the current editorial metadata
 			// TODO: do we care about the current_metadata at all?
 			//$current_metadata = get_post_meta( $id, $key, true );
-
-			// Bistro ToDo: Prevent the content-expiry-date from being edited if it's being saved already.
-
+			
 			$new_metadata = isset( $_POST[$key] ) ? $_POST[$key] : '';
 
 			$type = $term->type;
@@ -508,7 +500,7 @@ class EF_Editorial_Metadata extends EF_Module {
 					$date_to_parse =  isset( $_POST[ $key . '_hidden' ] ) ? $_POST[ $key . '_hidden' ] : '';
 					$date = DateTime::createFromFormat('Y-m-d H:i', $date_to_parse );
 
-					if ( false !== $date ) {
+					if ( false !== $date ) { 
 						$new_metadata = $date->getTimestamp();
 					} else {
 						// Fallback, in case $_POST[ $key . '_hidden' ] was not previosuly set
@@ -518,29 +510,27 @@ class EF_Editorial_Metadata extends EF_Module {
 				if ( 'number' === $type ) {
 					$new_metadata = (int)$new_metadata;
 				}
-
+				
 				$new_metadata = strip_tags( $new_metadata );
 				update_post_meta( $id, $key, $new_metadata );
-
+				
 				// Add the slugs of the terms with non-empty new metadata to an array
 				$term_slugs[] = $term->slug;
 			}
 			do_action( 'ef_editorial_metadata_field_updated', $key, $new_metadata, $id, $type );
 		}
-
+		
 		// Relate the post to the terms used and taxonomy type (wp_term_relationships table).
 		// This will allow us to update and display the count of metadata in posts in use per term.
 		// TODO: Core only correlates posts with terms if the post_status is publish. Do we care what it is?
 		if ( $post->post_status === 'publish' ) {
 			wp_set_object_terms( $id, $term_slugs, self::metadata_taxonomy );
-
-			// Bistro ToDo: Kick off a scheduled task in the future to change the status of the post to pending_review instead, using the content-expiry-date as the date to match against.
 		}
 	}
-
+	
 	/**
 	 * Generate a unique key based on the term
-	 *
+	 * 
 	 * @param object $term Term object
 	 * @return string $postmeta_key Unique key
 	 */
@@ -551,7 +541,7 @@ class EF_Editorial_Metadata extends EF_Module {
 		$postmeta_key = "{$prefix}_" . ( is_object( $term ) ? $term->slug : $term );
 		return $postmeta_key;
 	}
-
+	
 	/**
 	 * Returns the value for the given metadata
 	 *
@@ -568,14 +558,14 @@ class EF_Editorial_Metadata extends EF_Module {
 		$postmeta_key = $this->get_postmeta_key( $term );
 		return get_metadata( 'post', $post_id, $postmeta_key, true );
 	}
-
+	
 	/**
 	 * Get all of the editorial metadata terms as objects and sort by position
 	 * @todo Figure out what we should do with the filter...
-	 *
+	 * 
 	 * @param array $filter_args Filter to specific arguments
 	 * @return array $ordered_terms The terms as they should be ordered
-	 */
+	 */ 
 	function get_editorial_metadata_terms( $filter_args = array() ) {
 
 		// Try to fetch from internal object cache
@@ -583,7 +573,7 @@ class EF_Editorial_Metadata extends EF_Module {
 		if ( isset( $this->editorial_metadata_terms_cache[ $arg_hash ] ) ) {
 			return $this->editorial_metadata_terms_cache[ $arg_hash ];
 		}
-
+		
 		$args = array(
 		        'orderby'    => apply_filters( 'ef_editorial_metadata_term_order', 'name' ),
 		        'hide_empty' => false
@@ -594,7 +584,7 @@ class EF_Editorial_Metadata extends EF_Module {
 		$hold_to_end = array();
 		// Order the terms
 		foreach ( $terms as $key => $term ) {
-
+			
 			// Unencode and set all of our psuedo term meta because we need the position and viewable if they exists
 			// First do an array_merge() on the term object to make sure the keys exist, then array_merge()
 			// any values that may already exist
@@ -618,7 +608,7 @@ class EF_Editorial_Metadata extends EF_Module {
 			// Otherwise, hold it for later
 			if ( $term->position && !array_key_exists( $term->position, $ordered_terms ) )
 				$ordered_terms[(int)$term->position] = $term;
-			else
+			else 
 				$hold_to_end[] = $term;
 		}
 		// Sort the items numerically by key
@@ -635,11 +625,11 @@ class EF_Editorial_Metadata extends EF_Module {
 
 		return $ordered_terms;
 	}
-
+	
 	/**
 	 * Returns a term for single metadata field
 	 *
-	 * @param int|string $field The slug or ID for the metadata field term to return
+	 * @param int|string $field The slug or ID for the metadata field term to return 
 	 * @return object $term Term's object representation
 	 */
 	function get_editorial_metadata_term_by( $field, $value ) {
@@ -658,7 +648,7 @@ class EF_Editorial_Metadata extends EF_Module {
 		else
 			return false;
 	}
-
+	
 	/**
 	 * Register editorial metadata fields as columns in the manage posts view
 	 * Only adds columns for the currently active post types - logic controlled in $this->init()
@@ -682,7 +672,7 @@ class EF_Editorial_Metadata extends EF_Module {
 		}
 		return $posts_columns;
 	}
-
+	
 	/**
 	 * Register any viewable date editorial metadata as a sortable column
 	 *
@@ -717,7 +707,7 @@ class EF_Editorial_Metadata extends EF_Module {
 			set_query_var( 'orderby', 'meta_value_num' );
 		}
 	}
-
+	
 	/**
 	 * Handle the output of an editorial metadata custom column
 	 * Logic for the post types this is called on is controlled in $this->init()
@@ -729,7 +719,7 @@ class EF_Editorial_Metadata extends EF_Module {
 	 * @param int $post_id ID for the post of the row
 	 */
 	function action_manage_posts_custom_column( $column_name, $post_id ) {
-
+		
 		$terms = $this->get_editorial_metadata_terms();
 		// We're looking for the proper term to display its saved value
 		foreach( $terms as $term ) {
@@ -740,9 +730,9 @@ class EF_Editorial_Metadata extends EF_Module {
 			$current_metadata = $this->get_postmeta_value( $term, $post_id );
 			echo $this->generate_editorial_metadata_term_output( $term, $current_metadata );
 		}
-
+		
 	}
-
+	
 	/**
 	 * If the Edit Flow Calendar is enabled, add viewable Editorial Metadata terms
 	 *
@@ -755,13 +745,13 @@ class EF_Editorial_Metadata extends EF_Module {
 	 */
 	function filter_calendar_item_fields( $calendar_fields, $post_id ) {
 
-
+		
 		// Make sure we respect which post type we're on
 		if ( !in_array( get_post_type( $post_id ), $this->get_post_types_for_module( $this->module ) ) )
 			return $calendar_fields;
-
+			
 		$terms = $this->get_editorial_metadata_terms( array( 'viewable' => true ) );
-
+		
 		foreach( $terms as $term ) {
 			$key = $this->module->slug . '-' . $term->slug;
 
@@ -776,9 +766,9 @@ class EF_Editorial_Metadata extends EF_Module {
 			$calendar_fields[$key] = $term_data;
 		}
 		return $calendar_fields;
-
+		
 	}
-
+	
 	/**
 	 * If the Edit Flow Story Budget is enabled, register our viewable terms as columns
 	 *
@@ -789,7 +779,7 @@ class EF_Editorial_Metadata extends EF_Module {
 	 * @return array $term_columns Term columns with viewable Editorial Metadata terms
 	 */
 	function filter_story_budget_term_columns( $term_columns ) {
-
+		
 		$terms = $this->get_editorial_metadata_terms( array( 'viewable' => true ) );
 		foreach( $terms as $term ) {
 			// Prefixing slug with module slug because it isn't stored prefixed and we want to avoid collisions
@@ -797,11 +787,11 @@ class EF_Editorial_Metadata extends EF_Module {
 			// Switch to underscores
 			$key = str_replace( '-', '_', $key );
 			$term_columns[$key] = $term->name;
-		}
+		}		
 		return $term_columns;
-
+		
 	}
-
+	
 	/**
 	 * If the Edit Flow Story Budget is enabled,
 	 *
@@ -813,15 +803,15 @@ class EF_Editorial_Metadata extends EF_Module {
 	 * @param object $parent_term The parent term for the term column
 	 */
 	function filter_story_budget_term_column_values( $column_name, $post, $parent_term ) {
-
+		
 		$local_column_name = str_replace( '_', '-', $column_name );
 		// Don't accidentally handle values not our own
 		if ( false === strpos( $local_column_name, $this->module->slug ) )
 			return $column_name;
-
+			
 		$term_slug = str_replace( $this->module->slug . '-', '', $local_column_name );
 		$term = $this->get_editorial_metadata_term_by( 'slug', $term_slug );
-
+		
 		// Don't allow non-viewable term data to be displayed
 		if ( !$term->viewable )
 			return $column_name;
@@ -882,7 +872,7 @@ class EF_Editorial_Metadata extends EF_Module {
 		}
 		return $output;
 	}
-
+	
 	/**
 	 * Update an existing editorial metadata term if the term_id exists
 	 *
@@ -893,7 +883,7 @@ class EF_Editorial_Metadata extends EF_Module {
 	 * @return object|WP_Error $updated_term The updated term or a WP_Error object if something disastrous happened
 	 */
 	function update_editorial_metadata_term( $term_id, $args ) {
-
+		
 		$new_args = array();
 		$old_term = $this->get_editorial_metadata_term_by( 'id', $term_id );
 		if ( $old_term )
@@ -906,17 +896,17 @@ class EF_Editorial_Metadata extends EF_Module {
 				'viewable' => $old_term->viewable,
 			);
 		$new_args = array_merge( $old_args, $args );
-
+		
 		// We're encoding metadata that isn't supported by default in the term's description field
 		$args_to_encode = array(
 			'description' => $new_args['description'],
 			'position' => $new_args['position'],
 			'type' => $new_args['type'],
 			'viewable' => $new_args['viewable'],
-		);
+		);	
 		$encoded_description = $this->get_encoded_description( $args_to_encode );
 		$new_args['description'] = $encoded_description;
-
+		
 		$updated_term = wp_update_term( $term_id, self::metadata_taxonomy, $new_args );
 
 		// Reset the internal object cache
@@ -925,7 +915,7 @@ class EF_Editorial_Metadata extends EF_Module {
 		$updated_term = $this->get_editorial_metadata_term_by( 'id', $term_id );
 		return $updated_term;
 	}
-
+	
 	/**
 	 * Insert a new editorial metadata term
 	 * @todo Handle conflicts with existing terms at that position (if relevant)
@@ -934,7 +924,7 @@ class EF_Editorial_Metadata extends EF_Module {
 	 */
 	function insert_editorial_metadata_term( $args ) {
 
-
+		
 		// Term is always added to the end of the list
 		$default_position = count( $this->get_editorial_metadata_terms() ) + 2;
 		$defaults = array(
@@ -948,14 +938,14 @@ class EF_Editorial_Metadata extends EF_Module {
 		$args = array_merge( $defaults, $args );
 		$term_name = $args['name'];
 		unset( $args['name'] );
-
+		
 		// We're encoding metadata that isn't supported by default in the term's description field
 		$args_to_encode = array(
 			'description' => $args['description'],
 			'position' => $args['position'],
 			'type' => $args['type'],
 			'viewable' => $args['viewable'],
-		);
+		);	
 		$encoded_description = $this->get_encoded_description( $args_to_encode );
 		$args['description'] = $encoded_description;
 
@@ -966,16 +956,16 @@ class EF_Editorial_Metadata extends EF_Module {
 
 		return $inserted_term;
 	}
-
+	
 	/**
 	 * Settings and other management code
 	 */
-
+	
 	/**
 	 * Delete an existing editorial metadata term
 	 *
 	 * @since 0.7
-	 *
+	 * 
 	 * @param int $term_id The term we want deleted
 	 * @return bool $result Whether or not the term was deleted
 	 */
@@ -987,7 +977,7 @@ class EF_Editorial_Metadata extends EF_Module {
 
 		return $result;
 	}
-
+	
 	/**
 	 * Generate a link to one of the editorial metadata actions
 	 *
@@ -1012,31 +1002,31 @@ class EF_Editorial_Metadata extends EF_Module {
 				break;
 		}
 		return add_query_arg( $args, get_admin_url( null, 'admin.php' ) );
-	}
-
+	}	
+	
 	/**
 	 * Handles a request to add a new piece of editorial metadata
 	 */
 	function handle_add_editorial_metadata() {
 
-		if ( !isset( $_POST['submit'], $_POST['form-action'], $_GET['page'] )
+		if ( !isset( $_POST['submit'], $_POST['form-action'], $_GET['page'] ) 
 			|| $_GET['page'] != $this->module->settings_slug || $_POST['form-action'] != 'add-term' )
 				return;
-
+				
 		if ( !wp_verify_nonce( $_POST['_wpnonce'], 'editorial-metadata-add-nonce' ) )
 			wp_die( $this->module->messages['nonce-failed'] );
-
+			
 		if ( !current_user_can( 'manage_options' ) )
-			wp_die( $this->module->messages['invalid-permissions'] );
-
+			wp_die( $this->module->messages['invalid-permissions'] );			
+		
 		// Sanitize all of the user-entered values
 		$term_name = sanitize_text_field( trim( $_POST['metadata_name'] ) );
 		$term_slug = ( !empty( $_POST['metadata_slug'] ) ) ? sanitize_title( $_POST['metadata_slug'] ) : sanitize_title( $term_name );
 		$term_description = stripslashes( wp_filter_post_kses( trim( $_POST['metadata_description'] ) ) );
 		$term_type = sanitize_key( $_POST['metadata_type'] );
-
+		
 		$_REQUEST['form-errors'] = array();
-
+		
 		/**
 		 * Form validation for adding new editorial metadata term
 		 *
@@ -1070,7 +1060,7 @@ class EF_Editorial_Metadata extends EF_Module {
 		$term_viewable = false;
 		if ( $_POST['metadata_viewable'] == 'yes' )
 			$term_viewable = true;
-
+		
 		// Kick out if there are any errors
 		if ( count( $_REQUEST['form-errors'] ) ) {
 			$_REQUEST['error'] = 'form-error';
@@ -1093,27 +1083,27 @@ class EF_Editorial_Metadata extends EF_Module {
 		wp_redirect( $redirect_url );
 		exit;
 	}
-
+	
 	/**
 	 * Handles a request to edit an editorial metadata
 	 */
 	function handle_edit_editorial_metadata() {
-		if ( !isset( $_POST['submit'], $_GET['page'], $_GET['action'], $_GET['term-id'] )
+		if ( !isset( $_POST['submit'], $_GET['page'], $_GET['action'], $_GET['term-id'] ) 
 			|| $_GET['page'] != $this->module->settings_slug || $_GET['action'] != 'edit-term' )
-				return;
-
+				return; 
+				
 		if ( !wp_verify_nonce( $_POST['_wpnonce'], 'editorial-metadata-edit-nonce' ) )
 			wp_die( $this->module->messages['nonce-failed'] );
-
+			
 		if ( !current_user_can( 'manage_options' ) )
-			wp_die( $this->module->messages['invalid-permissions'] );
-
+			wp_die( $this->module->messages['invalid-permissions'] );			
+		
 		if ( !$existing_term = $this->get_editorial_metadata_term_by( 'id', (int)$_GET['term-id'] ) )
-			wp_die( $this->module->messages['term-missing'] );
-
+			wp_die( $this->module->messages['term-missing'] );			
+		
 		$new_name = sanitize_text_field( trim( $_POST['name'] ) );
 		$new_description = stripslashes( wp_filter_post_kses( strip_tags( trim( $_POST['description'] ) ) ) );
-
+			
 		/**
 		 * Form validation for editing editorial metadata term
 		 *
@@ -1121,11 +1111,11 @@ class EF_Editorial_Metadata extends EF_Module {
 		 * - "name", "slug", and "type" are required fields
 		 * - "description" can accept a limited amount of HTML, and is optional
 		 */
-		$_REQUEST['form-errors'] = array();
+		$_REQUEST['form-errors'] = array();	
 		// Check if name field was filled in
 		if( empty( $new_name ) )
 			$_REQUEST['form-errors']['name'] = __( 'Please enter a name for the editorial metadata', 'edit-flow' );
-
+			
 		// Check that the name isn't numeric
 		if ( is_numeric( $new_name ) )
 			$_REQUEST['form-errors']['name'] = __( 'Please enter a valid, non-numeric name for the editorial metadata.', 'edit-flow' );
@@ -1133,16 +1123,16 @@ class EF_Editorial_Metadata extends EF_Module {
 		$term_exists = term_exists( sanitize_title( $new_name ) );
 		if ( $term_exists && $term_exists != $existing_term->term_id )
 			$_REQUEST['form-errors']['name'] = __( 'Metadata name conflicts with existing term. Please choose another.', 'edit-flow' );
-
+			
 		// Check to ensure a term with the same name doesn't exist,
 		$search_term = $this->get_editorial_metadata_term_by( 'name', $new_name );
 		if ( is_object( $search_term ) && $search_term->term_id != $existing_term->term_id )
 			$_REQUEST['form-errors']['name'] = __( 'Name already in use. Please choose another.', 'edit-flow' );
-		// or that the term name doesn't map to an existing term's slug
+		// or that the term name doesn't map to an existing term's slug			
 		$search_term = $this->get_editorial_metadata_term_by( 'slug', sanitize_title( $new_name ) );
 		if ( is_object( $search_term ) && $search_term->term_id != $existing_term->term_id )
-			$_REQUEST['form-errors']['name'] = __( 'Name conflicts with slug for another term. Please choose something else.', 'edit-flow' );
-
+			$_REQUEST['form-errors']['name'] = __( 'Name conflicts with slug for another term. Please choose something else.', 'edit-flow' );					
+		
 		// Check that the term name doesn't exceed 200 chars
 		if ( strlen( $new_name ) > 200 )
 			$_REQUEST['form-errors']['name'] = __( 'Name cannot exceed 200 characters. Please try a shorter name.', 'edit-flow' );
@@ -1150,13 +1140,13 @@ class EF_Editorial_Metadata extends EF_Module {
 		$new_viewable = false;
 		if ( $_POST['viewable'] == 'yes' )
 			$new_viewable = true;
-
+	
 		// Kick out if there are any errors
 		if ( count( $_REQUEST['form-errors'] ) ) {
 			$_REQUEST['error'] = 'form-error';
 			return;
 		}
-
+		
 		// Try to add the metadata term
 		$args = array(
 			'name' => $new_name,
@@ -1166,39 +1156,39 @@ class EF_Editorial_Metadata extends EF_Module {
 		$return = $this->update_editorial_metadata_term( $existing_term->term_id, $args );
 		if ( is_wp_error( $return ) )
 			wp_die( __( 'Error updating term.', 'edit-flow' ) );
-
+		
 		$redirect_url = add_query_arg( array( 'page' => $this->module->settings_slug, 'message' => 'term-updated' ), get_admin_url( null, 'admin.php' ) );
 		wp_redirect( $redirect_url );
 		exit;
 	}
-
+	
 	/**
 	 * Handle a $_GET request to change the visibility of an Editorial Metadata term
 	 *
 	 * @since 0.7
 	 */
 	function handle_change_editorial_metadata_visibility() {
-
-		// Check that the current GET request is our GET request
+		
+		// Check that the current GET request is our GET request		
 		if ( !isset( $_GET['page'], $_GET['action'], $_GET['term-id'], $_GET['nonce'] )
 			|| $_GET['page'] != $this->module->settings_slug || !in_array( $_GET['action'], array( 'make-viewable', 'make-hidden' ) ) )
 			return;
-
+		
 		// Check for proper nonce
 		if ( !wp_verify_nonce( $_GET['nonce'], 'make-viewable' ) && !wp_verify_nonce( $_GET['nonce'], 'make-hidden' ) )
 			wp_die( $this->module->messages['nonce-failed'] );
-
+		
 		// Only allow users with the proper caps
 		if ( !current_user_can( 'manage_options' ) )
 			wp_die( $this->module->messages['invalid-permissions'] );
-
+		
 		$term_id = (int)$_GET['term-id'];
 		$args = array();
 		if ( $_GET['action'] == 'make-viewable' )
 			$args['viewable'] = true;
 		elseif ( $_GET['action'] == 'make-hidden' )
 			$args['viewable'] = false;
-
+		
 		$return = $this->update_editorial_metadata_term( $term_id, $args );
 		if ( is_wp_error( $return ) )
 			wp_die( __( 'Error updating term.', 'edit-flow' ) );
@@ -1206,32 +1196,32 @@ class EF_Editorial_Metadata extends EF_Module {
 		$redirect_url = $this->get_link( array( 'message' => 'term-visibility-changed' ) );
 		wp_redirect( $redirect_url );
 		exit;
-
+		
 	}
-
+	
 	/**
 	 * Handle the request to update a given Editorial Metadata term via inline edit
 	 *
 	 * @since 0.7
 	 */
 	function handle_ajax_inline_save_term() {
-
+		
 		if ( !wp_verify_nonce( $_POST['inline_edit'], 'editorial-metadata-inline-edit-nonce' ) )
 			die( $this->module->messages['nonce-failed'] );
-
+			
 		if ( !current_user_can( 'manage_options') )
 			die( $this->module->messages['invalid-permissions'] );
-
+		
 		$term_id = (int) $_POST['term_id'];
 		if ( !$existing_term = $this->get_editorial_metadata_term_by( 'id', $term_id ) )
 			die( $this->module->messages['term-missing'] );
-
+		
 		$metadata_name = sanitize_text_field( trim( $_POST['name'] ) );
 		$metadata_description = stripslashes( wp_filter_post_kses( trim( $_POST['description'] ) ) );
-
+		
 		/**
 		 * Form validation for editing editorial metadata term
-		 */
+		 */	
 		// Check if name field was filled in
 		if ( empty( $metadata_name ) ) {
 			$change_error = new WP_Error( 'invalid', __( 'Please enter a name for the editorial metadata', 'edit-flow' ) );
@@ -1243,20 +1233,20 @@ class EF_Editorial_Metadata extends EF_Module {
 			$change_error = new WP_Error( 'invalid', __( 'Please enter a valid, non-numeric name for the editorial metadata.', 'edit-flow' ) );
 			die( $change_error->get_error_message() );
 		}
-
+		
 		// Check that the term name doesn't exceed 200 chars
 		if ( strlen( $metadata_name ) > 200 ) {
 			$change_error = new WP_Error( 'invalid', __( 'Name cannot exceed 200 characters. Please try a shorter name.' ) );
 			die( $change_error->get_error_message() );
 		}
-
+		
 		// Check to make sure the status doesn't already exist as another term because otherwise we'd get a fatal error
 		$term_exists = term_exists( sanitize_title( $metadata_name ) );
 		if ( $term_exists && $term_exists != $term_id ) {
 			$change_error = new WP_Error( 'invalid', __( 'Metadata name conflicts with existing term. Please choose another.', 'edit-flow' ) );
 			die( $change_error->get_error_message() );
-		}
-
+		}		
+		
 		// Check to ensure a term with the same name doesn't exist,
 		$search_term = $this->get_editorial_metadata_term_by( 'name', $metadata_name );
 		if ( is_object( $search_term ) && $search_term->term_id != $existing_term->term_id ) {
@@ -1264,21 +1254,21 @@ class EF_Editorial_Metadata extends EF_Module {
 			die( $change_error->get_error_message() );
 		}
 
-		// or that the term name doesn't map to an existing term's slug
+		// or that the term name doesn't map to an existing term's slug			
 		$search_term = $this->get_editorial_metadata_term_by( 'slug', sanitize_title( $metadata_name ) );
 		if ( is_object( $search_term ) && $search_term->term_id != $existing_term->term_id ) {
 			$change_error = new WP_Error( 'invalid', __( 'Name conflicts with slug for another term. Please choose again.', 'edit-flow' ) );
-			die( $change_error->get_error_message() );
+			die( $change_error->get_error_message() );			
 		}
-
+		
 		// Prepare the term name and description for saving
 		$args = array(
 			'name' => $metadata_name,
 			'description' => $metadata_description,
 		);
 		$return = $this->update_editorial_metadata_term( $existing_term->term_id, $args );
-		if( !is_wp_error( $return ) ) {
-			set_current_screen( 'edit-editorial-metadata' );
+		if( !is_wp_error( $return ) ) {	
+			set_current_screen( 'edit-editorial-metadata' );					
 			$wp_list_table = new EF_Editorial_Metadata_List_Table();
 			$wp_list_table->prepare_items();
 			echo $wp_list_table->single_row( $return );
@@ -1287,9 +1277,9 @@ class EF_Editorial_Metadata extends EF_Module {
 			$change_error = new WP_Error( 'invalid', sprintf( __( 'Could not update the term: <strong>%s</strong>', 'edit-flow' ), $status_name ) );
 			die( $change_error->get_error_message() );
 		}
-
+		
 	}
-
+	
 	/**
 	 * Handle the ajax request to update all of the term positions
 	 *
@@ -1299,15 +1289,15 @@ class EF_Editorial_Metadata extends EF_Module {
 
 		if ( !wp_verify_nonce( $_POST['editorial_metadata_sortable_nonce'], 'editorial-metadata-sortable' ) )
 			$this->print_ajax_response( 'error', $this->module->messages['nonce-failed'] );
-
+		
 		if ( !current_user_can( 'manage_options') )
 			$this->print_ajax_response( 'error', $this->module->messages['invalid-permissions'] );
-
+		
 		if ( !isset( $_POST['term_positions'] ) || !is_array( $_POST['term_positions'] ) )
 			$this->print_ajax_response( 'error', __( 'Terms not set.', 'edit-flow' ) );
-
+			
 		foreach ( $_POST['term_positions'] as $position => $term_id ) {
-
+			
 			// Have to add 1 to the position because the index started with zero
 			$args = array(
 				'position' => (int)$position + 1,
@@ -1315,46 +1305,46 @@ class EF_Editorial_Metadata extends EF_Module {
 			$return = $this->update_editorial_metadata_term( (int)$term_id, $args );
 			// @todo check that this was a valid return
 		}
-		$this->print_ajax_response( 'success', $this->module->messages['term-position-updated'] );
+		$this->print_ajax_response( 'success', $this->module->messages['term-position-updated'] );	
 	}
-
+	
 	/**
 	 * Handles a request to delete an editorial metadata term
 	 */
 	function handle_delete_editorial_metadata() {
-		if ( !isset( $_GET['page'], $_GET['action'], $_GET['term-id'] )
+		if ( !isset( $_GET['page'], $_GET['action'], $_GET['term-id'] ) 
 			|| $_GET['page'] != $this->module->settings_slug || $_GET['action'] != 'delete-term' )
 				return;
-
+				
 		if ( !wp_verify_nonce( $_GET['nonce'], 'delete-term' ) )
 			wp_die( $this->module->messages['nonce-failed'] );
-
+			
 		if ( !current_user_can( 'manage_options' ) )
 			wp_die( $this->module->messages['invalid-permissions'] );
-
+			
 		if ( !$existing_term = $this->get_editorial_metadata_term_by( 'id', (int)$_GET['term-id'] ) )
-			wp_die( $this->module->messages['term-missing'] );
-
+			wp_die( $this->module->messages['term-missing'] );			
+			
 		$result = $this->delete_editorial_metadata_term( $existing_term->term_id );
 		if ( !$result || is_wp_error( $result ) )
 			wp_die( __( 'Error deleting term.', 'edit-flow' ) );
-
+			
 		$redirect_url = add_query_arg( array( 'page' => $this->module->settings_slug, 'message' => 'term-deleted' ), get_admin_url( null, 'admin.php' ) );
 		wp_redirect( $redirect_url );
-		exit;
+		exit;		
 	}
-
+	
 	/**
 	 * Register settings for notifications so we can partially use the Settings API
 	 * (We use the Settings API for form generation, but not saving)
-	 *
+	 * 
 	 * @since 0.7
 	 * @uses add_settings_section(), add_settings_field()
 	 */
 	function register_settings() {
 			add_settings_section( $this->module->options_group_name . '_general', false, '__return_false', $this->module->options_group_name );
 			add_settings_field( 'post_types', __( 'Add to these post types:', 'edit-flow' ), array( $this, 'settings_post_types_option' ), $this->module->options_group_name, $this->module->options_group_name . '_general' );
-	}
+	}	
 
 	/**
 	 * Choose the post types for editorial metadata
@@ -1375,15 +1365,15 @@ class EF_Editorial_Metadata extends EF_Module {
 	 * @return array $new_options Form values after they've been sanitized
 	 */
 	function settings_validate( $new_options ) {
-
+		
 		// Whitelist validation for the post type options
 		if ( !isset( $new_options['post_types'] ) )
 			$new_options['post_types'] = array();
-		$new_options['post_types'] = $this->clean_post_type_options( $new_options['post_types'], $this->module->post_type_support );
-
+		$new_options['post_types'] = $this->clean_post_type_options( $new_options['post_types'], $this->module->post_type_support );		
+		
 		return $new_options;
 	}
-
+	
 	/**
 	 * Prepare and display the configuration view for editorial metadata.
 	 * There are four primary components:
@@ -1393,7 +1383,7 @@ class EF_Editorial_Metadata extends EF_Module {
 	 * - Full page width view for editing a single Editorial Metadata term
 	 *
 	 * @since 0.7
-	 */
+	 */ 
 	function print_configure_view() {
 		global $edit_flow;
 		$wp_list_table = new EF_Editorial_Metadata_List_Table();
@@ -1412,8 +1402,8 @@ class EF_Editorial_Metadata extends EF_Module {
 		</div>
 		</div><!-- /col-right -->
 		<?php $wp_list_table->inline_edit(); ?>
-		<?php endif; ?>
-
+		<?php endif; ?>	
+		
 		<?php if ( isset( $_GET['action'], $_GET['term-id'] ) && $_GET['action'] == 'edit-term' ): ?>
 		<?php /** Full page width view for editing a given editorial metadata term **/ ?>
 		<?php
@@ -1422,12 +1412,12 @@ class EF_Editorial_Metadata extends EF_Module {
 			$term = $this->get_editorial_metadata_term_by( 'id', $term_id );
 			if ( !$term ) {
 				echo '<div class="error"><p>' . $this->module->messages['term-missing'] . '</p></div>';
-				return;
+				return; 
 			}
-			$metadata_types = $this->get_supported_metadata_types();
+			$metadata_types = $this->get_supported_metadata_types();			
 			$type = $term->type;
 			$edit_term_link = $this->get_link( array( 'action' => 'edit-term', 'term-id' => $term->term_id ) );
-
+			
 			$name = ( isset( $_POST['name'] ) ) ? stripslashes( $_POST['name'] ) : $term->name;
 			$description = ( isset( $_POST['description'] ) ) ? stripslashes( $_POST['description'] ) : $term->description;
 			if ( $term->viewable )
@@ -1436,7 +1426,7 @@ class EF_Editorial_Metadata extends EF_Module {
 				$viewable = 'no';
 			$viewable = ( isset( $_POST['viewable'] ) ) ? stripslashes( $_POST['viewable'] ) : $viewable;
 		?>
-
+		
 		<form method="post" action="<?php echo esc_url( $edit_term_link ); ?>" >
 		<input type="hidden" name="action" value="editedtag" />
 		<input type="hidden" name="tag_id" value="<?php echo esc_attr( $term->term_id ); ?>" />
@@ -1457,7 +1447,7 @@ class EF_Editorial_Metadata extends EF_Module {
 					<input type="text" disabled="disabled" value="<?php echo esc_attr( $term->slug ); ?>" />
 					<p class="description"><?php _e( 'The slug cannot be changed once the term has been created.', 'edit-flow' ); ?></p>
 				</td>
-			</tr>
+			</tr>			
 			<tr class="form-field">
 				<th scope="row" valign="top"><label for="description"><?php _e( 'Description', 'edit-flow' ); ?></label></th>
 				<td>
@@ -1496,22 +1486,22 @@ class EF_Editorial_Metadata extends EF_Module {
 		<a class="cancel-settings-link" href="<?php echo esc_url( add_query_arg( 'page', $this->module->settings_slug, get_admin_url( null, 'admin.php' ) ) ); ?>"><?php _e( 'Cancel', 'edit-flow' ); ?></a>
 		</p>
 		</form>
-
+		
 		<?php else: ?>
 		<?php /** If not in full-screen edit term mode, we can create new terms or change options **/ ?>
 		<div id="col-left">
-			<div class="col-wrap">
+			<div class="col-wrap">	
 			<div class="form-wrap">
 			<h3 class="nav-tab-wrapper">
 				<a href="<?php echo esc_url( add_query_arg( array( 'page' => $this->module->settings_slug ), get_admin_url( null, 'admin.php' ) ) ); ?>" class="nav-tab<?php if ( !isset( $_GET['action'] ) || $_GET['action'] != 'change-options' ) echo ' nav-tab-active'; ?>"><?php _e( 'Add New', 'edit-flow' ); ?></a>
 				<a href="<?php echo esc_url( add_query_arg( array( 'page' => $this->module->settings_slug, 'action' => 'change-options' ), get_admin_url( null, 'admin.php' ) ) ); ?>" class="nav-tab<?php if ( isset( $_GET['action'] ) && $_GET['action'] == 'change-options' ) echo ' nav-tab-active'; ?>"><?php _e( 'Options', 'edit-flow' ); ?></a>
 			</h3>
-
+			
 		<?php if ( isset( $_GET['action'] ) && $_GET['action'] == 'change-options' ): ?>
 		<?php /** Basic form built on WP Settings API for outputting Editorial Metadata options **/ ?>
 		<form class="basic-settings" action="<?php echo esc_url( add_query_arg( array( 'page' => $this->module->settings_slug, 'action' => 'change-options' ), get_admin_url( null, 'admin.php' ) ) ); ?>" method="post">
 			<?php settings_fields( $this->module->options_group_name ); ?>
-			<?php do_settings_sections( $this->module->options_group_name ); ?>
+			<?php do_settings_sections( $this->module->options_group_name ); ?>	
 			<?php echo '<input id="edit_flow_module_name" name="edit_flow_module_name" type="hidden" value="' . esc_attr( $this->module->name ) . '" />'; ?>
 			<?php submit_button(); ?>
 		</form>
@@ -1571,11 +1561,11 @@ class EF_Editorial_Metadata extends EF_Module {
 			</div>
 			</div>
 		</div>
-
+		
 		<?php
 		endif;
 	}
-
+	
 }
 
 }
@@ -1584,7 +1574,7 @@ class EF_Editorial_Metadata extends EF_Module {
  * Management interface for Editorial Metadata. Extends WP_List_Table class
  */
 class EF_Editorial_Metadata_List_Table extends WP_List_Table {
-
+	
 	var $callback_args;
 	var $taxonomy;
 	var $tax;
@@ -1596,16 +1586,16 @@ class EF_Editorial_Metadata_List_Table extends WP_List_Table {
 		global $edit_flow;
 
 		$this->taxonomy = EF_Editorial_Metadata::metadata_taxonomy;
-
+		
 		$this->tax = get_taxonomy( $this->taxonomy );
-
+		
 		$columns = $this->get_columns();
 		$hidden = array(
 			'position',
 		);
 		$sortable = array();
-
-		$this->_column_headers = array( $columns, $hidden, $sortable );
+		
+		$this->_column_headers = array( $columns, $hidden, $sortable );		
 
 		parent::__construct( array(
 			'plural' => 'editorial metadata',
@@ -1636,24 +1626,24 @@ class EF_Editorial_Metadata_List_Table extends WP_List_Table {
 	function no_items() {
 		_e( 'No editorial metadata found.', 'edit-flow' );
 	}
-
+	
 	/**
 	 * Register the columns to appear in the table
 	 *
 	 * @since 0.7
 	 */
 	function get_columns() {
-
+		
 		$columns = array(
 			'position'	  => __( 'Position', 'edit-flow' ),
 			'name'        => __( 'Name', 'edit-flow' ),
 			'type'		  => __( 'Metadata Type', 'edit-flow' ),
 			'description' => __( 'Description', 'edit-flow' ),
 			'viewable'    => __( 'Viewable', 'edit-flow' ),
-		);
+		);		
 		return $columns;
 	}
-
+	
 	/**
 	 * Prepare a single row of Editorial Metadata
 	 *
@@ -1671,7 +1661,7 @@ class EF_Editorial_Metadata_List_Table extends WP_List_Table {
  		echo $this->single_row_columns( $term );
  		echo '</tr>';
 	}
-
+	
 	/**
 	 * Handle the column output when there's no method for it
 	 *
@@ -1681,7 +1671,7 @@ class EF_Editorial_Metadata_List_Table extends WP_List_Table {
 	 * @param string $column_name How the column was registered at birth
 	 */
 	function column_default( $item, $column_name ) {
-
+		
 		switch( $column_name ) {
 			case 'position':
 			case 'type':
@@ -1691,13 +1681,13 @@ class EF_Editorial_Metadata_List_Table extends WP_List_Table {
 			case 'viewable':
 				if ( $item->viewable )
 					return __( 'Yes', 'edit-flow' );
-				else
+				else 
 					return __( 'No', 'edit-flow' );
 				break;
 			default:
 				break;
 		}
-
+		
 	}
 
 	/**
@@ -1711,9 +1701,9 @@ class EF_Editorial_Metadata_List_Table extends WP_List_Table {
 		global $edit_flow;
 		$item_edit_link = esc_url( $edit_flow->editorial_metadata->get_link( array( 'action' => 'edit-term', 'term-id' => $item->term_id ) ) );
 		$item_delete_link = esc_url( $edit_flow->editorial_metadata->get_link( array( 'action' => 'delete-term', 'term-id' => $item->term_id ) ) );
-
+		
 		$out = '<strong><a class="row-title" href="' . $item_edit_link . '">' . esc_html( $item->name ) . '</a></strong>';
-
+		
 		$actions = array();
 		$actions['edit'] = "<a href='$item_edit_link'>" . __( 'Edit', 'edit-flow' ) . "</a>";
 		$actions['inline hide-if-no-js'] = '<a href="#" class="editinline">' . __( 'Quick&nbsp;Edit' ) . '</a>';
@@ -1722,13 +1712,13 @@ class EF_Editorial_Metadata_List_Table extends WP_List_Table {
 		else
 			$actions['change-visibility make-viewable'] = '<a title="' . esc_attr( __( 'When viewable, metadata can be seen on views other than the edit post view (e.g. calendar, manage posts, story budget, etc.)', 'edit-flow' ) ) . '" href="' . esc_url( $edit_flow->editorial_metadata->get_link( array( 'action' => 'make-viewable', 'term-id' => $item->term_id ) ) ) . '">' . __( 'Make Viewable', 'edit-flow' ) . '</a>';
 		$actions['delete delete-status'] = "<a href='$item_delete_link'>" . __( 'Delete', 'edit-flow' ) . "</a>";
-
+		
 		$out .= $this->row_actions( $actions, false );
 		$out .= '<div class="hidden" id="inline_' . $item->term_id . '">';
 		$out .= '<div class="name">' . $item->name . '</div>';
-		$out .= '<div class="description">' . $item->description . '</div>';
+		$out .= '<div class="description">' . $item->description . '</div>';	
 		$out .= '</div>';
-
+		
 		return $out;
 	}
 

--- a/modules/editorial-metadata/editorial-metadata.php
+++ b/modules/editorial-metadata/editorial-metadata.php
@@ -552,7 +552,7 @@ class EF_Editorial_Metadata extends EF_Module {
 		if ( $post->post_status === 'publish' ) {
 			wp_set_object_terms( $id, $term_slugs, self::metadata_taxonomy );
 
-			// Bistro ToDo: Kick off a scheduled task in the future to change the status of the post to pending_review instead, using the content-expiry-date as the date to match against.
+			// ToDo: Kick off a scheduled task in the future to change the status of the post to pending_review instead, using the content-expiry-date as the date to match against.
 			if ( $send_time ) {
 				wp_schedule_event( $send_time, 'ef_unpublish_post_task', array( $id ) );
 			}
@@ -562,11 +562,11 @@ class EF_Editorial_Metadata extends EF_Module {
 	function unpublish_post_task( $post_id ) {
 		$post_status_to_set = 'pending';
 
-		if ( $this->module_enabled( 'custom-status' ) ) {
+		if ( $this->module_enabled( 'custom_status' ) ) {
 			$post_status_to_set	= 'expired';
 		}
 
-		// Bistro ToDo: Cancel the scheduled task to change the status of the post to pending_review.
+		// ToDo: Cancel the scheduled task to change the status of the post to pending_review.
 		$success_value = wp_update_post( array(
             'ID'          => $post_id,
             'post_status' => $post_status_to_set

--- a/modules/editorial-metadata/editorial-metadata.php
+++ b/modules/editorial-metadata/editorial-metadata.php
@@ -509,13 +509,6 @@ class EF_Editorial_Metadata extends EF_Module {
 			// TODO: do we care about the current_metadata at all?
 			//$current_metadata = get_post_meta( $id, $key, true );
 
-			if ( $term->slug == 'content-expiry-date' ) {
-				$current_metadata = get_post_meta( $id, $key, true );
-				if ( ! empty ( $current_metadata ) ) {
-					// Bistro ToDo: Update the scheduled task to have the new data now.
-				}
-			}
-
 			$new_metadata = isset( $_POST[$key] ) ? $_POST[$key] : '';
 
 			$type = $term->type;

--- a/modules/editorial-metadata/editorial-metadata.php
+++ b/modules/editorial-metadata/editorial-metadata.php
@@ -559,13 +559,9 @@ class EF_Editorial_Metadata extends EF_Module {
 			wp_set_object_terms( $id, $term_slugs, self::metadata_taxonomy );
 
 			// Bistro ToDo: Kick off a scheduled task in the future to change the status of the post to pending_review instead, using the content-expiry-date as the date to match against.
-			if ( $term->slug == 'content-expiry-date' ) {
-				$current_metadata = get_post_meta( $id, $key, true );
-				if ( ! empty ( $current_metadata ) ) {
-					// Bistro ToDo: Update the scheduled task to have the new data now.
-				}
+			if ( $send_time ) {
+				wp_schedule_single_event( $send_time, 'ef_unpublish_post_task', array( $id ) );
 			}
-			wp_schedule_single_event( $send_time, 'ef_unpublish_post_task', array( $id ) );
 		}
 	}
 

--- a/modules/editorial-metadata/editorial-metadata.php
+++ b/modules/editorial-metadata/editorial-metadata.php
@@ -569,7 +569,7 @@ class EF_Editorial_Metadata extends EF_Module {
 	 */
 	function schedule_unpublishing_post( $post_id, $send_time ) {
 		// If there's already a scheduled task for this post, we'll clear it out.
-		if ( ! wp_next_scheduled( 'ef_unpublish_post_task', array( $post_id ) ) ) {
+		if ( wp_next_scheduled( 'ef_unpublish_post_task', array( $post_id ) ) ) {
 			wp_clear_scheduled_hook( 'ef_unpublish_post_task', array( $post_id ) );
 		}
 

--- a/modules/editorial-metadata/editorial-metadata.php
+++ b/modules/editorial-metadata/editorial-metadata.php
@@ -14,7 +14,7 @@
  * 6) Clear the metadata for a single term in a post and watch the count go down!
  * 6) Delete a term and note the metadata disappears from posts
  * 7) Re-add the term (same slug) and the metadata returns!
- * 
+ *
  * Improvements to make:
  * @todo Abstract the permissions check for management to class level
  */
@@ -27,16 +27,16 @@ class EF_Editorial_Metadata extends EF_Module {
 	 */
 	const metadata_taxonomy = 'ef_editorial_meta';
 	const metadata_postmeta_key = "_ef_editorial_meta";
-	
+
 	var $module_name = 'editorial_metadata';
 
 	private $editorial_metadata_terms_cache = array();
-	
+
 	/**
 	 * Construct the EF_Editorial_Metadata class
 	 */
 	function __construct() {
-		
+
 		$this->module_url = $this->get_module_url( __FILE__ );
 		// Register the module with Edit Flow
 		$args = array(
@@ -71,55 +71,55 @@ class EF_Editorial_Metadata extends EF_Module {
 		);
 		EditFlow()->register_module( $this->module_name, $args );
 	}
-	
+
 	/**
 	 * Initialize the module. Conditionally loads if the module is enabled
 	 */
 	function init() {
-		
+
 		// Register the taxonomy we use for Editorial Metadata with WordPress core
 		$this->register_taxonomy();
 
 		// Anything that needs to happen in the admin
 		add_action( 'admin_init', array( $this, 'action_admin_init' ) );
-		
+
 		// Register our settings
-		add_action( 'admin_init', array( $this, 'register_settings' ) );		
-		
+		add_action( 'admin_init', array( $this, 'register_settings' ) );
+
 		// Actions relevant to the configuration view (adding, editing, or sorting existing Editorial Metadata)
 		add_action( 'admin_init', array( $this, 'handle_add_editorial_metadata' ) );
 		add_action( 'admin_init', array( $this, 'handle_edit_editorial_metadata' ) );
-		add_action( 'admin_init', array( $this, 'handle_change_editorial_metadata_visibility' ) );	
+		add_action( 'admin_init', array( $this, 'handle_change_editorial_metadata_visibility' ) );
 		add_action( 'admin_init', array( $this, 'handle_delete_editorial_metadata' ) );
 		add_action( 'wp_ajax_inline_save_term', array( $this, 'handle_ajax_inline_save_term' ) );
 		add_action( 'wp_ajax_update_term_positions', array( $this, 'handle_ajax_update_term_positions' ) );
-		
+
 		add_action( 'add_meta_boxes', array( $this, 'handle_post_metaboxes' ) );
 		add_action( 'save_post', array( $this, 'save_meta_box' ), 10, 2 );
-		
+
 		// Add Editorial Metadata columns to the Manage Posts view
 		$supported_post_types = $this->get_post_types_for_module( $this->module );
 		foreach( $supported_post_types as $post_type ) {
 			add_filter( "manage_{$post_type}_posts_columns", array( $this, 'filter_manage_posts_columns' ) );
 			add_action( "manage_{$post_type}_posts_custom_column", array( $this, 'action_manage_posts_custom_column' ), 10, 2 );
 		}
-		
+
 		// Add Editorial Metadata to the calendar if the calendar is activated
 		if ( $this->module_enabled( 'calendar' ) )
 			add_filter( 'ef_calendar_item_information_fields', array( $this, 'filter_calendar_item_fields' ), 10, 2 );
-		
+
 		// Add Editorial Metadata columns to the Story Budget if it exists
 		if ( $this->module_enabled( 'story_budget' ) ) {
 			add_filter( 'ef_story_budget_term_columns', array( $this, 'filter_story_budget_term_columns' ) );
 			// Register an action to handle this data later
 			add_filter( 'ef_story_budget_term_column_value', array( $this, 'filter_story_budget_term_column_values' ), 10, 3 );
-		}		
-		
+		}
+
 		// Load necessary scripts and stylesheets
-		add_action( 'admin_enqueue_scripts', array( $this, 'add_admin_scripts' ) );	
-		
+		add_action( 'admin_enqueue_scripts', array( $this, 'add_admin_scripts' ) );
+
 	}
-	
+
 	/**
 	 * Load default editorial metadata the first time the module is loaded
 	 *
@@ -152,6 +152,12 @@ class EF_Editorial_Metadata extends EF_Module {
 				'type' => 'number',
 				'description' => __( 'Required post length in words.', 'edit-flow' ),
 			),
+			array(
+				'name' => __( 'Expiry Date', 'edit-flow' ),
+				'slug' => 'content-expiry-date',
+				'type' => 'date',
+				'description' => __( 'When the content expires and needs to be updated.', 'edit-flow' ),
+			),
 		);
 		// Load the metadata fields if the slugs don't conflict
 		foreach ( $default_metadata as $args ) {
@@ -179,7 +185,7 @@ class EF_Editorial_Metadata extends EF_Module {
 			// Editorial metadata descriptions become base64_encoded, instead of maybe json_encoded.
 			$this->upgrade_074_term_descriptions( self::metadata_taxonomy );
 		}
-		
+
 	}
 
 	/**
@@ -192,7 +198,7 @@ class EF_Editorial_Metadata extends EF_Module {
 		// Parse the query when we're ordering by an editorial metadata term
 		add_action( 'parse_query', array( $this, 'action_parse_query' ) );
 	}
-	
+
 	/**
 	 * Generate <select> HTML for all of the metadata types
 	 */
@@ -207,7 +213,7 @@ class EF_Editorial_Metadata extends EF_Module {
 		</select>
 	<?php
 	}
-	
+
 	/**
 	 * Prepare an array of supported editorial metadata types
 	 *
@@ -225,13 +231,13 @@ class EF_Editorial_Metadata extends EF_Module {
 		);
 		return $supported_metadata_types;
 	}
-	
+
 	/**
 	 * Enqueue relevant admin Javascript
-	 */ 
+	 */
 	function add_admin_scripts() {
 		global $current_screen, $pagenow;
-		
+
 		// Add the metabox date picker JS and CSS
 		$current_post_type = $this->get_current_post_type();
 		$supported_post_types = $this->get_post_types_for_module( $this->module );
@@ -246,7 +252,7 @@ class EF_Editorial_Metadata extends EF_Module {
 			$terms = $this->get_editorial_metadata_terms();
 			$viewable_terms = array();
 			foreach( $terms as $term ) {
-				if ( $term->viewable ) 
+				if ( $term->viewable )
 					$viewable_terms[] = $term;
 			}
 			if ( !empty( $viewable_terms ) ) {
@@ -295,16 +301,16 @@ class EF_Editorial_Metadata extends EF_Module {
 				}
 				echo '</style>';
 			}
-			
+
 		}
-		
+
 		// Load Javascript specific to the editorial metadata configuration view
 		if ( $this->is_whitelisted_settings_view( $this->module->name ) ) {
-			wp_enqueue_script( 'jquery-ui-sortable' );			
+			wp_enqueue_script( 'jquery-ui-sortable' );
 			wp_enqueue_script( 'edit-flow-editorial-metadata-configure', EDIT_FLOW_URL . 'modules/editorial-metadata/lib/editorial-metadata-configure.js', array( 'jquery', 'jquery-ui-sortable', 'edit-flow-settings-js' ), EDIT_FLOW_VERSION, true );
 		}
 	}
-	
+
 	/**
 	 * Register the post metadata taxonomy
 	 */
@@ -312,7 +318,7 @@ class EF_Editorial_Metadata extends EF_Module {
 
 		// We need to make sure taxonomy is registered for all of the post types that support it
 		$supported_post_types = $this->get_post_types_for_module( $this->module );
-	
+
 		register_taxonomy( self::metadata_taxonomy, $supported_post_types,
 			array(
 				'public' => false,
@@ -331,11 +337,11 @@ class EF_Editorial_Metadata extends EF_Module {
 			)
 		);
 	}
-	
+
 	/*****************************************************
 	 * Post meta box generation and processing
 	 ****************************************************/
-	
+
 	/**
 	 * Load the post metaboxes for all of the post types that are supported
 	 */
@@ -347,7 +353,7 @@ class EF_Editorial_Metadata extends EF_Module {
 			add_meta_box( self::metadata_taxonomy, $title, array( $this, 'display_meta_box' ), $post_type, 'side' );
 		}
 	}
-	
+
 	/**
 	 * Displays HTML output for Editorial Metadata post meta box
 	 *
@@ -363,13 +369,13 @@ class EF_Editorial_Metadata extends EF_Module {
 			$url = add_query_arg( 'page', 'ef-editorial-metadata-settings', get_admin_url( null, 'admin.php' ) );
 			echo '<p><a href="'. esc_url( $url ) . '">' . __( 'Configure', 'edit-flow' ) . '</a></p>';
 		}
-	
+
 		$terms = $this->get_editorial_metadata_terms();
 		if ( !count( $terms ) ) {
 			$message = __( 'No editorial metadata available.' );
 			if ( current_user_can( 'manage_options' ) )
 				$message .= sprintf( __( ' <a href="%s">Add fields to get started</a>.' ), $this->get_link() );
-			else 
+			else
 				$message .= __( ' Encourage your site administrator to configure your editorial workflow by adding editorial metadata.' );
 			echo '<p>' . $message . '</p>';
 		} else {
@@ -388,7 +394,7 @@ class EF_Editorial_Metadata extends EF_Module {
 						// TODO: Move this to a function
 						if ( !empty( $current_metadata ) ) {
 							// Turn timestamp into a human-readable date
-							$current_metadata = $this->show_date_or_datetime( intval( $current_metadata ) );	
+							$current_metadata = $this->show_date_or_datetime( intval( $current_metadata ) );
 						}
 						echo "<label for='$postmeta_key'>{$term->name}</label>";
 						if ( $description_span )
@@ -416,12 +422,12 @@ class EF_Editorial_Metadata extends EF_Module {
 						echo "<label for='$postmeta_key'>{$term->name}$description_span</label>";
 						echo "<input id='$postmeta_key' name='$postmeta_key' type='checkbox' value='1' " . checked($current_metadata, 1, false) . " />";
 						break;
-					case "user": 
+					case "user":
 						echo "<label for='$postmeta_key'>{$term->name}$description_span</label>";
-						$user_dropdown_args = array( 
-								'show_option_all' => __( '-- Select a user --', 'edit-flow' ), 
+						$user_dropdown_args = array(
+								'show_option_all' => __( '-- Select a user --', 'edit-flow' ),
 								'name'     => $postmeta_key,
-								'selected' => $current_metadata 
+								'selected' => $current_metadata
 							);
 						$user_dropdown_args = apply_filters( 'ef_editorial_metadata_user_dropdown_args', $user_dropdown_args );
 						wp_dropdown_users( $user_dropdown_args );
@@ -429,17 +435,17 @@ class EF_Editorial_Metadata extends EF_Module {
 					case "number":
 						echo "<label for='$postmeta_key'>{$term->name}$description_span</label>";
 						echo "<input id='$postmeta_key' name='$postmeta_key' type='text' value='$current_metadata' />";
-						break;					
+						break;
 					default:
 						echo "<p>" . __( 'This editorial metadata type is not yet supported.', 'edit-flow' ) . "</p>";
 				}
 			echo "</div>";
 			echo "<div class='clear'></div>";
 		} // Done iterating through metadata terms
-		}		
+		}
 		echo "</div>";
 	}
-	
+
 	/**
 	 * Show date or datetime
 	 * @param  int $current_date
@@ -456,7 +462,7 @@ class EF_Editorial_Metadata extends EF_Module {
 
 	/**
 	 * Save any values in the editorial metadata post meta box
-	 * 
+	 *
 	 * @param int $id Unique ID for the post being saved
 	 * @param object $post Post object
 	 */
@@ -468,26 +474,28 @@ class EF_Editorial_Metadata extends EF_Module {
 			|| ! wp_verify_nonce( $_POST[self::metadata_taxonomy . "_nonce"], 'ef-save-metabox' ) ) {
 			return $id;
 		}
-		
+
 		if( ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE )
 			|| ! in_array( $post->post_type, $this->get_post_types_for_module( $this->module ) )
 			|| $post->post_type == 'post' && !current_user_can( 'edit_post', $id )
 			|| $post->post_type == 'page' && !current_user_can( 'edit_page', $id ) ) {
 			return $id;
 		}
-		
-		// Authentication passed, let's save the data		
+
+		// Authentication passed, let's save the data
 		$terms = $this->get_editorial_metadata_terms();
 		$term_slugs = array();
-				
+
 		foreach ( $terms as $term ) {
 			// Setup the key for this editorial metadata term (same as what's in $_POST)
 			$key = $this->get_postmeta_key( $term );
-			
+
 			// Get the current editorial metadata
 			// TODO: do we care about the current_metadata at all?
 			//$current_metadata = get_post_meta( $id, $key, true );
-			
+
+			// Bistro ToDo: Prevent the content-expiry-date from being edited if it's being saved already.
+
 			$new_metadata = isset( $_POST[$key] ) ? $_POST[$key] : '';
 
 			$type = $term->type;
@@ -500,7 +508,7 @@ class EF_Editorial_Metadata extends EF_Module {
 					$date_to_parse =  isset( $_POST[ $key . '_hidden' ] ) ? $_POST[ $key . '_hidden' ] : '';
 					$date = DateTime::createFromFormat('Y-m-d H:i', $date_to_parse );
 
-					if ( false !== $date ) { 
+					if ( false !== $date ) {
 						$new_metadata = $date->getTimestamp();
 					} else {
 						// Fallback, in case $_POST[ $key . '_hidden' ] was not previosuly set
@@ -510,27 +518,29 @@ class EF_Editorial_Metadata extends EF_Module {
 				if ( 'number' === $type ) {
 					$new_metadata = (int)$new_metadata;
 				}
-				
+
 				$new_metadata = strip_tags( $new_metadata );
 				update_post_meta( $id, $key, $new_metadata );
-				
+
 				// Add the slugs of the terms with non-empty new metadata to an array
 				$term_slugs[] = $term->slug;
 			}
 			do_action( 'ef_editorial_metadata_field_updated', $key, $new_metadata, $id, $type );
 		}
-		
+
 		// Relate the post to the terms used and taxonomy type (wp_term_relationships table).
 		// This will allow us to update and display the count of metadata in posts in use per term.
 		// TODO: Core only correlates posts with terms if the post_status is publish. Do we care what it is?
 		if ( $post->post_status === 'publish' ) {
 			wp_set_object_terms( $id, $term_slugs, self::metadata_taxonomy );
+
+			// Bistro ToDo: Kick off a scheduled task in the future to change the status of the post to pending_review instead, using the content-expiry-date as the date to match against.
 		}
 	}
-	
+
 	/**
 	 * Generate a unique key based on the term
-	 * 
+	 *
 	 * @param object $term Term object
 	 * @return string $postmeta_key Unique key
 	 */
@@ -541,7 +551,7 @@ class EF_Editorial_Metadata extends EF_Module {
 		$postmeta_key = "{$prefix}_" . ( is_object( $term ) ? $term->slug : $term );
 		return $postmeta_key;
 	}
-	
+
 	/**
 	 * Returns the value for the given metadata
 	 *
@@ -558,14 +568,14 @@ class EF_Editorial_Metadata extends EF_Module {
 		$postmeta_key = $this->get_postmeta_key( $term );
 		return get_metadata( 'post', $post_id, $postmeta_key, true );
 	}
-	
+
 	/**
 	 * Get all of the editorial metadata terms as objects and sort by position
 	 * @todo Figure out what we should do with the filter...
-	 * 
+	 *
 	 * @param array $filter_args Filter to specific arguments
 	 * @return array $ordered_terms The terms as they should be ordered
-	 */ 
+	 */
 	function get_editorial_metadata_terms( $filter_args = array() ) {
 
 		// Try to fetch from internal object cache
@@ -573,7 +583,7 @@ class EF_Editorial_Metadata extends EF_Module {
 		if ( isset( $this->editorial_metadata_terms_cache[ $arg_hash ] ) ) {
 			return $this->editorial_metadata_terms_cache[ $arg_hash ];
 		}
-		
+
 		$args = array(
 		        'orderby'    => apply_filters( 'ef_editorial_metadata_term_order', 'name' ),
 		        'hide_empty' => false
@@ -584,7 +594,7 @@ class EF_Editorial_Metadata extends EF_Module {
 		$hold_to_end = array();
 		// Order the terms
 		foreach ( $terms as $key => $term ) {
-			
+
 			// Unencode and set all of our psuedo term meta because we need the position and viewable if they exists
 			// First do an array_merge() on the term object to make sure the keys exist, then array_merge()
 			// any values that may already exist
@@ -608,7 +618,7 @@ class EF_Editorial_Metadata extends EF_Module {
 			// Otherwise, hold it for later
 			if ( $term->position && !array_key_exists( $term->position, $ordered_terms ) )
 				$ordered_terms[(int)$term->position] = $term;
-			else 
+			else
 				$hold_to_end[] = $term;
 		}
 		// Sort the items numerically by key
@@ -625,11 +635,11 @@ class EF_Editorial_Metadata extends EF_Module {
 
 		return $ordered_terms;
 	}
-	
+
 	/**
 	 * Returns a term for single metadata field
 	 *
-	 * @param int|string $field The slug or ID for the metadata field term to return 
+	 * @param int|string $field The slug or ID for the metadata field term to return
 	 * @return object $term Term's object representation
 	 */
 	function get_editorial_metadata_term_by( $field, $value ) {
@@ -648,7 +658,7 @@ class EF_Editorial_Metadata extends EF_Module {
 		else
 			return false;
 	}
-	
+
 	/**
 	 * Register editorial metadata fields as columns in the manage posts view
 	 * Only adds columns for the currently active post types - logic controlled in $this->init()
@@ -672,7 +682,7 @@ class EF_Editorial_Metadata extends EF_Module {
 		}
 		return $posts_columns;
 	}
-	
+
 	/**
 	 * Register any viewable date editorial metadata as a sortable column
 	 *
@@ -707,7 +717,7 @@ class EF_Editorial_Metadata extends EF_Module {
 			set_query_var( 'orderby', 'meta_value_num' );
 		}
 	}
-	
+
 	/**
 	 * Handle the output of an editorial metadata custom column
 	 * Logic for the post types this is called on is controlled in $this->init()
@@ -719,7 +729,7 @@ class EF_Editorial_Metadata extends EF_Module {
 	 * @param int $post_id ID for the post of the row
 	 */
 	function action_manage_posts_custom_column( $column_name, $post_id ) {
-		
+
 		$terms = $this->get_editorial_metadata_terms();
 		// We're looking for the proper term to display its saved value
 		foreach( $terms as $term ) {
@@ -730,9 +740,9 @@ class EF_Editorial_Metadata extends EF_Module {
 			$current_metadata = $this->get_postmeta_value( $term, $post_id );
 			echo $this->generate_editorial_metadata_term_output( $term, $current_metadata );
 		}
-		
+
 	}
-	
+
 	/**
 	 * If the Edit Flow Calendar is enabled, add viewable Editorial Metadata terms
 	 *
@@ -745,13 +755,13 @@ class EF_Editorial_Metadata extends EF_Module {
 	 */
 	function filter_calendar_item_fields( $calendar_fields, $post_id ) {
 
-		
+
 		// Make sure we respect which post type we're on
 		if ( !in_array( get_post_type( $post_id ), $this->get_post_types_for_module( $this->module ) ) )
 			return $calendar_fields;
-			
+
 		$terms = $this->get_editorial_metadata_terms( array( 'viewable' => true ) );
-		
+
 		foreach( $terms as $term ) {
 			$key = $this->module->slug . '-' . $term->slug;
 
@@ -766,9 +776,9 @@ class EF_Editorial_Metadata extends EF_Module {
 			$calendar_fields[$key] = $term_data;
 		}
 		return $calendar_fields;
-		
+
 	}
-	
+
 	/**
 	 * If the Edit Flow Story Budget is enabled, register our viewable terms as columns
 	 *
@@ -779,7 +789,7 @@ class EF_Editorial_Metadata extends EF_Module {
 	 * @return array $term_columns Term columns with viewable Editorial Metadata terms
 	 */
 	function filter_story_budget_term_columns( $term_columns ) {
-		
+
 		$terms = $this->get_editorial_metadata_terms( array( 'viewable' => true ) );
 		foreach( $terms as $term ) {
 			// Prefixing slug with module slug because it isn't stored prefixed and we want to avoid collisions
@@ -787,11 +797,11 @@ class EF_Editorial_Metadata extends EF_Module {
 			// Switch to underscores
 			$key = str_replace( '-', '_', $key );
 			$term_columns[$key] = $term->name;
-		}		
+		}
 		return $term_columns;
-		
+
 	}
-	
+
 	/**
 	 * If the Edit Flow Story Budget is enabled,
 	 *
@@ -803,15 +813,15 @@ class EF_Editorial_Metadata extends EF_Module {
 	 * @param object $parent_term The parent term for the term column
 	 */
 	function filter_story_budget_term_column_values( $column_name, $post, $parent_term ) {
-		
+
 		$local_column_name = str_replace( '_', '-', $column_name );
 		// Don't accidentally handle values not our own
 		if ( false === strpos( $local_column_name, $this->module->slug ) )
 			return $column_name;
-			
+
 		$term_slug = str_replace( $this->module->slug . '-', '', $local_column_name );
 		$term = $this->get_editorial_metadata_term_by( 'slug', $term_slug );
-		
+
 		// Don't allow non-viewable term data to be displayed
 		if ( !$term->viewable )
 			return $column_name;
@@ -872,7 +882,7 @@ class EF_Editorial_Metadata extends EF_Module {
 		}
 		return $output;
 	}
-	
+
 	/**
 	 * Update an existing editorial metadata term if the term_id exists
 	 *
@@ -883,7 +893,7 @@ class EF_Editorial_Metadata extends EF_Module {
 	 * @return object|WP_Error $updated_term The updated term or a WP_Error object if something disastrous happened
 	 */
 	function update_editorial_metadata_term( $term_id, $args ) {
-		
+
 		$new_args = array();
 		$old_term = $this->get_editorial_metadata_term_by( 'id', $term_id );
 		if ( $old_term )
@@ -896,17 +906,17 @@ class EF_Editorial_Metadata extends EF_Module {
 				'viewable' => $old_term->viewable,
 			);
 		$new_args = array_merge( $old_args, $args );
-		
+
 		// We're encoding metadata that isn't supported by default in the term's description field
 		$args_to_encode = array(
 			'description' => $new_args['description'],
 			'position' => $new_args['position'],
 			'type' => $new_args['type'],
 			'viewable' => $new_args['viewable'],
-		);	
+		);
 		$encoded_description = $this->get_encoded_description( $args_to_encode );
 		$new_args['description'] = $encoded_description;
-		
+
 		$updated_term = wp_update_term( $term_id, self::metadata_taxonomy, $new_args );
 
 		// Reset the internal object cache
@@ -915,7 +925,7 @@ class EF_Editorial_Metadata extends EF_Module {
 		$updated_term = $this->get_editorial_metadata_term_by( 'id', $term_id );
 		return $updated_term;
 	}
-	
+
 	/**
 	 * Insert a new editorial metadata term
 	 * @todo Handle conflicts with existing terms at that position (if relevant)
@@ -924,7 +934,7 @@ class EF_Editorial_Metadata extends EF_Module {
 	 */
 	function insert_editorial_metadata_term( $args ) {
 
-		
+
 		// Term is always added to the end of the list
 		$default_position = count( $this->get_editorial_metadata_terms() ) + 2;
 		$defaults = array(
@@ -938,14 +948,14 @@ class EF_Editorial_Metadata extends EF_Module {
 		$args = array_merge( $defaults, $args );
 		$term_name = $args['name'];
 		unset( $args['name'] );
-		
+
 		// We're encoding metadata that isn't supported by default in the term's description field
 		$args_to_encode = array(
 			'description' => $args['description'],
 			'position' => $args['position'],
 			'type' => $args['type'],
 			'viewable' => $args['viewable'],
-		);	
+		);
 		$encoded_description = $this->get_encoded_description( $args_to_encode );
 		$args['description'] = $encoded_description;
 
@@ -956,16 +966,16 @@ class EF_Editorial_Metadata extends EF_Module {
 
 		return $inserted_term;
 	}
-	
+
 	/**
 	 * Settings and other management code
 	 */
-	
+
 	/**
 	 * Delete an existing editorial metadata term
 	 *
 	 * @since 0.7
-	 * 
+	 *
 	 * @param int $term_id The term we want deleted
 	 * @return bool $result Whether or not the term was deleted
 	 */
@@ -977,7 +987,7 @@ class EF_Editorial_Metadata extends EF_Module {
 
 		return $result;
 	}
-	
+
 	/**
 	 * Generate a link to one of the editorial metadata actions
 	 *
@@ -1002,31 +1012,31 @@ class EF_Editorial_Metadata extends EF_Module {
 				break;
 		}
 		return add_query_arg( $args, get_admin_url( null, 'admin.php' ) );
-	}	
-	
+	}
+
 	/**
 	 * Handles a request to add a new piece of editorial metadata
 	 */
 	function handle_add_editorial_metadata() {
 
-		if ( !isset( $_POST['submit'], $_POST['form-action'], $_GET['page'] ) 
+		if ( !isset( $_POST['submit'], $_POST['form-action'], $_GET['page'] )
 			|| $_GET['page'] != $this->module->settings_slug || $_POST['form-action'] != 'add-term' )
 				return;
-				
+
 		if ( !wp_verify_nonce( $_POST['_wpnonce'], 'editorial-metadata-add-nonce' ) )
 			wp_die( $this->module->messages['nonce-failed'] );
-			
+
 		if ( !current_user_can( 'manage_options' ) )
-			wp_die( $this->module->messages['invalid-permissions'] );			
-		
+			wp_die( $this->module->messages['invalid-permissions'] );
+
 		// Sanitize all of the user-entered values
 		$term_name = sanitize_text_field( trim( $_POST['metadata_name'] ) );
 		$term_slug = ( !empty( $_POST['metadata_slug'] ) ) ? sanitize_title( $_POST['metadata_slug'] ) : sanitize_title( $term_name );
 		$term_description = stripslashes( wp_filter_post_kses( trim( $_POST['metadata_description'] ) ) );
 		$term_type = sanitize_key( $_POST['metadata_type'] );
-		
+
 		$_REQUEST['form-errors'] = array();
-		
+
 		/**
 		 * Form validation for adding new editorial metadata term
 		 *
@@ -1060,7 +1070,7 @@ class EF_Editorial_Metadata extends EF_Module {
 		$term_viewable = false;
 		if ( $_POST['metadata_viewable'] == 'yes' )
 			$term_viewable = true;
-		
+
 		// Kick out if there are any errors
 		if ( count( $_REQUEST['form-errors'] ) ) {
 			$_REQUEST['error'] = 'form-error';
@@ -1083,27 +1093,27 @@ class EF_Editorial_Metadata extends EF_Module {
 		wp_redirect( $redirect_url );
 		exit;
 	}
-	
+
 	/**
 	 * Handles a request to edit an editorial metadata
 	 */
 	function handle_edit_editorial_metadata() {
-		if ( !isset( $_POST['submit'], $_GET['page'], $_GET['action'], $_GET['term-id'] ) 
+		if ( !isset( $_POST['submit'], $_GET['page'], $_GET['action'], $_GET['term-id'] )
 			|| $_GET['page'] != $this->module->settings_slug || $_GET['action'] != 'edit-term' )
-				return; 
-				
+				return;
+
 		if ( !wp_verify_nonce( $_POST['_wpnonce'], 'editorial-metadata-edit-nonce' ) )
 			wp_die( $this->module->messages['nonce-failed'] );
-			
+
 		if ( !current_user_can( 'manage_options' ) )
-			wp_die( $this->module->messages['invalid-permissions'] );			
-		
+			wp_die( $this->module->messages['invalid-permissions'] );
+
 		if ( !$existing_term = $this->get_editorial_metadata_term_by( 'id', (int)$_GET['term-id'] ) )
-			wp_die( $this->module->messages['term-missing'] );			
-		
+			wp_die( $this->module->messages['term-missing'] );
+
 		$new_name = sanitize_text_field( trim( $_POST['name'] ) );
 		$new_description = stripslashes( wp_filter_post_kses( strip_tags( trim( $_POST['description'] ) ) ) );
-			
+
 		/**
 		 * Form validation for editing editorial metadata term
 		 *
@@ -1111,11 +1121,11 @@ class EF_Editorial_Metadata extends EF_Module {
 		 * - "name", "slug", and "type" are required fields
 		 * - "description" can accept a limited amount of HTML, and is optional
 		 */
-		$_REQUEST['form-errors'] = array();	
+		$_REQUEST['form-errors'] = array();
 		// Check if name field was filled in
 		if( empty( $new_name ) )
 			$_REQUEST['form-errors']['name'] = __( 'Please enter a name for the editorial metadata', 'edit-flow' );
-			
+
 		// Check that the name isn't numeric
 		if ( is_numeric( $new_name ) )
 			$_REQUEST['form-errors']['name'] = __( 'Please enter a valid, non-numeric name for the editorial metadata.', 'edit-flow' );
@@ -1123,16 +1133,16 @@ class EF_Editorial_Metadata extends EF_Module {
 		$term_exists = term_exists( sanitize_title( $new_name ) );
 		if ( $term_exists && $term_exists != $existing_term->term_id )
 			$_REQUEST['form-errors']['name'] = __( 'Metadata name conflicts with existing term. Please choose another.', 'edit-flow' );
-			
+
 		// Check to ensure a term with the same name doesn't exist,
 		$search_term = $this->get_editorial_metadata_term_by( 'name', $new_name );
 		if ( is_object( $search_term ) && $search_term->term_id != $existing_term->term_id )
 			$_REQUEST['form-errors']['name'] = __( 'Name already in use. Please choose another.', 'edit-flow' );
-		// or that the term name doesn't map to an existing term's slug			
+		// or that the term name doesn't map to an existing term's slug
 		$search_term = $this->get_editorial_metadata_term_by( 'slug', sanitize_title( $new_name ) );
 		if ( is_object( $search_term ) && $search_term->term_id != $existing_term->term_id )
-			$_REQUEST['form-errors']['name'] = __( 'Name conflicts with slug for another term. Please choose something else.', 'edit-flow' );					
-		
+			$_REQUEST['form-errors']['name'] = __( 'Name conflicts with slug for another term. Please choose something else.', 'edit-flow' );
+
 		// Check that the term name doesn't exceed 200 chars
 		if ( strlen( $new_name ) > 200 )
 			$_REQUEST['form-errors']['name'] = __( 'Name cannot exceed 200 characters. Please try a shorter name.', 'edit-flow' );
@@ -1140,13 +1150,13 @@ class EF_Editorial_Metadata extends EF_Module {
 		$new_viewable = false;
 		if ( $_POST['viewable'] == 'yes' )
 			$new_viewable = true;
-	
+
 		// Kick out if there are any errors
 		if ( count( $_REQUEST['form-errors'] ) ) {
 			$_REQUEST['error'] = 'form-error';
 			return;
 		}
-		
+
 		// Try to add the metadata term
 		$args = array(
 			'name' => $new_name,
@@ -1156,39 +1166,39 @@ class EF_Editorial_Metadata extends EF_Module {
 		$return = $this->update_editorial_metadata_term( $existing_term->term_id, $args );
 		if ( is_wp_error( $return ) )
 			wp_die( __( 'Error updating term.', 'edit-flow' ) );
-		
+
 		$redirect_url = add_query_arg( array( 'page' => $this->module->settings_slug, 'message' => 'term-updated' ), get_admin_url( null, 'admin.php' ) );
 		wp_redirect( $redirect_url );
 		exit;
 	}
-	
+
 	/**
 	 * Handle a $_GET request to change the visibility of an Editorial Metadata term
 	 *
 	 * @since 0.7
 	 */
 	function handle_change_editorial_metadata_visibility() {
-		
-		// Check that the current GET request is our GET request		
+
+		// Check that the current GET request is our GET request
 		if ( !isset( $_GET['page'], $_GET['action'], $_GET['term-id'], $_GET['nonce'] )
 			|| $_GET['page'] != $this->module->settings_slug || !in_array( $_GET['action'], array( 'make-viewable', 'make-hidden' ) ) )
 			return;
-		
+
 		// Check for proper nonce
 		if ( !wp_verify_nonce( $_GET['nonce'], 'make-viewable' ) && !wp_verify_nonce( $_GET['nonce'], 'make-hidden' ) )
 			wp_die( $this->module->messages['nonce-failed'] );
-		
+
 		// Only allow users with the proper caps
 		if ( !current_user_can( 'manage_options' ) )
 			wp_die( $this->module->messages['invalid-permissions'] );
-		
+
 		$term_id = (int)$_GET['term-id'];
 		$args = array();
 		if ( $_GET['action'] == 'make-viewable' )
 			$args['viewable'] = true;
 		elseif ( $_GET['action'] == 'make-hidden' )
 			$args['viewable'] = false;
-		
+
 		$return = $this->update_editorial_metadata_term( $term_id, $args );
 		if ( is_wp_error( $return ) )
 			wp_die( __( 'Error updating term.', 'edit-flow' ) );
@@ -1196,32 +1206,32 @@ class EF_Editorial_Metadata extends EF_Module {
 		$redirect_url = $this->get_link( array( 'message' => 'term-visibility-changed' ) );
 		wp_redirect( $redirect_url );
 		exit;
-		
+
 	}
-	
+
 	/**
 	 * Handle the request to update a given Editorial Metadata term via inline edit
 	 *
 	 * @since 0.7
 	 */
 	function handle_ajax_inline_save_term() {
-		
+
 		if ( !wp_verify_nonce( $_POST['inline_edit'], 'editorial-metadata-inline-edit-nonce' ) )
 			die( $this->module->messages['nonce-failed'] );
-			
+
 		if ( !current_user_can( 'manage_options') )
 			die( $this->module->messages['invalid-permissions'] );
-		
+
 		$term_id = (int) $_POST['term_id'];
 		if ( !$existing_term = $this->get_editorial_metadata_term_by( 'id', $term_id ) )
 			die( $this->module->messages['term-missing'] );
-		
+
 		$metadata_name = sanitize_text_field( trim( $_POST['name'] ) );
 		$metadata_description = stripslashes( wp_filter_post_kses( trim( $_POST['description'] ) ) );
-		
+
 		/**
 		 * Form validation for editing editorial metadata term
-		 */	
+		 */
 		// Check if name field was filled in
 		if ( empty( $metadata_name ) ) {
 			$change_error = new WP_Error( 'invalid', __( 'Please enter a name for the editorial metadata', 'edit-flow' ) );
@@ -1233,20 +1243,20 @@ class EF_Editorial_Metadata extends EF_Module {
 			$change_error = new WP_Error( 'invalid', __( 'Please enter a valid, non-numeric name for the editorial metadata.', 'edit-flow' ) );
 			die( $change_error->get_error_message() );
 		}
-		
+
 		// Check that the term name doesn't exceed 200 chars
 		if ( strlen( $metadata_name ) > 200 ) {
 			$change_error = new WP_Error( 'invalid', __( 'Name cannot exceed 200 characters. Please try a shorter name.' ) );
 			die( $change_error->get_error_message() );
 		}
-		
+
 		// Check to make sure the status doesn't already exist as another term because otherwise we'd get a fatal error
 		$term_exists = term_exists( sanitize_title( $metadata_name ) );
 		if ( $term_exists && $term_exists != $term_id ) {
 			$change_error = new WP_Error( 'invalid', __( 'Metadata name conflicts with existing term. Please choose another.', 'edit-flow' ) );
 			die( $change_error->get_error_message() );
-		}		
-		
+		}
+
 		// Check to ensure a term with the same name doesn't exist,
 		$search_term = $this->get_editorial_metadata_term_by( 'name', $metadata_name );
 		if ( is_object( $search_term ) && $search_term->term_id != $existing_term->term_id ) {
@@ -1254,21 +1264,21 @@ class EF_Editorial_Metadata extends EF_Module {
 			die( $change_error->get_error_message() );
 		}
 
-		// or that the term name doesn't map to an existing term's slug			
+		// or that the term name doesn't map to an existing term's slug
 		$search_term = $this->get_editorial_metadata_term_by( 'slug', sanitize_title( $metadata_name ) );
 		if ( is_object( $search_term ) && $search_term->term_id != $existing_term->term_id ) {
 			$change_error = new WP_Error( 'invalid', __( 'Name conflicts with slug for another term. Please choose again.', 'edit-flow' ) );
-			die( $change_error->get_error_message() );			
+			die( $change_error->get_error_message() );
 		}
-		
+
 		// Prepare the term name and description for saving
 		$args = array(
 			'name' => $metadata_name,
 			'description' => $metadata_description,
 		);
 		$return = $this->update_editorial_metadata_term( $existing_term->term_id, $args );
-		if( !is_wp_error( $return ) ) {	
-			set_current_screen( 'edit-editorial-metadata' );					
+		if( !is_wp_error( $return ) ) {
+			set_current_screen( 'edit-editorial-metadata' );
 			$wp_list_table = new EF_Editorial_Metadata_List_Table();
 			$wp_list_table->prepare_items();
 			echo $wp_list_table->single_row( $return );
@@ -1277,9 +1287,9 @@ class EF_Editorial_Metadata extends EF_Module {
 			$change_error = new WP_Error( 'invalid', sprintf( __( 'Could not update the term: <strong>%s</strong>', 'edit-flow' ), $status_name ) );
 			die( $change_error->get_error_message() );
 		}
-		
+
 	}
-	
+
 	/**
 	 * Handle the ajax request to update all of the term positions
 	 *
@@ -1289,15 +1299,15 @@ class EF_Editorial_Metadata extends EF_Module {
 
 		if ( !wp_verify_nonce( $_POST['editorial_metadata_sortable_nonce'], 'editorial-metadata-sortable' ) )
 			$this->print_ajax_response( 'error', $this->module->messages['nonce-failed'] );
-		
+
 		if ( !current_user_can( 'manage_options') )
 			$this->print_ajax_response( 'error', $this->module->messages['invalid-permissions'] );
-		
+
 		if ( !isset( $_POST['term_positions'] ) || !is_array( $_POST['term_positions'] ) )
 			$this->print_ajax_response( 'error', __( 'Terms not set.', 'edit-flow' ) );
-			
+
 		foreach ( $_POST['term_positions'] as $position => $term_id ) {
-			
+
 			// Have to add 1 to the position because the index started with zero
 			$args = array(
 				'position' => (int)$position + 1,
@@ -1305,46 +1315,46 @@ class EF_Editorial_Metadata extends EF_Module {
 			$return = $this->update_editorial_metadata_term( (int)$term_id, $args );
 			// @todo check that this was a valid return
 		}
-		$this->print_ajax_response( 'success', $this->module->messages['term-position-updated'] );	
+		$this->print_ajax_response( 'success', $this->module->messages['term-position-updated'] );
 	}
-	
+
 	/**
 	 * Handles a request to delete an editorial metadata term
 	 */
 	function handle_delete_editorial_metadata() {
-		if ( !isset( $_GET['page'], $_GET['action'], $_GET['term-id'] ) 
+		if ( !isset( $_GET['page'], $_GET['action'], $_GET['term-id'] )
 			|| $_GET['page'] != $this->module->settings_slug || $_GET['action'] != 'delete-term' )
 				return;
-				
+
 		if ( !wp_verify_nonce( $_GET['nonce'], 'delete-term' ) )
 			wp_die( $this->module->messages['nonce-failed'] );
-			
+
 		if ( !current_user_can( 'manage_options' ) )
 			wp_die( $this->module->messages['invalid-permissions'] );
-			
+
 		if ( !$existing_term = $this->get_editorial_metadata_term_by( 'id', (int)$_GET['term-id'] ) )
-			wp_die( $this->module->messages['term-missing'] );			
-			
+			wp_die( $this->module->messages['term-missing'] );
+
 		$result = $this->delete_editorial_metadata_term( $existing_term->term_id );
 		if ( !$result || is_wp_error( $result ) )
 			wp_die( __( 'Error deleting term.', 'edit-flow' ) );
-			
+
 		$redirect_url = add_query_arg( array( 'page' => $this->module->settings_slug, 'message' => 'term-deleted' ), get_admin_url( null, 'admin.php' ) );
 		wp_redirect( $redirect_url );
-		exit;		
+		exit;
 	}
-	
+
 	/**
 	 * Register settings for notifications so we can partially use the Settings API
 	 * (We use the Settings API for form generation, but not saving)
-	 * 
+	 *
 	 * @since 0.7
 	 * @uses add_settings_section(), add_settings_field()
 	 */
 	function register_settings() {
 			add_settings_section( $this->module->options_group_name . '_general', false, '__return_false', $this->module->options_group_name );
 			add_settings_field( 'post_types', __( 'Add to these post types:', 'edit-flow' ), array( $this, 'settings_post_types_option' ), $this->module->options_group_name, $this->module->options_group_name . '_general' );
-	}	
+	}
 
 	/**
 	 * Choose the post types for editorial metadata
@@ -1365,15 +1375,15 @@ class EF_Editorial_Metadata extends EF_Module {
 	 * @return array $new_options Form values after they've been sanitized
 	 */
 	function settings_validate( $new_options ) {
-		
+
 		// Whitelist validation for the post type options
 		if ( !isset( $new_options['post_types'] ) )
 			$new_options['post_types'] = array();
-		$new_options['post_types'] = $this->clean_post_type_options( $new_options['post_types'], $this->module->post_type_support );		
-		
+		$new_options['post_types'] = $this->clean_post_type_options( $new_options['post_types'], $this->module->post_type_support );
+
 		return $new_options;
 	}
-	
+
 	/**
 	 * Prepare and display the configuration view for editorial metadata.
 	 * There are four primary components:
@@ -1383,7 +1393,7 @@ class EF_Editorial_Metadata extends EF_Module {
 	 * - Full page width view for editing a single Editorial Metadata term
 	 *
 	 * @since 0.7
-	 */ 
+	 */
 	function print_configure_view() {
 		global $edit_flow;
 		$wp_list_table = new EF_Editorial_Metadata_List_Table();
@@ -1402,8 +1412,8 @@ class EF_Editorial_Metadata extends EF_Module {
 		</div>
 		</div><!-- /col-right -->
 		<?php $wp_list_table->inline_edit(); ?>
-		<?php endif; ?>	
-		
+		<?php endif; ?>
+
 		<?php if ( isset( $_GET['action'], $_GET['term-id'] ) && $_GET['action'] == 'edit-term' ): ?>
 		<?php /** Full page width view for editing a given editorial metadata term **/ ?>
 		<?php
@@ -1412,12 +1422,12 @@ class EF_Editorial_Metadata extends EF_Module {
 			$term = $this->get_editorial_metadata_term_by( 'id', $term_id );
 			if ( !$term ) {
 				echo '<div class="error"><p>' . $this->module->messages['term-missing'] . '</p></div>';
-				return; 
+				return;
 			}
-			$metadata_types = $this->get_supported_metadata_types();			
+			$metadata_types = $this->get_supported_metadata_types();
 			$type = $term->type;
 			$edit_term_link = $this->get_link( array( 'action' => 'edit-term', 'term-id' => $term->term_id ) );
-			
+
 			$name = ( isset( $_POST['name'] ) ) ? stripslashes( $_POST['name'] ) : $term->name;
 			$description = ( isset( $_POST['description'] ) ) ? stripslashes( $_POST['description'] ) : $term->description;
 			if ( $term->viewable )
@@ -1426,7 +1436,7 @@ class EF_Editorial_Metadata extends EF_Module {
 				$viewable = 'no';
 			$viewable = ( isset( $_POST['viewable'] ) ) ? stripslashes( $_POST['viewable'] ) : $viewable;
 		?>
-		
+
 		<form method="post" action="<?php echo esc_url( $edit_term_link ); ?>" >
 		<input type="hidden" name="action" value="editedtag" />
 		<input type="hidden" name="tag_id" value="<?php echo esc_attr( $term->term_id ); ?>" />
@@ -1447,7 +1457,7 @@ class EF_Editorial_Metadata extends EF_Module {
 					<input type="text" disabled="disabled" value="<?php echo esc_attr( $term->slug ); ?>" />
 					<p class="description"><?php _e( 'The slug cannot be changed once the term has been created.', 'edit-flow' ); ?></p>
 				</td>
-			</tr>			
+			</tr>
 			<tr class="form-field">
 				<th scope="row" valign="top"><label for="description"><?php _e( 'Description', 'edit-flow' ); ?></label></th>
 				<td>
@@ -1486,22 +1496,22 @@ class EF_Editorial_Metadata extends EF_Module {
 		<a class="cancel-settings-link" href="<?php echo esc_url( add_query_arg( 'page', $this->module->settings_slug, get_admin_url( null, 'admin.php' ) ) ); ?>"><?php _e( 'Cancel', 'edit-flow' ); ?></a>
 		</p>
 		</form>
-		
+
 		<?php else: ?>
 		<?php /** If not in full-screen edit term mode, we can create new terms or change options **/ ?>
 		<div id="col-left">
-			<div class="col-wrap">	
+			<div class="col-wrap">
 			<div class="form-wrap">
 			<h3 class="nav-tab-wrapper">
 				<a href="<?php echo esc_url( add_query_arg( array( 'page' => $this->module->settings_slug ), get_admin_url( null, 'admin.php' ) ) ); ?>" class="nav-tab<?php if ( !isset( $_GET['action'] ) || $_GET['action'] != 'change-options' ) echo ' nav-tab-active'; ?>"><?php _e( 'Add New', 'edit-flow' ); ?></a>
 				<a href="<?php echo esc_url( add_query_arg( array( 'page' => $this->module->settings_slug, 'action' => 'change-options' ), get_admin_url( null, 'admin.php' ) ) ); ?>" class="nav-tab<?php if ( isset( $_GET['action'] ) && $_GET['action'] == 'change-options' ) echo ' nav-tab-active'; ?>"><?php _e( 'Options', 'edit-flow' ); ?></a>
 			</h3>
-			
+
 		<?php if ( isset( $_GET['action'] ) && $_GET['action'] == 'change-options' ): ?>
 		<?php /** Basic form built on WP Settings API for outputting Editorial Metadata options **/ ?>
 		<form class="basic-settings" action="<?php echo esc_url( add_query_arg( array( 'page' => $this->module->settings_slug, 'action' => 'change-options' ), get_admin_url( null, 'admin.php' ) ) ); ?>" method="post">
 			<?php settings_fields( $this->module->options_group_name ); ?>
-			<?php do_settings_sections( $this->module->options_group_name ); ?>	
+			<?php do_settings_sections( $this->module->options_group_name ); ?>
 			<?php echo '<input id="edit_flow_module_name" name="edit_flow_module_name" type="hidden" value="' . esc_attr( $this->module->name ) . '" />'; ?>
 			<?php submit_button(); ?>
 		</form>
@@ -1561,11 +1571,11 @@ class EF_Editorial_Metadata extends EF_Module {
 			</div>
 			</div>
 		</div>
-		
+
 		<?php
 		endif;
 	}
-	
+
 }
 
 }
@@ -1574,7 +1584,7 @@ class EF_Editorial_Metadata extends EF_Module {
  * Management interface for Editorial Metadata. Extends WP_List_Table class
  */
 class EF_Editorial_Metadata_List_Table extends WP_List_Table {
-	
+
 	var $callback_args;
 	var $taxonomy;
 	var $tax;
@@ -1586,16 +1596,16 @@ class EF_Editorial_Metadata_List_Table extends WP_List_Table {
 		global $edit_flow;
 
 		$this->taxonomy = EF_Editorial_Metadata::metadata_taxonomy;
-		
+
 		$this->tax = get_taxonomy( $this->taxonomy );
-		
+
 		$columns = $this->get_columns();
 		$hidden = array(
 			'position',
 		);
 		$sortable = array();
-		
-		$this->_column_headers = array( $columns, $hidden, $sortable );		
+
+		$this->_column_headers = array( $columns, $hidden, $sortable );
 
 		parent::__construct( array(
 			'plural' => 'editorial metadata',
@@ -1626,24 +1636,24 @@ class EF_Editorial_Metadata_List_Table extends WP_List_Table {
 	function no_items() {
 		_e( 'No editorial metadata found.', 'edit-flow' );
 	}
-	
+
 	/**
 	 * Register the columns to appear in the table
 	 *
 	 * @since 0.7
 	 */
 	function get_columns() {
-		
+
 		$columns = array(
 			'position'	  => __( 'Position', 'edit-flow' ),
 			'name'        => __( 'Name', 'edit-flow' ),
 			'type'		  => __( 'Metadata Type', 'edit-flow' ),
 			'description' => __( 'Description', 'edit-flow' ),
 			'viewable'    => __( 'Viewable', 'edit-flow' ),
-		);		
+		);
 		return $columns;
 	}
-	
+
 	/**
 	 * Prepare a single row of Editorial Metadata
 	 *
@@ -1661,7 +1671,7 @@ class EF_Editorial_Metadata_List_Table extends WP_List_Table {
  		echo $this->single_row_columns( $term );
  		echo '</tr>';
 	}
-	
+
 	/**
 	 * Handle the column output when there's no method for it
 	 *
@@ -1671,7 +1681,7 @@ class EF_Editorial_Metadata_List_Table extends WP_List_Table {
 	 * @param string $column_name How the column was registered at birth
 	 */
 	function column_default( $item, $column_name ) {
-		
+
 		switch( $column_name ) {
 			case 'position':
 			case 'type':
@@ -1681,13 +1691,13 @@ class EF_Editorial_Metadata_List_Table extends WP_List_Table {
 			case 'viewable':
 				if ( $item->viewable )
 					return __( 'Yes', 'edit-flow' );
-				else 
+				else
 					return __( 'No', 'edit-flow' );
 				break;
 			default:
 				break;
 		}
-		
+
 	}
 
 	/**
@@ -1701,9 +1711,9 @@ class EF_Editorial_Metadata_List_Table extends WP_List_Table {
 		global $edit_flow;
 		$item_edit_link = esc_url( $edit_flow->editorial_metadata->get_link( array( 'action' => 'edit-term', 'term-id' => $item->term_id ) ) );
 		$item_delete_link = esc_url( $edit_flow->editorial_metadata->get_link( array( 'action' => 'delete-term', 'term-id' => $item->term_id ) ) );
-		
+
 		$out = '<strong><a class="row-title" href="' . $item_edit_link . '">' . esc_html( $item->name ) . '</a></strong>';
-		
+
 		$actions = array();
 		$actions['edit'] = "<a href='$item_edit_link'>" . __( 'Edit', 'edit-flow' ) . "</a>";
 		$actions['inline hide-if-no-js'] = '<a href="#" class="editinline">' . __( 'Quick&nbsp;Edit' ) . '</a>';
@@ -1712,13 +1722,13 @@ class EF_Editorial_Metadata_List_Table extends WP_List_Table {
 		else
 			$actions['change-visibility make-viewable'] = '<a title="' . esc_attr( __( 'When viewable, metadata can be seen on views other than the edit post view (e.g. calendar, manage posts, story budget, etc.)', 'edit-flow' ) ) . '" href="' . esc_url( $edit_flow->editorial_metadata->get_link( array( 'action' => 'make-viewable', 'term-id' => $item->term_id ) ) ) . '">' . __( 'Make Viewable', 'edit-flow' ) . '</a>';
 		$actions['delete delete-status'] = "<a href='$item_delete_link'>" . __( 'Delete', 'edit-flow' ) . "</a>";
-		
+
 		$out .= $this->row_actions( $actions, false );
 		$out .= '<div class="hidden" id="inline_' . $item->term_id . '">';
 		$out .= '<div class="name">' . $item->name . '</div>';
-		$out .= '<div class="description">' . $item->description . '</div>';	
+		$out .= '<div class="description">' . $item->description . '</div>';
 		$out .= '</div>';
-		
+
 		return $out;
 	}
 


### PR DESCRIPTION
## Description

This PR is meant to add the ability to expire the content of a post, on a set date. This is done by:

- Introducing a new custom status called expired
- Introducing a new field called expiry date

When the expiry date is set, a task is made to set the post's status as expired. That in turn, if notifications have been subscribed to, will notify groups or users.

The intention is that, we want to slowly build in more workflow features on top of this plugin and this is our stepping stone to that.

## Steps to Test

1. Draft up a new post.
2. Set the expiry date on it.
3. Publish it.
4. Check the cron list using wp-cli to ensure a task with the name `ef_unpublish_post_task` has been made.
5. Go in and update the expiry date on that post.
6. Check the cron list using wp-cli to ensure the task's date has been updated.
7. Wait for the task's date to pass.
8. Check the post to see that it's status was changes to `expired`. This will be visible in the story budget view.
9. Repeat this test, but this time delete the expired status and ensure the status is set to `pending`.

Note: If you are using the `vip dev-env` to test this PR, you'll need to manually run the task as cron doesn't run with the dev-env.
