### PR TITLE
Bump the minimim version of php to 8.0

### DIFF
--- a/.github/workflows/php-tests.yml
+++ b/.github/workflows/php-tests.yml
@@ -18,8 +18,8 @@ jobs:
       matrix:
         include:
           # Check lowest supported WP version, with the lowest supported PHP.
-          - php: '7.4'
-            wp: '5.9'
+          - php: '8.0'
+            wp: '6.0'
             allowed_failure: false
           # Check latest WP with the highest supported PHP.
           - php: 'latest'

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
   },
   "require": {
     "composer/installers": "~1.0",
-    "php": ">=7.4"
+    "php": ">=8.0"
   },
   "require-dev": {
     "automattic/vipwpcs": "^3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5cf9481316e1e0b6e33ee6392c28d45a",
+    "content-hash": "b52213b4b3d6b33a45a906d80d77b46e",
     "packages": [
         {
             "name": "composer/installers",
@@ -2255,16 +2255,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.10.0",
+            "version": "3.10.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
-                "reference": "57e09801c2fbae2d257b8b75bebb3deeb7e9deb2"
+                "reference": "8f90f7a53ce271935282967f53d0894f8f1ff877"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/57e09801c2fbae2d257b8b75bebb3deeb7e9deb2",
-                "reference": "57e09801c2fbae2d257b8b75bebb3deeb7e9deb2",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/8f90f7a53ce271935282967f53d0894f8f1ff877",
+                "reference": "8f90f7a53ce271935282967f53d0894f8f1ff877",
                 "shasum": ""
             },
             "require": {
@@ -2331,7 +2331,7 @@
                     "type": "open_collective"
                 }
             ],
-            "time": "2024-05-20T08:11:32+00:00"
+            "time": "2024-05-22T21:24:41+00:00"
         },
         {
             "name": "theseer/tokenizer",
@@ -2519,7 +2519,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=7.4"
+        "php": ">=8.0"
     },
     "platform-dev": [],
     "plugin-api-version": "2.6.0"

--- a/edit_flow.php
+++ b/edit_flow.php
@@ -1,31 +1,17 @@
 <?php
-/*
-Plugin Name: Edit Flow
-Plugin URI: http://editflow.org/
-Description: Remixing the WordPress admin for better editorial workflow options.
-Author: Daniel Bachhuber, Scott Bressler, Mohammad Jangda, Automattic, and others
-Version: 0.9.8
-Author URI: http://editflow.org/
-
-Copyright 2009-2019 Mohammad Jangda, Daniel Bachhuber, Automattic, et al.
-
-GNU General Public License, Free Software Foundation <http://creativecommons.org/licenses/GPL/2.0/>
-
-This program is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 2 of the License, or
-(at your option) any later version.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this program; if not, write to the Free Software
-Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
-
-*/
+/**
+ * Plugin Name: Edit Flow
+ * Plugin URI: http://editflow.org/
+ * Description: Remixing the WordPress admin for better editorial workflow options.
+ * Author: Daniel Bachhuber, Scott Bressler, Mohammad Jangda, Automattic, and others
+ * Version: 0.9.8
+ * Requires at least: 6.0
+ * Requires PHP: 8.0
+ * License: GPL-3
+ * License URI: https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * Copyright 2009-2019 Mohammad Jangda, Daniel Bachhuber, Automattic, et al.
+ */
 
 /**
  * Print admin notice regarding having an old version of PHP.
@@ -35,12 +21,12 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 function _ef_print_php_version_admin_notice() {
 	?>
 	<div class="notice notice-error">
-			<p><?php esc_html_e( 'Edit Flow requires PHP 7.4+. Please contact your host to update your PHP version.', 'edit-flow' ); ?></p>
+			<p><?php esc_html_e( 'Edit Flow requires PHP 8.0+. Please contact your host to update your PHP version.', 'edit-flow' ); ?></p>
 		</div>
 	<?php
 }
 
-if ( version_compare( phpversion(), '7.4', '<' ) ) {
+if ( version_compare( phpversion(), '8.0', '<' ) ) {
 	add_action( 'admin_notices', '_ef_print_php_version_admin_notice' );
 	return;
 }


### PR DESCRIPTION
## Description

Bump the minimum version of php to 8.0, as well as the minimum WP version to 6.0. As a result of this, the packages in `composer.json` have been updated and the GH workflow has been modified to run against 8.0/6.0 rather than 7.4/5.9.

