### PR TITLE
Lint the various modules

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,10 +21,10 @@
   },
   "scripts": {
     "cs": [
-      "@php ./vendor/bin/phpcs -p -s -v -n . --standard=\"phpcs.xml.dist\" --extensions=php --ignore=\"/vendor/*,/node_modules/*,/tests/*\""
+      "@php ./vendor/bin/phpcs -p -s -v -n . --standard=\"phpcs.xml.dist\" --extensions=php --ignore=\"/vendor/*,/node_modules/*,/tests/*,/common/*\""
     ],
     "cbf": [
-      "@php ./vendor/bin/phpcbf -p -s -v -n . --standard=\"phpcs.xml.dist\" --extensions=php --ignore=\"/vendor/*,/node_modules/*,/tests/*\""
+      "@php ./vendor/bin/phpcbf -p -s -v -n . --standard=\"phpcs.xml.dist\" --extensions=php --ignore=\"/vendor/*,/node_modules/*,/tests/*,/common/*\""
     ],
     "integration": "wp-env run tests-cli --env-cwd=wp-content/plugins/Edit-Flow ./vendor/bin/phpunit",
     "integration-ms": "wp-env run tests-cli --env-cwd=wp-content/plugins/Edit-Flow /bin/bash -c 'WP_MULTISITE=1 ./vendor/bin/phpunit'"

--- a/composer.json
+++ b/composer.json
@@ -21,10 +21,10 @@
   },
   "scripts": {
     "cs": [
-      "@php ./vendor/bin/phpcs -p -s -v -n . --standard=\"WordPress-VIP-Go\" --extensions=php --ignore=\"/vendor/*,/node_modules/*,/tests/*\""
+      "@php ./vendor/bin/phpcs -p -s -v -n . --standard=\"phpcs.xml.dist\" --extensions=php --ignore=\"/vendor/*,/node_modules/*,/tests/*\""
     ],
     "cbf": [
-      "@php ./vendor/bin/phpcbf -p -s -v -n . --standard=\"WordPress-VIP-Go\" --extensions=php --ignore=\"/vendor/*,/node_modules/*,/tests/*\""
+      "@php ./vendor/bin/phpcbf -p -s -v -n . --standard=\"phpcs.xml.dist\" --extensions=php --ignore=\"/vendor/*,/node_modules/*,/tests/*\""
     ],
     "integration": "wp-env run tests-cli --env-cwd=wp-content/plugins/Edit-Flow ./vendor/bin/phpunit",
     "integration-ms": "wp-env run tests-cli --env-cwd=wp-content/plugins/Edit-Flow /bin/bash -c 'WP_MULTISITE=1 ./vendor/bin/phpunit'"

--- a/edit-flow.php
+++ b/edit-flow.php
@@ -8,4 +8,4 @@
  *
  * Since this is not the primary plugin file, it does not have the standard WordPress headers.
  */
-require_once dirname( __FILE__ ) . '/edit_flow.php';
+require_once __DIR__ . '/edit_flow.php';

--- a/edit_flow.php
+++ b/edit_flow.php
@@ -189,9 +189,9 @@ class edit_flow {
 	 * Inititalizes the Edit Flows!
 	 * Loads options for each registered module and then initializes it if it's active
 	 */
-	function action_init() {
+	public function action_init() {
 
-		load_plugin_textdomain( 'edit-flow', null, dirname( plugin_basename( __FILE__ ) ) . '/languages/' );
+		load_plugin_textdomain( 'edit-flow', false, dirname( plugin_basename( __FILE__ ) ) . '/languages/' );
 
 		$this->load_modules();
 
@@ -218,7 +218,7 @@ class edit_flow {
 	/**
 	 * Initialize the plugin for the admin
 	 */
-	function action_admin_init() {
+	public function action_admin_init() {
 
 		// Upgrade if need be but don't run the upgrade if the plugin has never been used
 		$previous_version = get_option( $this->options_group . 'version' );
@@ -315,7 +315,7 @@ class edit_flow {
 	 * Load all of the module options from the database
 	 * If a given option isn't yet set, then set it to the module's default (upgrades, etc.)
 	 */
-	function load_module_options() {
+	public function load_module_options() {
 
 		foreach ( $this->modules as $mod_name => $mod_data ) {
 
@@ -343,7 +343,7 @@ class edit_flow {
 	 *
 	 * @see http://dev.editflow.org/2011/11/17/edit-flow-v0-7-alpha2-notes/#comment-232
 	 */
-	function action_init_after() {
+	public function action_init_after() {
 		foreach ( $this->modules as $mod_name => $mod_data ) {
 
 			if ( isset( $this->modules->$mod_name->options->post_types ) ) {
@@ -360,7 +360,7 @@ class edit_flow {
 	 * @param string $key The property to use for searching a module (ex: 'name')
 	 * @param string|int|array $value The value to compare (using ==)
 	 */
-	function get_module_by( $key, $value ) {
+	public function get_module_by( $key, $value ) {
 		$module = false;
 		foreach ( $this->modules as $mod_name => $mod_data ) {
 
@@ -380,13 +380,13 @@ class edit_flow {
 	/**
 	 * Update the $edit_flow object with new value and save to the database
 	 */
-	function update_module_option( $mod_name, $key, $value ) {
+	public function update_module_option( $mod_name, $key, $value ) {
 		$this->modules->$mod_name->options->$key = $value;
 		$this->$mod_name->module                 = $this->modules->$mod_name;
 		return update_option( $this->options_group . $mod_name . '_options', $this->modules->$mod_name->options );
 	}
 
-	function update_all_module_options( $mod_name, $new_options ) {
+	public function update_all_module_options( $mod_name, $new_options ) {
 		if ( is_array( $new_options ) ) {
 			$new_options = (object) $new_options;
 		}
@@ -398,7 +398,7 @@ class edit_flow {
 	/**
 	 * Registers commonly used scripts + styles for easy enqueueing
 	 */
-	function register_scripts_and_styles() {
+	public function register_scripts_and_styles() {
 		wp_enqueue_style( 'ef-admin-css', EDIT_FLOW_URL . 'common/css/edit-flow-admin.css', false, EDIT_FLOW_VERSION, 'all' );
 
 		wp_register_script( 'jquery-listfilterizer', EDIT_FLOW_URL . 'common/js/jquery.listfilterizer.js', array( 'jquery' ), EDIT_FLOW_VERSION, true );
@@ -418,6 +418,7 @@ class edit_flow {
 	}
 }
 
+// phpcs:disable WordPress.NamingConventions.ValidFunctionName.FunctionNameInvalid
 function EditFlow() {
 	return edit_flow::instance();
 }

--- a/modules/calendar/calendar.php
+++ b/modules/calendar/calendar.php
@@ -5,697 +5,706 @@
  *
  * @author danielbachhuber
  */
-if ( !class_exists('EF_Calendar') ) {
+if ( ! class_exists( 'EF_Calendar' ) ) {
 
-class EF_Calendar extends EF_Module {
+	class EF_Calendar extends EF_Module {
 
-	const usermeta_key_prefix = 'ef_calendar_';
-	const screen_id = 'dashboard_page_calendar';
+		// phpcs:ignore Generic.NamingConventions.UpperCaseConstantName.ClassConstantNotUpperCase
+		const usermeta_key_prefix = 'ef_calendar_';
+		// phpcs:ignore Generic.NamingConventions.UpperCaseConstantName.ClassConstantNotUpperCase
+		const screen_id = 'dashboard_page_calendar';
 
-	var $module;
+		public $module;
 
-	var $start_date = '';
-	var $current_week = 1;
-	var $total_weeks = 6; // default number of weeks to show per screen
-	var $hidden = 0; // counter of hidden posts per date square
-	var $max_visible_posts_per_date = 4; // total number of posts to be shown per square before 'more' link
+		public $start_date = '';
+		public $current_week = 1;
+		public $total_weeks = 6; // default number of weeks to show per screen
+		public $hidden = 0; // counter of hidden posts per date square
+		public $max_visible_posts_per_date = 4; // total number of posts to be shown per square before 'more' link
 
-	private $post_date_cache = array();
-	private static $post_li_html_cache_key = 'ef_calendar_post_li_html';
-	private int $max_weeks;
-	private string $create_post_cap;
+		private $post_date_cache = array();
+		private static $post_li_html_cache_key = 'ef_calendar_post_li_html';
+		private int $max_weeks;
+		private string $create_post_cap;
 
-	/**
-	 * Calendar published statuses are the same as other
-	 * components but without the future
-	 */
-	public $published_statuses = array(
-		'publish',
-		'private',
-	);
-
-	/**
-	 * Construct the EF_Calendar class
-	 */
-	function __construct() {
-		$this->max_weeks = 12;
-
-		$this->module_url = $this->get_module_url( __FILE__ );
-		// Register the module with Edit Flow
-		$args = array(
-			'title' => __( 'Calendar', 'edit-flow' ),
-			'short_description' => sprintf( __( 'View upcoming content in a <a href="%s">customizable calendar</a>.', 'edit-flow' ), admin_url( 'index.php?page=calendar' ) ),
-			'extended_description' => __( 'Edit Flow’s calendar lets you see your posts over a customizable date range. Filter by status or click on the post title to see its details. Drag and drop posts between days to change their publication date.', 'edit-flow' ),
-			'module_url' => $this->module_url,
-			'img_url' => $this->module_url . 'lib/calendar_s128.png',
-			'slug' => 'calendar',
-			'post_type_support' => 'ef_calendar',
-			'default_options' => array(
-				'enabled' => 'on',
-				'post_types' => array(
-					'post' => 'on',
-					'page' => 'off',
-				),
-				'quick_create_post_type' => 'post',
-				'ics_subscription' => 'off',
-				'ics_secret_key' => '',
-			),
-			'messages' => array(
-				'post-date-updated' => __( "Post date updated.", 'edit-flow' ),
-				'update-error' => __( 'There was an error updating the post. Please try again.', 'edit-flow' ),
-				'published-post-ajax' => __( "Updating the post date dynamically doesn't work for published content. Please <a href='%s'>edit the post</a>.", 'edit-flow' ),
-				'key-regenerated' => __( 'iCal secret key regenerated. Please inform all users they will need to resubscribe.', 'edit-flow' ),
-			),
-			'configure_page_cb' => 'print_configure_view',
-			'configure_link_text' => __( 'Calendar Options', 'edit-flow' ),
-			'settings_help_tab' => array(
-				'id' => 'ef-calendar-overview',
-				'title' => __('Overview', 'edit-flow'),
-				'content' => __('<p>The calendar is a convenient week-by-week or month-by-month view into your content. Quickly see which stories are on track to being published on time, and which will need extra effort.</p>', 'edit-flow'),
-				),
-			'settings_help_sidebar' => __( '<p><strong>For more information:</strong></p><p><a href="http://editflow.org/features/calendar/">Calendar Documentation</a></p><p><a href="http://wordpress.org/tags/edit-flow?forum_id=10">Edit Flow Forum</a></p><p><a href="https://github.com/danielbachhuber/Edit-Flow">Edit Flow on Github</a></p>', 'edit-flow' ),
-		);
-		$this->module = EditFlow()->register_module( 'calendar', $args );
-
-	}
-
-	/**
-	 * Initialize all of our methods and such. Only runs if the module is active
-	 *
-	 * @uses add_action()
-	 */
-	function init() {
-
-		// .ics calendar subscriptions
-		add_action( 'wp_ajax_ef_calendar_ics_subscription', array( $this, 'handle_ics_subscription' ) );
-		add_action( 'wp_ajax_nopriv_ef_calendar_ics_subscription', array( $this, 'handle_ics_subscription' ) );
-
-		// Check whether the user should have the ability to view the calendar
-		$view_calendar_cap = 'ef_view_calendar';
-		$view_calendar_cap = apply_filters( 'ef_view_calendar_cap', $view_calendar_cap );
-		if ( !current_user_can( $view_calendar_cap ) ) return false;
-
-		// Define the create-post capability
-		$this->create_post_cap = apply_filters( 'ef_calendar_create_post_cap', 'edit_posts' );
-
-		add_action( 'admin_init', array( $this, 'add_screen_options_panel' ) );
-		add_action( 'admin_init', array( $this, 'handle_save_screen_options' ) );
-
-		add_action( 'admin_init', array( $this, 'register_settings' ) );
-		add_action( 'admin_menu', array( $this, 'action_admin_menu' ) );
-		add_action( 'admin_print_styles', array( $this, 'add_admin_styles' ) );
-		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_admin_scripts' ) );
-
-		// Ajax manipulation for the calendar
-		add_action( 'wp_ajax_ef_calendar_drag_and_drop', array( $this, 'handle_ajax_drag_and_drop' ) );
-
-		// Ajax insert post placeholder for a specific date
-		add_action( 'wp_ajax_ef_insert_post', array( $this, 'handle_ajax_insert_post' ) );
-
-		//Update metadata
-		add_action( 'wp_ajax_ef_calendar_update_metadata', array( $this, 'handle_ajax_update_metadata' ) );
-
-		// Clear li cache for a post when post cache is cleared
-		add_action( 'clean_post_cache', array( $this, 'action_clean_li_html_cache' ) );
-
-		// Action to regenerate the calendar feed sekret
-		add_action( 'admin_init', array( $this, 'handle_regenerate_calendar_feed_secret' ) );
-
-		// Hacks to fix deficiencies in core
-		add_action( 'pre_post_update', array( $this, 'fix_post_date_on_update_part_one' ), 10, 2 );
-		add_action( 'post_updated', array( $this, 'fix_post_date_on_update_part_two' ), 10, 3 );
-	}
-
-	/**
-	 * Load the capabilities onto users the first time the module is run
-	 *
-	 * @since 0.7
-	 */
-	function install() {
-
-		// Add necessary capabilities to allow management of calendar
-		// view_calendar - administrator --> contributor
-		$calendar_roles = array(
-			'administrator' => array('ef_view_calendar'),
-			'editor' =>        array('ef_view_calendar'),
-			'author' =>        array('ef_view_calendar'),
-			'contributor' =>   array('ef_view_calendar')
+		/**
+		 * Calendar published statuses are the same as other
+		 * components but without the future
+		 */
+		public $published_statuses = array(
+			'publish',
+			'private',
 		);
 
-		foreach ( $calendar_roles as $role => $caps ) {
-			$this->add_caps_to_role( $role, $caps );
-		}
-	}
+		/**
+		 * Construct the EF_Calendar class
+		 */
+		public function __construct() {
+			$this->max_weeks = 12;
 
-	/**
-	 * Upgrade our data in case we need to
-	 *
-	 * @since 0.7
-	 */
-	function upgrade( $previous_version ) {
-		global $edit_flow;
-
-		// Upgrade path to v0.7
-		if ( version_compare( $previous_version, '0.7' , '<' ) ) {
-			// Migrate whether the calendar was enabled or not and clean up old option
-			if ( $enabled = get_option( 'edit_flow_calendar_enabled' ) )
-				$enabled = 'on';
-			else
-				$enabled = 'off';
-			$edit_flow->update_module_option( $this->module->name, 'enabled', $enabled );
-			delete_option( 'edit_flow_calendar_enabled' );
-
-			// Technically we've run this code before so we don't want to auto-install new data
-			$edit_flow->update_module_option( $this->module->name, 'loaded_once', true );
-		}
-
-	}
-
-	/**
-	 * Add the calendar link underneath the "Dashboard"
-	 *
-	 * @uses add_submenu_page
-	 */
-	function action_admin_menu() {
-		add_submenu_page('index.php', __('Calendar', 'edit-flow'), __('Calendar', 'edit-flow'), apply_filters( 'ef_view_calendar_cap', 'ef_view_calendar' ), $this->module->slug, array( $this, 'view_calendar' ) );
-	}
-
-	/**
-	 * Add any necessary CSS to the WordPress admin
-	 *
-	 * @uses wp_enqueue_style()
-	 */
-	function add_admin_styles() {
-		global $pagenow;
-		// Only load calendar styles on the calendar page
-		if ( 'index.php' === $pagenow && isset( $_GET['page'] ) && 'calendar' === $_GET['page'] ) {
-			wp_enqueue_style( 'edit-flow-calendar-css', $this->module_url . 'lib/calendar.css', false, EDIT_FLOW_VERSION );
-			wp_enqueue_style( 'edit-flow-calendar-react-css', $this->module_url . 'lib/dist/calendar.react.style.build.css', array( 'wp-components' ), EDIT_FLOW_VERSION );
-		}
-	}
-
-	/**
-	 * Add any necessary JS to the WordPress admin
-	 *
-	 * @since 0.7
-	 * @uses wp_enqueue_script()
-	 */
-	function enqueue_admin_scripts() {
-		global $pagenow;
-
-		if ( 'index.php' === $pagenow && isset( $_GET['page'] ) && 'calendar' === $_GET['page'] ) {
-			$this->enqueue_datepicker_resources();
-
-			$js_libraries = array(
-				'jquery',
-				'jquery-ui-core',
-				'jquery-ui-sortable',
-				'jquery-ui-draggable',
-				'jquery-ui-droppable',
-				'wp-data'
+			$this->module_url = $this->get_module_url( __FILE__ );
+			// Register the module with Edit Flow
+			$args = array(
+				'title' => __( 'Calendar', 'edit-flow' ),
+				/* translators: %s: URL to the calendar page */
+				'short_description' => sprintf( __( 'View upcoming content in a <a href="%s">customizable calendar</a>.', 'edit-flow' ), admin_url( 'index.php?page=calendar' ) ),
+				'extended_description' => __( 'Edit Flow’s calendar lets you see your posts over a customizable date range. Filter by status or click on the post title to see its details. Drag and drop posts between days to change their publication date.', 'edit-flow' ),
+				'module_url' => $this->module_url,
+				'img_url' => $this->module_url . 'lib/calendar_s128.png',
+				'slug' => 'calendar',
+				'post_type_support' => 'ef_calendar',
+				'default_options' => array(
+					'enabled' => 'on',
+					'post_types' => array(
+						'post' => 'on',
+						'page' => 'off',
+					),
+					'quick_create_post_type' => 'post',
+					'ics_subscription' => 'off',
+					'ics_secret_key' => '',
+				),
+				'messages' => array(
+					'post-date-updated' => __( 'Post date updated.', 'edit-flow' ),
+					'update-error' => __( 'There was an error updating the post. Please try again.', 'edit-flow' ),
+					/* translators: %s: URL to the published post */
+					'published-post-ajax' => __( "Updating the post date dynamically doesn't work for published content. Please <a href='%s'>edit the post</a>.", 'edit-flow' ),
+					'key-regenerated' => __( 'iCal secret key regenerated. Please inform all users they will need to resubscribe.', 'edit-flow' ),
+				),
+				'configure_page_cb' => 'print_configure_view',
+				'configure_link_text' => __( 'Calendar Options', 'edit-flow' ),
+				'settings_help_tab' => array(
+					'id' => 'ef-calendar-overview',
+					'title' => __( 'Overview', 'edit-flow' ),
+					'content' => __( '<p>The calendar is a convenient week-by-week or month-by-month view into your content. Quickly see which stories are on track to being published on time, and which will need extra effort.</p>', 'edit-flow' ),
+				),
+				'settings_help_sidebar' => __( '<p><strong>For more information:</strong></p><p><a href="http://editflow.org/features/calendar/">Calendar Documentation</a></p><p><a href="http://wordpress.org/tags/edit-flow?forum_id=10">Edit Flow Forum</a></p><p><a href="https://github.com/danielbachhuber/Edit-Flow">Edit Flow on Github</a></p>', 'edit-flow' ),
 			);
-			foreach( $js_libraries as $js_library ) {
-				wp_enqueue_script( $js_library );
+			$this->module = EditFlow()->register_module( 'calendar', $args );
+		}
+
+		/**
+		 * Initialize all of our methods and such. Only runs if the module is active
+		 *
+		 * @uses add_action()
+		 */
+		public function init() {
+
+			// .ics calendar subscriptions
+			add_action( 'wp_ajax_ef_calendar_ics_subscription', array( $this, 'handle_ics_subscription' ) );
+			add_action( 'wp_ajax_nopriv_ef_calendar_ics_subscription', array( $this, 'handle_ics_subscription' ) );
+
+			// Check whether the user should have the ability to view the calendar
+			$view_calendar_cap = 'ef_view_calendar';
+			$view_calendar_cap = apply_filters( 'ef_view_calendar_cap', $view_calendar_cap );
+			if ( ! current_user_can( $view_calendar_cap ) ) {
+				return false;
 			}
-			wp_enqueue_script( 'edit-flow-calendar-js', $this->module_url . 'lib/calendar.js', $js_libraries, EDIT_FLOW_VERSION, true );
 
-			$ef_cal_js_params = array( 'can_add_posts' => current_user_can( $this->create_post_cap ) ? 'true' : 'false' );
-			wp_localize_script( 'edit-flow-calendar-js', 'ef_calendar_params', $ef_cal_js_params );
+			// Define the create-post capability
+			$this->create_post_cap = apply_filters( 'ef_calendar_create_post_cap', 'edit_posts' );
 
-			/**
-			 * Powering the new React interface
-			 */
-			wp_enqueue_script( 'edit-flow-calendar-react-js', $this->module_url . 'lib/dist/calendar.react.build.js', array( 'react', 'react-dom', 'wp-components', 'wp-url', 'wp-data', 'moment' ), EDIT_FLOW_VERSION, true );
+			add_action( 'admin_init', array( $this, 'add_screen_options_panel' ) );
+			add_action( 'admin_init', array( $this, 'handle_save_screen_options' ) );
 
-			wp_add_inline_script(
-				'edit-flow-calendar-react-js',
-				'var EF_CALENDAR = ' . wp_json_encode( $this->get_calendar_frontend_config() ),
-				'before'
-			);
+			add_action( 'admin_init', array( $this, 'register_settings' ) );
+			add_action( 'admin_menu', array( $this, 'action_admin_menu' ) );
+			add_action( 'admin_print_styles', array( $this, 'add_admin_styles' ) );
+			add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_admin_scripts' ) );
+
+			// Ajax manipulation for the calendar
+			add_action( 'wp_ajax_ef_calendar_drag_and_drop', array( $this, 'handle_ajax_drag_and_drop' ) );
+
+			// Ajax insert post placeholder for a specific date
+			add_action( 'wp_ajax_ef_insert_post', array( $this, 'handle_ajax_insert_post' ) );
+
+			//Update metadata
+			add_action( 'wp_ajax_ef_calendar_update_metadata', array( $this, 'handle_ajax_update_metadata' ) );
+
+			// Clear li cache for a post when post cache is cleared
+			add_action( 'clean_post_cache', array( $this, 'action_clean_li_html_cache' ) );
+
+			// Action to regenerate the calendar feed sekret
+			add_action( 'admin_init', array( $this, 'handle_regenerate_calendar_feed_secret' ) );
+
+			// Hacks to fix deficiencies in core
+			add_action( 'pre_post_update', array( $this, 'fix_post_date_on_update_part_one' ), 10, 2 );
+			add_action( 'post_updated', array( $this, 'fix_post_date_on_update_part_two' ), 10, 3 );
 		}
 
-	}
+		/**
+		 * Load the capabilities onto users the first time the module is run
+		 *
+		 * @since 0.7
+		 */
+		public function install() {
 
-	/**
-	 * Prepare the options that need to appear in Screen Options
-	 *
-	 * @since 0.7
-	 */
-	function generate_screen_options() {
+			// Add necessary capabilities to allow management of calendar
+			// view_calendar - administrator --> contributor
+			$calendar_roles = array(
+				'administrator' => array( 'ef_view_calendar' ),
+				'editor' => array( 'ef_view_calendar' ),
+				'author' => array( 'ef_view_calendar' ),
+				'contributor' => array( 'ef_view_calendar' ),
+			);
 
-		$output = '';
+			foreach ( $calendar_roles as $role => $caps ) {
+				$this->add_caps_to_role( $role, $caps );
+			}
+		}
 
-		$args = array(
+		/**
+		 * Upgrade our data in case we need to
+		 *
+		 * @since 0.7
+		 */
+		public function upgrade( $previous_version ) {
+			global $edit_flow;
+
+			// Upgrade path to v0.7
+			if ( version_compare( $previous_version, '0.7', '<' ) ) {
+				// Migrate whether the calendar was enabled or not and clean up old option
+				$enabled = get_option( 'edit_flow_calendar_enabled' );
+				if ( $enabled ) {
+					$enabled = 'on';
+				} else {
+					$enabled = 'off';
+				}
+				$edit_flow->update_module_option( $this->module->name, 'enabled', $enabled );
+				delete_option( 'edit_flow_calendar_enabled' );
+
+				// Technically we've run this code before so we don't want to auto-install new data
+				$edit_flow->update_module_option( $this->module->name, 'loaded_once', true );
+			}
+		}
+
+		/**
+		 * Add the calendar link underneath the "Dashboard"
+		 *
+		 * @uses add_submenu_page
+		 */
+		public function action_admin_menu() {
+			add_submenu_page( 'index.php', __( 'Calendar', 'edit-flow' ), __( 'Calendar', 'edit-flow' ), apply_filters( 'ef_view_calendar_cap', 'ef_view_calendar' ), $this->module->slug, array( $this, 'view_calendar' ) );
+		}
+
+		/**
+		 * Add any necessary CSS to the WordPress admin
+		 *
+		 * @uses wp_enqueue_style()
+		 */
+		public function add_admin_styles() {
+			global $pagenow;
+			// Only load calendar styles on the calendar page
+			if ( 'index.php' === $pagenow && isset( $_GET['page'] ) && 'calendar' === $_GET['page'] ) {
+				wp_enqueue_style( 'edit-flow-calendar-css', $this->module_url . 'lib/calendar.css', false, EDIT_FLOW_VERSION );
+				wp_enqueue_style( 'edit-flow-calendar-react-css', $this->module_url . 'lib/dist/calendar.react.style.build.css', array( 'wp-components' ), EDIT_FLOW_VERSION );
+			}
+		}
+
+		/**
+		 * Add any necessary JS to the WordPress admin
+		 *
+		 * @since 0.7
+		 * @uses wp_enqueue_script()
+		 */
+		public function enqueue_admin_scripts() {
+			global $pagenow;
+
+			if ( 'index.php' === $pagenow && isset( $_GET['page'] ) && 'calendar' === $_GET['page'] ) {
+				$this->enqueue_datepicker_resources();
+
+				$js_libraries = array(
+					'jquery',
+					'jquery-ui-core',
+					'jquery-ui-sortable',
+					'jquery-ui-draggable',
+					'jquery-ui-droppable',
+					'wp-data',
+				);
+				foreach ( $js_libraries as $js_library ) {
+					wp_enqueue_script( $js_library );
+				}
+				wp_enqueue_script( 'edit-flow-calendar-js', $this->module_url . 'lib/calendar.js', $js_libraries, EDIT_FLOW_VERSION, true );
+
+				$ef_cal_js_params = array( 'can_add_posts' => current_user_can( $this->create_post_cap ) ? 'true' : 'false' );
+				wp_localize_script( 'edit-flow-calendar-js', 'ef_calendar_params', $ef_cal_js_params );
+
+				/**
+				 * Powering the new React interface
+				 */
+				wp_enqueue_script( 'edit-flow-calendar-react-js', $this->module_url . 'lib/dist/calendar.react.build.js', array( 'react', 'react-dom', 'wp-components', 'wp-url', 'wp-data', 'moment' ), EDIT_FLOW_VERSION, true );
+
+				wp_add_inline_script(
+					'edit-flow-calendar-react-js',
+					'var EF_CALENDAR = ' . wp_json_encode( $this->get_calendar_frontend_config() ),
+					'before'
+				);
+			}
+		}
+
+		/**
+		 * Prepare the options that need to appear in Screen Options
+		 *
+		 * @since 0.7
+		 */
+		public function generate_screen_options() {
+
+			$output = '';
+
+			$args = array(
 				'action'       => 'ef_calendar_ics_subscription',
 				'user'         => wp_get_current_user()->user_login,
 				'user_key'     => md5( wp_get_current_user()->user_login . $this->module->options->ics_secret_key ),
 			);
-		$subscription_link = add_query_arg( $args, admin_url( 'admin-ajax.php' ) );
-		$output .= '<br />';
-		$output .= __( 'Subscribe in iCal or Google Calendar', 'edit-flow' );
-		$output .= ':<br /><input type="text" size="100" value="' . esc_attr( $subscription_link ) . '" />';
+			$subscription_link = add_query_arg( $args, admin_url( 'admin-ajax.php' ) );
+			$output .= '<br />';
+			$output .= __( 'Subscribe in iCal or Google Calendar', 'edit-flow' );
+			$output .= ':<br /><input type="text" size="100" value="' . esc_attr( $subscription_link ) . '" />';
 
-		return $output;
-	}
-
-	/**
-	 * Add module options to the screen panel
-	 *
-	 * @since 0.8.3
-	 */
-	function add_screen_options_panel() {
-		require_once( EDIT_FLOW_ROOT . '/common/php/' . 'screen-options.php' );
-		if ( 'on' == $this->module->options->ics_subscription && $this->module->options->ics_secret_key ) {
-			add_screen_options_panel( self::usermeta_key_prefix . 'screen_options', __( 'Calendar Options', 'edit-flow' ), array( $this, 'generate_screen_options' ), self::screen_id, false, true );
-		}
-	}
-
-	/**
-	 * Handle the request to save the screen options
-	 *
-	 * @since 0.7
-	 */
-	function handle_save_screen_options() {
-
-		// Only handle screen options submissions from the current screen
-		if ( ! isset( $_POST['screen-options-apply'] ) )
-			return;
-
-		// Nonce check
-		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-		if ( !isset( $_POST['_wpnonce-' . self::usermeta_key_prefix . 'screen_options'] ) || !wp_verify_nonce ( $_POST['_wpnonce-' . self::usermeta_key_prefix . 'screen_options'], 'save_settings-' . self::usermeta_key_prefix . 'screen_options' ) ) {
-			wp_die( esc_html( $this->module->messages['nonce-failed'] ) );
+			return $output;
 		}
 
-		// Get the current screen options
-		$screen_options = $this->get_screen_options();
-
-		// Save the screen options
-		$current_user = wp_get_current_user();
-		$this->update_user_meta( $current_user->ID, self::usermeta_key_prefix . 'screen_options', $screen_options );
-
-		// Redirect after we're complete
-		$redirect_to = menu_page_url( $this->module->slug, false );
-		wp_redirect( $redirect_to );
-		exit;
-	}
-
-	/**
-	 * Handle an AJAX request from the calendar to update a post's timestamp.
-	 * Notes:
-	 * - For Post Time, if the post is unpublished, the change sets the publication timestamp
-	 * - If the post was published or scheduled for the future, the change will change the timestamp. 'publish' posts
-	 * will become scheduled if moved past today and 'future' posts will be published if moved before today
-	 * - Need to respect user permissions. Editors can move all, authors can move their own, and contributors can't move at all
-	 *
-	 * @since 0.7
-	 */
-	function handle_ajax_drag_and_drop() {
-		global $wpdb;
-
-		// Nonce check!
-		if ( !isset( $_POST['nonce'] ) || !wp_verify_nonce( $_POST['nonce'], 'ef-calendar-modify' ) ) { // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-			$this->print_ajax_response( 'error', $this->module->messages['nonce-failed'] );
-		}
-
-		if ( !isset( $_POST['post_id'] ) ) {
-			$this->print_ajax_response( 'error', $this->module->messages['missing-post'] );
-		}
-
-		// Check that we got a proper post
-		$post_id = (int) $_POST['post_id'];
-		$post = get_post( $post_id );
-		if ( !$post ) {
-			$this->print_ajax_response( 'error', $this->module->messages['missing-post'] );
-		}
-
-		// Check that the user can modify the post
-		if ( !$this->current_user_can_modify_post( $post ) ) {
-			$this->print_ajax_response( 'error', $this->module->messages['invalid-permissions'] );
-		}
-
-		// Check that it's not yet published
-		if ( in_array( $post->post_status, $this->published_statuses ) ) {
-			$this->print_ajax_response( 'error', sprintf( $this->module->messages['published-post-ajax'], get_edit_post_link( $post_id ) ) );
-		}
-
-		if ( !isset( $_POST['next_date'] ) ) {
-			$this->print_ajax_response( 'error', __( 'Missing new date.', 'edit-flow' ) );
-		}
-
-		// Check that the new date passed is a valid one
-		$next_date_full = strtotime( $_POST['next_date'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-		if ( !$next_date_full ) {
-			$this->print_ajax_response( 'error', __( 'Something is wrong with the format for the new date.', 'edit-flow' ) );
-		}
-
-		// Persist the old hourstamp because we can't manipulate the exact time on the calendar
-		// Bump the last modified timestamps too
-		$existing_time = date( 'H:i:s', strtotime( $post->post_date ) );
-		$existing_time_gmt = date( 'H:i:s', strtotime( $post->post_date_gmt ) );
-		$new_values = array(
-			'post_date' => date( 'Y-m-d', $next_date_full ) . ' ' . $existing_time,
-			'post_modified' => current_time( 'mysql' ),
-			'post_modified_gmt' => current_time( 'mysql', 1 ),
-		);
-
-		// By default, changing a post on the calendar won't set the timestamp.
-		// If the user desires that to be the behaviour, they can set the result of this filter to 'true'
-		// With how WordPress works internally, setting 'post_date_gmt' will set the timestamp
-		if ( apply_filters( 'ef_calendar_allow_ajax_to_set_timestamp', false ) ) {
-			$new_values['post_date_gmt'] = date( 'Y-m-d', $next_date_full ) . ' ' . $existing_time_gmt;
-		}
-
-		// We have to do SQL unfortunately because of core bugginess
-		// Note to those reading this: bug Nacin to allow us to finish the custom status API
-		// See http://core.trac.wordpress.org/ticket/18362
-		$response = $wpdb->update( $wpdb->posts, $new_values, array( 'ID' => $post->ID ) );
-		clean_post_cache( $post->ID );
-
-		if ( !$response ) {
-			$this->print_ajax_response( 'error', $this->module->messages['update-error'] );
-		}
-
-		$this->print_ajax_response( 'success', $this->module->messages['post-date-updated'] );
-		exit;
-	}
-
-	/**
-	 * After checking that the request is valid, do an .ics file
-	 *
-	 * @since 0.8
-	 */
-	function handle_ics_subscription() {
-
-		// Only do .ics subscriptions when the option is active
-		if ( 'on' != $this->module->options->ics_subscription )
-			die(); // @todo return accepted response value.
-
-		// Confirm all of the arguments are present
-		if ( ! isset( $_GET['user'], $_GET['user_key'] ) ) // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-			die(); // @todo return an error response
-
-		// Confirm this is a valid request
-		$user = sanitize_user( $_GET['user'] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		$user_key = sanitize_user( $_GET['user_key'] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		$ics_secret_key = $this->module->options->ics_secret_key;
-		if ( ! $ics_secret_key || md5( $user . $ics_secret_key ) !== $user_key ) {
-			die( esc_html( $this->module->messages['nonce-failed'] ) );
-		}
-
-		// Set up the post data to be printed
-		$post_query_args = array();
-		$calendar_filters = $this->calendar_filters();
-		foreach( $calendar_filters as $filter ) {
-			if ( isset( $_GET[$filter] ) && false !== ( $value = $this->sanitize_filter( $filter, $_GET[$filter] ) ) ) //phpcs:ignore WordPress.Security.NonceVerification.Recommended
-				$post_query_args[$filter] = $value;
-		}
-
-		// Set the start date for the posts_where filter
-		$this->start_date = apply_filters( 'ef_calendar_ics_subscription_start_date', $this->get_beginning_of_week( date( 'Y-m-d', current_time( 'timestamp' ) ) ) );
-
-		$this->total_weeks = apply_filters( 'ef_calendar_total_weeks', $this->total_weeks, 'ics_subscription' );
-
-		$formatted_posts = array();
-		for( $current_week = 1; $current_week <= $this->total_weeks; $current_week++ ) {
-			// We need to set the object variable for our posts_where filter
-			$this->current_week = $current_week;
-			$week_posts = $this->get_calendar_posts_for_week( $post_query_args, 'ics_subscription' );
-			foreach( $week_posts as $date => $day_posts ) {
-				foreach( $day_posts as $num => $post ) {
-
-					$start_date    = self::ics_format_time( $post->post_date );
-					$end_date      = self::ics_format_time( $post->post_date, 5 * MINUTE_IN_SECONDS );
-					$last_modified = self::ics_format_time( $post->post_modified );
-					$post_status_obj = get_post_status_object( get_post_status( $post->ID ) );
-					// Remove the convert chars and wptexturize filters from the title
-					remove_filter( 'the_title', 'convert_chars' );
-					remove_filter( 'the_title', 'wptexturize' );
-
-					$formatted_post = array(
-						'BEGIN'           => 'VEVENT',
-						'UID'             => $post->guid,
-						'SUMMARY'         => $this->do_ics_escaping( apply_filters( 'the_title', $post->post_title ) ) . ' - ' . $post_status_obj->label,
-						'DTSTART'         => $start_date,
-						'DTEND'           => $end_date,
-						'LAST-MODIFIED'   => $last_modified,
-						'URL'             => get_post_permalink( $post->ID ),
-					);
-
-					// Description should include everything visible in the calendar popup
-					$information_fields = $this->get_post_information_fields( $post );
-					$formatted_post['DESCRIPTION'] = '';
-					if ( ! empty( $information_fields ) ) {
-						foreach( $information_fields as $key => $values ) {
-							$formatted_post['DESCRIPTION'] .= $values['label'] . ': ' . $values['value'] . '\n';
-						}
-						$formatted_post['DESCRIPTION'] = rtrim( $formatted_post['DESCRIPTION'] );
-					}
-
-					$formatted_post['END'] = 'VEVENT';
-
-					// @todo auto format any field longer than 75 bytes
-
-					$formatted_posts[] = $formatted_post;
-				}
+		/**
+		 * Add module options to the screen panel
+		 *
+		 * @since 0.8.3
+		 */
+		public function add_screen_options_panel() {
+			require_once EDIT_FLOW_ROOT . '/common/php/screen-options.php';
+			if ( 'on' == $this->module->options->ics_subscription && $this->module->options->ics_secret_key ) {
+				add_screen_options_panel( self::usermeta_key_prefix . 'screen_options', __( 'Calendar Options', 'edit-flow' ), array( $this, 'generate_screen_options' ), self::screen_id, false, true );
 			}
 		}
 
-		// Other template data
-		$header = array(
+		/**
+		 * Handle the request to save the screen options
+		 *
+		 * @since 0.7
+		 */
+		public function handle_save_screen_options() {
+
+			// Only handle screen options submissions from the current screen
+			if ( ! isset( $_POST['screen-options-apply'] ) ) {
+				return;
+			}
+
+			// Nonce check
+			// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+			if ( ! isset( $_POST[ '_wpnonce-' . self::usermeta_key_prefix . 'screen_options' ] ) || ! wp_verify_nonce( $_POST[ '_wpnonce-' . self::usermeta_key_prefix . 'screen_options' ], 'save_settings-' . self::usermeta_key_prefix . 'screen_options' ) ) {
+				wp_die( esc_html( $this->module->messages['nonce-failed'] ) );
+			}
+
+			// Get the current screen options
+			$screen_options = $this->get_screen_options();
+
+			// Save the screen options
+			$current_user = wp_get_current_user();
+			$this->update_user_meta( $current_user->ID, self::usermeta_key_prefix . 'screen_options', $screen_options );
+
+			// Redirect after we're complete
+			$redirect_to = menu_page_url( $this->module->slug, false );
+			wp_redirect( $redirect_to );
+			exit;
+		}
+
+		/**
+		 * Handle an AJAX request from the calendar to update a post's timestamp.
+		 * Notes:
+		 * - For Post Time, if the post is unpublished, the change sets the publication timestamp
+		 * - If the post was published or scheduled for the future, the change will change the timestamp. 'publish' posts
+		 * will become scheduled if moved past today and 'future' posts will be published if moved before today
+		 * - Need to respect user permissions. Editors can move all, authors can move their own, and contributors can't move at all
+		 *
+		 * @since 0.7
+		 */
+		public function handle_ajax_drag_and_drop() {
+			global $wpdb;
+
+			// Nonce check!
+			if ( ! isset( $_POST['nonce'] ) || ! wp_verify_nonce( $_POST['nonce'], 'ef-calendar-modify' ) ) { // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+				$this->print_ajax_response( 'error', $this->module->messages['nonce-failed'] );
+			}
+
+			if ( ! isset( $_POST['post_id'] ) ) {
+				$this->print_ajax_response( 'error', $this->module->messages['missing-post'] );
+			}
+
+			// Check that we got a proper post
+			$post_id = (int) $_POST['post_id'];
+			$post = get_post( $post_id );
+			if ( ! $post ) {
+				$this->print_ajax_response( 'error', $this->module->messages['missing-post'] );
+			}
+
+			// Check that the user can modify the post
+			if ( ! $this->current_user_can_modify_post( $post ) ) {
+				$this->print_ajax_response( 'error', $this->module->messages['invalid-permissions'] );
+			}
+
+			// Check that it's not yet published
+			if ( in_array( $post->post_status, $this->published_statuses ) ) {
+				$this->print_ajax_response( 'error', sprintf( $this->module->messages['published-post-ajax'], get_edit_post_link( $post_id ) ) );
+			}
+
+			if ( ! isset( $_POST['next_date'] ) ) {
+				$this->print_ajax_response( 'error', __( 'Missing new date.', 'edit-flow' ) );
+			}
+
+			// Check that the new date passed is a valid one
+			$next_date_full = strtotime( $_POST['next_date'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+			if ( ! $next_date_full ) {
+				$this->print_ajax_response( 'error', __( 'Something is wrong with the format for the new date.', 'edit-flow' ) );
+			}
+
+			// Persist the old hourstamp because we can't manipulate the exact time on the calendar
+			// Bump the last modified timestamps too
+			$existing_time = gmdate( 'H:i:s', strtotime( $post->post_date ) );
+			$existing_time_gmt = gmdate( 'H:i:s', strtotime( $post->post_date_gmt ) );
+			$new_values = array(
+				'post_date' => gmdate( 'Y-m-d', $next_date_full ) . ' ' . $existing_time,
+				'post_modified' => current_time( 'mysql' ),
+				'post_modified_gmt' => current_time( 'mysql', 1 ),
+			);
+
+			// By default, changing a post on the calendar won't set the timestamp.
+			// If the user desires that to be the behaviour, they can set the result of this filter to 'true'
+			// With how WordPress works internally, setting 'post_date_gmt' will set the timestamp
+			if ( apply_filters( 'ef_calendar_allow_ajax_to_set_timestamp', false ) ) {
+				$new_values['post_date_gmt'] = gmdate( 'Y-m-d', $next_date_full ) . ' ' . $existing_time_gmt;
+			}
+
+			// We have to do SQL unfortunately because of core bugginess
+			// Note to those reading this: bug Nacin to allow us to finish the custom status API
+			// See http://core.trac.wordpress.org/ticket/18362
+			$response = $wpdb->update( $wpdb->posts, $new_values, array( 'ID' => $post->ID ) );
+			clean_post_cache( $post->ID );
+
+			if ( ! $response ) {
+				$this->print_ajax_response( 'error', $this->module->messages['update-error'] );
+			}
+
+			$this->print_ajax_response( 'success', $this->module->messages['post-date-updated'] );
+			exit;
+		}
+
+		/**
+		 * After checking that the request is valid, do an .ics file
+		 *
+		 * @since 0.8
+		 */
+		public function handle_ics_subscription() {
+
+			// Only do .ics subscriptions when the option is active
+			if ( 'on' != $this->module->options->ics_subscription ) {
+				die(); // @todo return accepted response value.
+			}
+
+			// Confirm all of the arguments are present
+			if ( ! isset( $_GET['user'], $_GET['user_key'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+				die(); // @todo return an error response
+			}
+
+			// Confirm this is a valid request
+			$user = sanitize_user( $_GET['user'] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			$user_key = sanitize_user( $_GET['user_key'] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			$ics_secret_key = $this->module->options->ics_secret_key;
+			if ( ! $ics_secret_key || md5( $user . $ics_secret_key ) !== $user_key ) {
+				die( esc_html( $this->module->messages['nonce-failed'] ) );
+			}
+
+			// Set up the post data to be printed
+			$post_query_args = array();
+			$calendar_filters = $this->calendar_filters();
+			foreach ( $calendar_filters as $filter ) {
+				if ( isset( $_GET[ $filter ] ) && false !== ( $value = $this->sanitize_filter( $filter, $_GET[ $filter ] ) ) ) { //phpcs:ignore WordPress.Security.NonceVerification.Recommended
+					$post_query_args[ $filter ] = $value;
+				}
+			}
+
+			// Set the start date for the posts_where filter
+			$this->start_date = apply_filters( 'ef_calendar_ics_subscription_start_date', $this->get_beginning_of_week( gmdate( 'Y-m-d', current_time( 'timestamp' ) ) ) );
+
+			$this->total_weeks = apply_filters( 'ef_calendar_total_weeks', $this->total_weeks, 'ics_subscription' );
+
+			$formatted_posts = array();
+			for ( $current_week = 1; $current_week <= $this->total_weeks; $current_week++ ) {
+				// We need to set the object variable for our posts_where filter
+				$this->current_week = $current_week;
+				$week_posts = $this->get_calendar_posts_for_week( $post_query_args, 'ics_subscription' );
+				foreach ( $week_posts as $date => $day_posts ) {
+					foreach ( $day_posts as $num => $post ) {
+
+						$start_date    = self::ics_format_time( $post->post_date );
+						$end_date      = self::ics_format_time( $post->post_date, 5 * MINUTE_IN_SECONDS );
+						$last_modified = self::ics_format_time( $post->post_modified );
+						$post_status_obj = get_post_status_object( get_post_status( $post->ID ) );
+						// Remove the convert chars and wptexturize filters from the title
+						remove_filter( 'the_title', 'convert_chars' );
+						remove_filter( 'the_title', 'wptexturize' );
+
+						$formatted_post = array(
+							'BEGIN'           => 'VEVENT',
+							'UID'             => $post->guid,
+							'SUMMARY'         => $this->do_ics_escaping( apply_filters( 'the_title', $post->post_title ) ) . ' - ' . $post_status_obj->label,
+							'DTSTART'         => $start_date,
+							'DTEND'           => $end_date,
+							'LAST-MODIFIED'   => $last_modified,
+							'URL'             => get_post_permalink( $post->ID ),
+						);
+
+						// Description should include everything visible in the calendar popup
+						$information_fields = $this->get_post_information_fields( $post );
+						$formatted_post['DESCRIPTION'] = '';
+						if ( ! empty( $information_fields ) ) {
+							foreach ( $information_fields as $key => $values ) {
+								$formatted_post['DESCRIPTION'] .= $values['label'] . ': ' . $values['value'] . '\n';
+							}
+							$formatted_post['DESCRIPTION'] = rtrim( $formatted_post['DESCRIPTION'] );
+						}
+
+						$formatted_post['END'] = 'VEVENT';
+
+						// @todo auto format any field longer than 75 bytes
+
+						$formatted_posts[] = $formatted_post;
+					}
+				}
+			}
+
+			// Other template data
+			$header = array(
 				'BEGIN'             => 'VCALENDAR',
 				'VERSION'           => '2.0',
 				'PRODID'            => '-//Edit Flow//Edit Flow ' . EDIT_FLOW_VERSION . '//EN',
 			);
 
-		$footer = array(
+			$footer = array(
 				'END'               => 'VCALENDAR',
 			);
 
-		// Render the .ics template and set the content type
-		header( 'Content-type: text/calendar' );
-		foreach( array( $header, $formatted_posts, $footer ) as $section ) {
-			foreach( $section as $key => $value ) {
-				/**
-				 * This is output to text/calendar content-type
-				 */
-				if ( is_string( $value ) )
-					echo $this->do_ics_line_folding( $key . ':' . $value ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-				else
-					foreach( $value as $k => $v ) {
-						echo $this->do_ics_line_folding( $k . ':' . $v ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+			// Render the .ics template and set the content type
+			header( 'Content-type: text/calendar' );
+			foreach ( array( $header, $formatted_posts, $footer ) as $section ) {
+				foreach ( $section as $key => $value ) {
+					/**
+					 * This is output to text/calendar content-type
+					 */
+					if ( is_string( $value ) ) {
+						echo $this->do_ics_line_folding( $key . ':' . $value ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+					} else {
+						foreach ( $value as $k => $v ) {
+							echo $this->do_ics_line_folding( $k . ':' . $v ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+						}
 					}
+				}
 			}
+			die();
 		}
-		die();
-
-	}
-
-	/**
-	 * Perform line folding according to RFC 5545.
-	 *
-	 * @param string $line The line without trailing CRLF
-	 * @return string The line after line-folding with all necessary CRLF.
-	 */
-	function do_ics_line_folding( $line ) {
-		$len = mb_strlen( $line );
-		if ( $len <= 75) {
-			return $line . "\r\n";
-		}
-
-		$chunks = array();
-		$start = 0;
-		while( true ) {
-			$chunk = mb_substr( $line, $start, 75 );
-			$chunkLen = mb_strlen( $chunk );
-			$start += $chunkLen;
-			if ( $start < $len ) {
-				$chunks[] = $chunk . "\r\n ";
-			}
-			else {
-				$chunks[] = $chunk ."\r\n";
-				return implode( "", $chunks );
-			}
-		}
-	}
-
-	/**
-	 * Perform the encoding necessary for ICS feed text.
-	 *
-	 * @param string $text The string that needs to be escaped
-	 * @return string The string after escaping for ICS.
-	 * @since 0.8
-	 * */
-
-	function do_ics_escaping( $text ) {
-		$text = str_replace( ",", "\,", $text );
-		$text = str_replace( ";", "\:", $text );
-		$text = str_replace( "\\", "\\\\", $text );
-		return $text;
-	}
-
-	/**
-	 * Convert a time string into a `.ics` formatted time string with the proper GMT offset
-	 *
-	 * @param     $time_string       - Any time string that `strtotime()` can understand
-	 * @param int $offset_in_seconds - Allows to offset the timestamp generated from $time_string
-	 *
-	 * @return string|false
-	 */
-	public static function ics_format_time( $time_string, $offset_in_seconds = 0) {
-
-		// Timestamp it
-		$timestamp = strtotime( $time_string );
-
-		if( ! $timestamp ) {
-			return false;
-		}
-
-		// Subtract GMT Offset to return to UTC+0
-		$timestamp -= get_option('gmt_offset') * HOUR_IN_SECONDS;
-
-		// Add manual offset
-		$timestamp += $offset_in_seconds;
-
-		// \T and \Z are escaped for literal T and Z characters
-		return date( 'Ymd\THis\Z', $timestamp );
-
-	}
-
-	/**
-	 * Handle a request to regenerate the calendar feed secret
-	 *
-	 * @since 0.8
-	 */
-	public function handle_regenerate_calendar_feed_secret() {
-
-		if ( ! isset( $_GET['action'] ) || 'ef_calendar_regenerate_calendar_feed_secret' != $_GET['action'] )
-			return;
-
-		if ( ! current_user_can( 'manage_options' ) ) {
-			wp_die( esc_html( $this->module->messages['invalid-permissions'] ) );
-		}
-
-		if ( ! isset( $_GET['_wpnonce'] ) || ! wp_verify_nonce( $_GET['_wpnonce'], 'ef-regenerate-ics-key' ) ) { // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-			wp_die( esc_html( $this->module->messages['nonce-failed'] ) );
-		}
-
-		EditFlow()->update_module_option( $this->module->name, 'ics_secret_key', wp_generate_password() );
-
-		wp_safe_redirect( add_query_arg( 'message', 'key-regenerated', menu_page_url( $this->module->settings_slug, false ) ) );
-		exit;
-	}
-
-	/**
-	 * Get a user's screen options
-	 *
-	 * @since 0.7
-	 * @uses get_user_meta()
-	 *
-	 * @return array $screen_options The screen options values
-	 */
-	function get_screen_options() {
 
 		/**
-		 * `num_weeks` has been moved to a filter and out of screen options, it's maintained here for legacy purposes
-		 * @deprecated `num_weeks`
+		 * Perform line folding according to RFC 5545.
+		 *
+		 * @param string $line The line without trailing CRLF
+		 * @return string The line after line-folding with all necessary CRLF.
 		 */
-		$defaults = array(
-			'num_weeks' => (int)$this->total_weeks,
-		);
-		$current_user = wp_get_current_user();
-		$screen_options = $this->get_user_meta( $current_user->ID, self::usermeta_key_prefix . 'screen_options', true );
-		$screen_options = array_merge( (array)$defaults, (array)$screen_options );
+		public function do_ics_line_folding( $line ) {
+			$len = mb_strlen( $line );
+			if ( $len <= 75 ) {
+				return $line . "\r\n";
+			}
 
-		return $screen_options;
-	}
-
-	/**
-	 * Get the user's filters for calendar, either with $_GET or from saved
-	 *
-	 * @uses get_user_meta()
-	 * @return array $filters All of the set or saved calendar filters
-	 */
-	function get_filters() {
-		$current_user 	= wp_get_current_user();
-		$filters 		= array();
-		$old_filters 	= $this->get_user_meta( $current_user->ID, self::usermeta_key_prefix . 'filters', true );
+			$chunks = array();
+			$start = 0;
+			while ( true ) {
+				$chunk = mb_substr( $line, $start, 75 );
+				$chunk_len = mb_strlen( $chunk );
+				$start += $chunk_len;
+				if ( $start < $len ) {
+					$chunks[] = $chunk . "\r\n ";
+				} else {
+					$chunks[] = $chunk . "\r\n";
+					return implode( '', $chunks );
+				}
+			}
+		}
 
 		/**
-		 * To support legacy screen option for num_weeks
-		 */
-		$screen_options = $this->get_user_meta( $current_user->ID, self::usermeta_key_prefix . 'screen_options', true );
+		 * Perform the encoding necessary for ICS feed text.
+		 *
+		 * @param string $text The string that needs to be escaped
+		 * @return string The string after escaping for ICS.
+		 * @since 0.8
+		 * */
 
-		$default_filters = array(
+		public function do_ics_escaping( $text ) {
+			$text = str_replace( ',', '\,', $text );
+			$text = str_replace( ';', '\:', $text );
+			$text = str_replace( '\\', '\\\\', $text );
+			return $text;
+		}
+
+		/**
+		 * Convert a time string into a `.ics` formatted time string with the proper GMT offset
+		 *
+		 * @param     $time_string       - Any time string that `strtotime()` can understand
+		 * @param int $offset_in_seconds - Allows to offset the timestamp generated from $time_string
+		 *
+		 * @return string|false
+		 */
+		public static function ics_format_time( $time_string, $offset_in_seconds = 0 ) {
+
+			// Timestamp it
+			$timestamp = strtotime( $time_string );
+
+			if ( ! $timestamp ) {
+				return false;
+			}
+
+			// Subtract GMT Offset to return to UTC+0
+			$timestamp -= get_option( 'gmt_offset' ) * HOUR_IN_SECONDS;
+
+			// Add manual offset
+			$timestamp += $offset_in_seconds;
+
+			// \T and \Z are escaped for literal T and Z characters
+			return gmdate( 'Ymd\THis\Z', $timestamp );
+		}
+
+		/**
+		 * Handle a request to regenerate the calendar feed secret
+		 *
+		 * @since 0.8
+		 */
+		public function handle_regenerate_calendar_feed_secret() {
+
+			if ( ! isset( $_GET['action'] ) || 'ef_calendar_regenerate_calendar_feed_secret' != $_GET['action'] ) {
+				return;
+			}
+
+			if ( ! current_user_can( 'manage_options' ) ) {
+				wp_die( esc_html( $this->module->messages['invalid-permissions'] ) );
+			}
+
+			if ( ! isset( $_GET['_wpnonce'] ) || ! wp_verify_nonce( $_GET['_wpnonce'], 'ef-regenerate-ics-key' ) ) { // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+				wp_die( esc_html( $this->module->messages['nonce-failed'] ) );
+			}
+
+			EditFlow()->update_module_option( $this->module->name, 'ics_secret_key', wp_generate_password() );
+
+			wp_safe_redirect( add_query_arg( 'message', 'key-regenerated', menu_page_url( $this->module->settings_slug, false ) ) );
+			exit;
+		}
+
+		/**
+		 * Get a user's screen options
+		 *
+		 * @since 0.7
+		 * @uses get_user_meta()
+		 *
+		 * @return array $screen_options The screen options values
+		 */
+		public function get_screen_options() {
+
+			/**
+			 * `num_weeks` has been moved to a filter and out of screen options, it's maintained here for legacy purposes
+			 * @deprecated `num_weeks`
+			 */
+			$defaults = array(
+				'num_weeks' => (int) $this->total_weeks,
+			);
+			$current_user = wp_get_current_user();
+			$screen_options = $this->get_user_meta( $current_user->ID, self::usermeta_key_prefix . 'screen_options', true );
+			$screen_options = array_merge( (array) $defaults, (array) $screen_options );
+
+			return $screen_options;
+		}
+
+		/**
+		 * Get the user's filters for calendar, either with $_GET or from saved
+		 *
+		 * @uses get_user_meta()
+		 * @return array $filters All of the set or saved calendar filters
+		 */
+		public function get_filters() {
+			$current_user   = wp_get_current_user();
+			$filters        = array();
+			$old_filters    = $this->get_user_meta( $current_user->ID, self::usermeta_key_prefix . 'filters', true );
+
+			/**
+			 * To support legacy screen option for num_weeks
+			 */
+			$screen_options = $this->get_user_meta( $current_user->ID, self::usermeta_key_prefix . 'screen_options', true );
+
+			$default_filters = array(
 				'post_status' => '',
 				'cpt' => '',
 				'cat' => '',
 				'author' => '',
 				'num_weeks' => $this->total_weeks,
-				'start_date' => date( 'Y-m-d', current_time( 'timestamp' ) ),
+				'start_date' => gmdate( 'Y-m-d', current_time( 'timestamp' ) ),
 			);
-		$old_filters = array_merge( $default_filters, isset( $screen_options['num_weeks'] ) ? array( 'num_weeks' => $screen_options['num_weeks'] ) : array(), (array)$old_filters );
+			$old_filters = array_merge( $default_filters, isset( $screen_options['num_weeks'] ) ? array( 'num_weeks' => $screen_options['num_weeks'] ) : array(), (array) $old_filters );
 
-		// Sanitize and validate any newly added filters
-		foreach( $old_filters as $key => $old_value ) {
-			if ( isset( $_GET[$key] ) && false !== ( $new_value = $this->sanitize_filter( $key, $_GET[$key] ) ) )
-				$filters[$key] = $new_value;
-			else
-				$filters[$key] = $old_value;
+			// Sanitize and validate any newly added filters
+			foreach ( $old_filters as $key => $old_value ) {
+				if ( isset( $_GET[ $key ] ) && false !== ( $new_value = $this->sanitize_filter( $key, $_GET[ $key ] ) ) ) {
+					$filters[ $key ] = $new_value;
+				} else {
+					$filters[ $key ] = $old_value;
+				}
+			}
+
+			// Set the start date as the beginning of the week, according to blog settings
+			$filters['start_date'] = $this->get_beginning_of_week( $filters['start_date'] );
+
+			$filters = apply_filters( 'ef_calendar_filter_values', $filters, $old_filters );
+
+			$this->update_user_meta( $current_user->ID, self::usermeta_key_prefix . 'filters', $filters );
+
+			return $filters;
 		}
 
-		// Set the start date as the beginning of the week, according to blog settings
-		$filters['start_date'] = $this->get_beginning_of_week( $filters['start_date'] );
+		/**
+		 * Build all of the HTML for the calendar view
+		 */
+		public function view_calendar() {
+			$supported_post_types = $this->get_post_types_for_module( $this->module );
 
-		$filters = apply_filters( 'ef_calendar_filter_values', $filters, $old_filters );
+			// Get filters either from $_GET or from user settings
+			$filters = $this->get_filters();
 
-		$this->update_user_meta( $current_user->ID, self::usermeta_key_prefix . 'filters', $filters );
+			// Total number of weeks to display on the calendar. Run it through a filter in case we want to override the
+			// user's standard
+			$this->total_weeks = apply_filters( 'ef_calendar_total_weeks', $filters['num_weeks'], 'dashboard' );
 
-		return $filters;
-	}
+			$dotw = array(
+				'Sat',
+				'Sun',
+			);
+			$dotw = apply_filters( 'ef_calendar_weekend_days', $dotw );
 
-	/**
-	 * Build all of the HTML for the calendar view
-	 */
-	function view_calendar() {
-		$supported_post_types = $this->get_post_types_for_module( $this->module );
+			// For generating the WP Query objects later on
+			$post_query_args = array(
+				'post_status' => $filters['post_status'],
+				'post_type'   => $filters['cpt'],
+				'cat'         => $filters['cat'],
+				'author'      => $filters['author'],
+			);
+			$this->start_date = $filters['start_date'];
 
-		// Get filters either from $_GET or from user settings
-		$filters = $this->get_filters();
+			// We use this later to label posts if they need labeling
+			if ( count( $supported_post_types ) > 1 ) {
+				$all_post_types = get_post_types( null, 'objects' );
+			}
+			$dates = array();
+			$heading_date = $filters['start_date'];
+			for ( $i = 0; $i < 7; $i++ ) {
+				$dates[ $i ] = $heading_date;
+				$heading_date = gmdate( 'Y-m-d', strtotime( '+1 day', strtotime( $heading_date ) ) );
+			}
 
-		// Total number of weeks to display on the calendar. Run it through a filter in case we want to override the
-		// user's standard
-		$this->total_weeks = apply_filters( 'ef_calendar_total_weeks', $filters['num_weeks'], 'dashboard' );
-
-		$dotw = array(
-			'Sat',
-			'Sun',
-		);
-		$dotw = apply_filters( 'ef_calendar_weekend_days', $dotw );
-
-		// For generating the WP Query objects later on
-		$post_query_args = array(
-			'post_status' => $filters['post_status'],
-			'post_type'   => $filters['cpt'],
-			'cat'         => $filters['cat'],
-			'author'      => $filters['author']
-		);
-		$this->start_date = $filters['start_date'];
-
-		// We use this later to label posts if they need labeling
-		if ( count( $supported_post_types ) > 1 ) {
-			$all_post_types = get_post_types( null, 'objects' );
-		}
-		$dates = array();
-		$heading_date = $filters['start_date'];
-		for ( $i=0; $i<7; $i++ ) {
-			$dates[$i] = $heading_date;
-			$heading_date = date( 'Y-m-d', strtotime( "+1 day", strtotime( $heading_date ) ) );
-		}
-
-		// we sort by post statuses....... eventually
-		$post_statuses = $this->get_calendar_post_stati();
-		?>
+			// we sort by post statuses....... eventually
+			$post_statuses = $this->get_calendar_post_stati();
+			?>
 		<div class="wrap">
 			<div id="ef-calendar-title"><!-- Calendar Title -->
 				<?php echo '<img src="' . esc_url( $this->module->img_url ) . '" class="module-icon icon32" />'; ?>
@@ -704,23 +713,25 @@ class EF_Calendar extends EF_Module {
 
 			<?php
 				// Handle posts that have been trashed or untrashed
-				if ( isset( $_GET['trashed'] ) || isset( $_GET['untrashed'] ) ) {
+			if ( isset( $_GET['trashed'] ) || isset( $_GET['untrashed'] ) ) {
 
-					echo '<div id="trashed-message" class="updated"><p>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-					if ( isset( $_GET['trashed'] ) && (int) $_GET['trashed'] ) { // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-						echo esc_html( sprintf( _n( 'Post moved to the trash.', '%d posts moved to the trash.', $_GET['trashed'] ), number_format_i18n( $_GET['trashed'] ) ) );
-						$ids = isset($_GET['ids']) ? $_GET['ids'] : 0;
-						$pid = explode( ',', $ids );
-						$post_type = get_post_type( $pid[0] );
-						echo ' <a href="' . esc_url( wp_nonce_url( "edit.php?post_type=$post_type&doaction=undo&action=untrash&ids=$ids", "bulk-posts" ) ) . '">' . esc_html__( 'Undo', 'edit-flow' ) . '</a><br />';
-						unset( $_GET['trashed'] );
-					}
-					if ( isset($_GET['untrashed'] ) && (int) $_GET['untrashed'] ) { // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-						echo esc_html( sprintf( _n( 'Post restored from the Trash.', '%d posts restored from the Trash.', $_GET['untrashed'] ), number_format_i18n( $_GET['untrashed'] ) ) );
-						unset( $_GET['undeleted'] );
-					}
-					echo '</p></div>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+				echo '<div id="trashed-message" class="updated"><p>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+				if ( isset( $_GET['trashed'] ) && (int) $_GET['trashed'] ) { // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+					/* translators: %d: number of posts trashed */
+					echo esc_html( sprintf( _n( 'Post moved to the trash.', '%d posts moved to the trash.', $_GET['trashed'] ), number_format_i18n( $_GET['trashed'] ) ) );
+					$ids = isset( $_GET['ids'] ) ? $_GET['ids'] : 0;
+					$pid = explode( ',', $ids );
+					$post_type = get_post_type( $pid[0] );
+					echo ' <a href="' . esc_url( wp_nonce_url( "edit.php?post_type=$post_type&doaction=undo&action=untrash&ids=$ids", 'bulk-posts' ) ) . '">' . esc_html__( 'Undo', 'edit-flow' ) . '</a><br />';
+					unset( $_GET['trashed'] );
 				}
+				if ( isset( $_GET['untrashed'] ) && (int) $_GET['untrashed'] ) { // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+					/* translators: %d: number of posts restored */
+					echo esc_html( sprintf( _n( 'Post restored from the Trash.', '%d posts restored from the Trash.', $_GET['untrashed'] ), number_format_i18n( $_GET['untrashed'] ) ) );
+					unset( $_GET['undeleted'] );
+				}
+				echo '</p></div>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+			}
 			?>
 
 			<div id="ef-calendar-navigation-mount"></div> <!-- Mount point for React -->
@@ -730,12 +741,13 @@ class EF_Calendar extends EF_Module {
 			<?php
 				$table_classes = array();
 				// CSS don't like our classes to start with numbers
-				if ( $this->total_weeks == 1 )
-					$table_classes[] = 'one-week-showing';
-				elseif ( $this->total_weeks == 2 )
-					$table_classes[] = 'two-weeks-showing';
-				elseif ( $this->total_weeks == 3 )
-					$table_classes[] = 'three-weeks-showing';
+			if ( 1 == $this->total_weeks ) {
+				$table_classes[] = 'one-week-showing';
+			} elseif ( 2 == $this->total_weeks ) {
+				$table_classes[] = 'two-weeks-showing';
+			} elseif ( 3 == $this->total_weeks ) {
+				$table_classes[] = 'three-weeks-showing';
+			}
 
 				$table_classes = apply_filters( 'ef_calendar_table_classes', $table_classes );
 			?>
@@ -749,7 +761,7 @@ class EF_Calendar extends EF_Module {
 
 				<?php
 				$current_month = date_i18n( 'F', strtotime( $filters['start_date'] ) );
-				for( $current_week = 1; $current_week <= $this->total_weeks; $current_week++ ):
+				for ( $current_week = 1; $current_week <= $this->total_weeks; $current_week++ ) :
 					// We need to set the object variable for our posts_where filter
 					$this->current_week = $current_week;
 					$week_posts = $this->get_calendar_posts_for_week( $post_query_args );
@@ -757,103 +769,108 @@ class EF_Calendar extends EF_Module {
 					$week_single_date = $this->get_beginning_of_week( $filters['start_date'], $date_format, $current_week );
 					$week_dates = array();
 					$split_month = false;
-					for ( $i = 0 ; $i < 7; $i++ ) {
-						$week_dates[$i] = $week_single_date;
+					for ( $i = 0; $i < 7; $i++ ) {
+						$week_dates[ $i ] = $week_single_date;
 						$single_date_month = date_i18n( 'F', strtotime( $week_single_date ) );
 						if ( $single_date_month != $current_month ) {
 							$split_month = $single_date_month;
 							$current_month = $single_date_month;
 						}
-						$week_single_date = date( 'Y-m-d', strtotime( "+1 day", strtotime( $week_single_date ) ) );
+						$week_single_date = gmdate( 'Y-m-d', strtotime( '+1 day', strtotime( $week_single_date ) ) );
 					}
-				?>
-				<?php if ( $split_month ): ?>
+					?>
+					<?php if ( $split_month ) : ?>
 				<tr class="month-marker">
-					<?php foreach( $week_dates as $key => $week_single_date ) {
-						if ( date_i18n( 'F', strtotime( $week_single_date ) ) != $split_month && date_i18n( 'F', strtotime( "+1 day", strtotime( $week_single_date ) ) ) == $split_month ) {
-							$previous_month = date_i18n( 'F', strtotime( $week_single_date ) );
-							echo '<td class="month-marker-previous">' . esc_html( $previous_month ) . '</td>';
-						} else if ( date_i18n( 'F', strtotime( $week_single_date ) ) == $split_month && date_i18n( 'F', strtotime( "-1 day", strtotime( $week_single_date ) ) ) != $split_month ) {
-							echo '<td class="month-marker-current">' . esc_html( $split_month ) . '</td>';
-						} else {
-							echo '<td class="month-marker-empty"></td>';
+						<?php
+						foreach ( $week_dates as $key => $week_single_date ) {
+							if ( date_i18n( 'F', strtotime( $week_single_date ) ) != $split_month && date_i18n( 'F', strtotime( '+1 day', strtotime( $week_single_date ) ) ) == $split_month ) {
+								$previous_month = date_i18n( 'F', strtotime( $week_single_date ) );
+								echo '<td class="month-marker-previous">' . esc_html( $previous_month ) . '</td>';
+							} else if ( date_i18n( 'F', strtotime( $week_single_date ) ) == $split_month && date_i18n( 'F', strtotime( '-1 day', strtotime( $week_single_date ) ) ) != $split_month ) {
+								echo '<td class="month-marker-current">' . esc_html( $split_month ) . '</td>';
+							} else {
+								echo '<td class="month-marker-empty"></td>';
+							}
 						}
-					} ?>
+						?>
 				</tr>
 				<?php endif; ?>
 
 				<tr class="week-unit">
-				<?php foreach( $week_dates as $day_num => $week_single_date ): ?>
-				<?php
-					// Somewhat ghetto way of sorting all of the day's posts by post status order
-					if ( !empty( $week_posts[$week_single_date] ) ) {
-						$week_posts_by_status = array();
-						foreach( $post_statuses as $post_status ) {
-							$week_posts_by_status[$post_status->name] = array();
-						}
-						// These statuses aren't handled by custom statuses or post statuses
-						$week_posts_by_status['private'] = array();
-						$week_posts_by_status['publish'] = array();
-						$week_posts_by_status['future'] = array();
-						foreach( $week_posts[$week_single_date] as $num => $post ) {
-							$week_posts_by_status[$post->post_status][$num] = $post;
-						}
-						unset( $week_posts[$week_single_date] );
-						foreach( $week_posts_by_status as $status ) {
-							foreach( $status as $num => $post ) {
-								$week_posts[$week_single_date][] = $post;
+					<?php foreach ( $week_dates as $day_num => $week_single_date ) : ?>
+						<?php
+						// Somewhat ghetto way of sorting all of the day's posts by post status order
+						if ( ! empty( $week_posts[ $week_single_date ] ) ) {
+							$week_posts_by_status = array();
+							foreach ( $post_statuses as $post_status ) {
+								$week_posts_by_status[ $post_status->name ] = array();
+							}
+							// These statuses aren't handled by custom statuses or post statuses
+							$week_posts_by_status['private'] = array();
+							$week_posts_by_status['publish'] = array();
+							$week_posts_by_status['future'] = array();
+							foreach ( $week_posts[ $week_single_date ] as $num => $post ) {
+								$week_posts_by_status[ $post->post_status ][ $num ] = $post;
+							}
+							unset( $week_posts[ $week_single_date ] );
+							foreach ( $week_posts_by_status as $status ) {
+								foreach ( $status as $num => $post ) {
+									$week_posts[ $week_single_date ][] = $post;
+								}
 							}
 						}
-					}
 
-					$td_classes = array(
-						'day-unit',
-					);
-					$day_name = date( 'D', strtotime( $week_single_date ) );
+						$td_classes = array(
+							'day-unit',
+						);
+						$day_name = gmdate( 'D', strtotime( $week_single_date ) );
 
-					if ( in_array( $day_name, $dotw ) )
-						$td_classes[] = 'weekend-day';
+						if ( in_array( $day_name, $dotw ) ) {
+							$td_classes[] = 'weekend-day';
+						}
 
-					if ( $week_single_date == date( 'Y-m-d', current_time( 'timestamp' ) ) )
-						$td_classes[] = 'today';
+						if ( gmdate( 'Y-m-d', current_time( 'timestamp' ) ) == $week_single_date ) {
+							$td_classes[] = 'today';
+						}
 
-					// Last day of the week
-					if ( $day_num == 6 )
-						$td_classes[] = 'last-day';
+						// Last day of the week
+						if ( 6 == $day_num ) {
+							$td_classes[] = 'last-day';
+						}
 
-					$td_classes = apply_filters( 'ef_calendar_table_td_classes', $td_classes, $week_single_date );
-				?>
+						$td_classes = apply_filters( 'ef_calendar_table_td_classes', $td_classes, $week_single_date );
+						?>
 				<td class="<?php echo esc_attr( implode( ' ', $td_classes ) ); ?>" id="<?php echo esc_attr( $week_single_date ); ?>">
 					<button class='schedule-new-post-button'>+</button>
-					<?php if ( $week_single_date == date( 'Y-m-d', current_time( 'timestamp' ) ) ): ?>
+						<?php if ( gmdate( 'Y-m-d', current_time( 'timestamp' ) ) == $week_single_date ) : ?>
 						<div class="day-unit-today"><?php esc_html_e( 'Today', 'edit-flow' ); ?></div>
 					<?php endif; ?>
-					<div class="day-unit-label"><?php echo esc_html( date( 'j', strtotime( $week_single_date ) ) ); ?></div>
+					<div class="day-unit-label"><?php echo esc_html( gmdate( 'j', strtotime( $week_single_date ) ) ); ?></div>
 					<ul class="post-list">
 						<?php
 						$this->hidden = 0;
-						if ( !empty( $week_posts[$week_single_date] ) ) {
+						if ( ! empty( $week_posts[ $week_single_date ] ) ) {
 
-							$week_posts[$week_single_date] = apply_filters( 'ef_calendar_posts_for_week', $week_posts[$week_single_date], $week_single_date );
+							$week_posts[ $week_single_date ] = apply_filters( 'ef_calendar_posts_for_week', $week_posts[ $week_single_date ], $week_single_date );
 
-							foreach ( $week_posts[$week_single_date] as $num => $post ) {
+							foreach ( $week_posts[ $week_single_date ] as $num => $post ) {
 								$output = apply_filters( 'ef_pre_calendar_single_date_item_html', '', $this, $num, $post, $week_single_date );
 								if ( ! $output ) {
 									$output = $this->generate_post_li_html( $post, $week_single_date, $num );
 								}
 								echo $output; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 							}
-
-						 }
-						 ?>
+						}
+						?>
 					</ul>
-					<?php if ( $this->hidden ): ?>
-						<a class="show-more" href="#"><?php esc_html_e( sprintf( __( 'Show %d more', 'edit-flow' ), $this->hidden ) ); ?></a>
+						<?php if ( $this->hidden ) : ?>
+						<a class="show-more" href="#"><?php /* translators: %d = number of posts to show */ esc_html_e( sprintf( __( 'Show %d more', 'edit-flow' ), $this->hidden ) ); ?></a>
 					<?php endif; ?>
 
-					<?php if( current_user_can( $this->create_post_cap ) ) :
-						$date_formatted = date( 'D, M jS, Y', strtotime( $week_single_date ) );
-					?>
+						<?php
+						if ( current_user_can( $this->create_post_cap ) ) :
+							$date_formatted = gmdate( 'D, M jS, Y', strtotime( $week_single_date ) );
+							?>
 
 						<form method="POST" class="post-insert-dialog">
 							<?php /* translators: %1$s = post type name, %2$s = date */ ?>
@@ -862,12 +879,12 @@ class EF_Calendar extends EF_Module {
 							<input type="text" class="post-insert-dialog-post-title" name="post-insert-dialog-post-title" placeholder="<?php echo esc_attr( sprintf( _x( '%s Title', 'post type name', 'edit-flow' ), $this->get_quick_create_post_type_name() ) ); ?>">
 							<input type="hidden" class="post-insert-dialog-post-date" name="post-insert-dialog-post-title" value="<?php echo esc_attr( $week_single_date ); ?>">
 							<div class="post-insert-dialog-controls">
-								<input type="submit" class="button left" value="<?php echo esc_attr( sprintf( _x( 'Create %s', 'post type name', 'edit-flow' ), $this->get_quick_create_post_type_name() ) ); ?>">
-								<a class="post-insert-dialog-edit-post-link" href="#"><?php echo esc_attr( sprintf( _x( 'Edit %s', 'post type name', 'edit-flow' ), $this->get_quick_create_post_type_name() ) ); ?>&nbsp;&raquo;</a>
+								<input type="submit" class="button left" value="<?php /* translators: %s = post type name */ echo esc_attr( sprintf( _x( 'Create %s', 'post type name', 'edit-flow' ), $this->get_quick_create_post_type_name() ) ); ?>">
+								<a class="post-insert-dialog-edit-post-link" href="#"><?php /* translators: %s = post type name */ echo esc_html( sprintf( _x( 'Edit %s', 'post type name', 'edit-flow' ), $this->get_quick_create_post_type_name() ) ); ?>&nbsp;&raquo;</a>
 							</div>
 							<div class="spinner">&nbsp;</div>
 						</form>
-					<?php endif; ?>
+						<?php endif; ?>
 
 					</td>
 					<?php endforeach; ?>
@@ -879,64 +896,66 @@ class EF_Calendar extends EF_Module {
 					</table><!-- /Week Wrapper -->
 					<?php
 					// Nonce field for AJAX actions
-					wp_nonce_field( 'ef-calendar-modify', 'ef-calendar-modify' ); ?>
+					wp_nonce_field( 'ef-calendar-modify', 'ef-calendar-modify' );
+					?>
 
 					<div class="clear"></div>
 				</div><!-- /Calendar Wrapper -->
 
 			  </div>
 
-		<?php
-
-	}
-
-	/**
-	 * Generates the HTML for a single post item in the calendar
-	 * @param  obj $post The WordPress post in question
-	 * @param  str $post_date The date of the post
-	 * @param  int $num The index of the post
-	 *
-	 * @return str HTML for a single post item
-	 */
-	function generate_post_li_html( $post, $post_date, $num = 0 ){
-
-		$can_modify = ( $this->current_user_can_modify_post( $post ) ) ? 'can_modify' : 'read_only';
-		$cache_key = $post->ID . $can_modify . '_' . get_current_user_id();
-		$cache_val = wp_cache_get( $cache_key, self::$post_li_html_cache_key );
-		// Because $num is pertinent to the display of the post LI, need to make sure that's what's in cache
-		if ( is_array( $cache_val ) && $cache_val['num'] == $num ) {
-			$this->hidden = $cache_val['hidden'];
-			return $cache_val['post_li_html'];
+			<?php
 		}
 
-		ob_start();
-		$post_id = $post->ID;
-		$edit_post_link = get_edit_post_link( $post_id );
-		$status_object = get_post_status_object( get_post_status( $post_id ) );
+		/**
+		 * Generates the HTML for a single post item in the calendar
+		 * @param  obj $post The WordPress post in question
+		 * @param  str $post_date The date of the post
+		 * @param  int $num The index of the post
+		 *
+		 * @return str HTML for a single post item
+		 */
+		public function generate_post_li_html( $post, $post_date, $num = 0 ) {
 
-		$post_classes = array(
-			'day-item',
-			'custom-status-' . $post->post_status,
-		);
-		// Only allow the user to drag the post if they have permissions to
-		// or if it's in an approved post status
-		// This is checked on the ajax request too.
-		if ( $this->current_user_can_modify_post( $post ) && !in_array( $post->post_status, $this->published_statuses ) )
-			$post_classes[] = 'sortable';
+			$can_modify = ( $this->current_user_can_modify_post( $post ) ) ? 'can_modify' : 'read_only';
+			$cache_key = $post->ID . $can_modify . '_' . get_current_user_id();
+			$cache_val = wp_cache_get( $cache_key, self::$post_li_html_cache_key );
+			// Because $num is pertinent to the display of the post LI, need to make sure that's what's in cache
+			if ( is_array( $cache_val ) && $cache_val['num'] == $num ) {
+				$this->hidden = $cache_val['hidden'];
+				return $cache_val['post_li_html'];
+			}
 
-		if ( in_array( $post->post_status, $this->published_statuses ) )
-			$post_classes[] = 'is-published';
+			ob_start();
+			$post_id = $post->ID;
+			$edit_post_link = get_edit_post_link( $post_id );
+			$status_object = get_post_status_object( get_post_status( $post_id ) );
 
-		// Hide posts over a certain number to prevent clutter, unless user is only viewing 1 or 2 weeks
-		$max_visible_posts = apply_filters( 'ef_calendar_max_visible_posts_per_date', $this->max_visible_posts_per_date);
+			$post_classes = array(
+				'day-item',
+				'custom-status-' . $post->post_status,
+			);
+			// Only allow the user to drag the post if they have permissions to
+			// or if it's in an approved post status
+			// This is checked on the ajax request too.
+			if ( $this->current_user_can_modify_post( $post ) && ! in_array( $post->post_status, $this->published_statuses ) ) {
+				$post_classes[] = 'sortable';
+			}
 
-		if ( $num >= $max_visible_posts && $this->total_weeks > 2 ) {
-			$post_classes[] = 'hidden';
-			$this->hidden++;
-		}
-		$post_classes = apply_filters( 'ef_calendar_table_td_li_classes', $post_classes, $post_date, $post->ID );
+			if ( in_array( $post->post_status, $this->published_statuses ) ) {
+				$post_classes[] = 'is-published';
+			}
 
-		?>
+			// Hide posts over a certain number to prevent clutter, unless user is only viewing 1 or 2 weeks
+			$max_visible_posts = apply_filters( 'ef_calendar_max_visible_posts_per_date', $this->max_visible_posts_per_date );
+
+			if ( $num >= $max_visible_posts && $this->total_weeks > 2 ) {
+				$post_classes[] = 'hidden';
+				$this->hidden++;
+			}
+			$post_classes = apply_filters( 'ef_calendar_table_td_li_classes', $post_classes, $post_date, $post->ID );
+
+			?>
 		<li class="<?php echo esc_attr( implode( ' ', $post_classes ) ); ?>" id="post-<?php echo esc_attr( $post->ID ); ?>">
 			<div style="clear:right;"></div>
 			<div class="item-static">
@@ -952,51 +971,54 @@ class EF_Calendar extends EF_Module {
 				</div>
 			</div>
 		</li>
-		<?php
+			<?php
 
-		$post_li_html = ob_get_contents();
-		ob_end_clean();
+			$post_li_html = ob_get_contents();
+			ob_end_clean();
 
-		$post_li_cache = array(
-			'num' => $num,
-			'post_li_html' => $post_li_html,
-			'hidden' => $this->hidden,
+			$post_li_cache = array(
+				'num' => $num,
+				'post_li_html' => $post_li_html,
+				'hidden' => $this->hidden,
 			);
-		wp_cache_set( $cache_key, $post_li_cache, self::$post_li_html_cache_key );
+			wp_cache_set( $cache_key, $post_li_cache, self::$post_li_html_cache_key );
 
-		return $post_li_html;
+			return $post_li_html;
+		} // generate_post_li_html()
 
-	} // generate_post_li_html()
-
-	/**
-	 * get_inner_information description
-	 * Functionality for generating the inner html elements on the calendar
-	 * has been separated out so various ajax functions can reload certain
-	 * parts of an inner html element.
-	 * @param  array $ef_calendar_item_information_fields
-	 * @param  WP_Post $post
-	 * @param  array $published_statuses
-	 *
-	 * @since 0.8
-	 */
-	function get_inner_information( $ef_calendar_item_information_fields, $post ) {
-		?>
+		/**
+		 * get_inner_information description
+		 * Functionality for generating the inner html elements on the calendar
+		 * has been separated out so various ajax functions can reload certain
+		 * parts of an inner html element.
+		 * @param  array $ef_calendar_item_information_fields
+		 * @param  WP_Post $post
+		 * @param  array $published_statuses
+		 *
+		 * @since 0.8
+		 */
+		public function get_inner_information( $ef_calendar_item_information_fields, $post ) {
+			?>
 			<table class="item-information">
-				<?php foreach( $this->get_post_information_fields( $post ) as $field => $values ): ?>
+				<?php foreach ( $this->get_post_information_fields( $post ) as $field => $values ) : ?>
 					<tr class="item-field item-information-<?php echo esc_attr( $field ); ?>">
 						<th class="label"><?php echo esc_html( $values['label'] ); ?>:</th>
-						<?php if ( $values['value'] && isset($values['type']) ): ?>
-							<?php if( isset( $values['editable'] ) && $this->current_user_can_modify_post( $post ) ) : ?>
-								<td class="value<?php if( $values['editable'] ) { ?> editable-value<?php } ?>"><?php echo esc_html( $values['value'] ); ?></td>
-								<?php if( $values['editable'] ): ?>
+						<?php if ( $values['value'] && isset( $values['type'] ) ) : ?>
+							<?php if ( isset( $values['editable'] ) && $this->current_user_can_modify_post( $post ) ) : ?>
+								<td class="value
+								<?php
+								if ( $values['editable'] ) {
+									?>
+									editable-value<?php } ?>"><?php echo esc_html( $values['value'] ); ?></td>
+								<?php if ( $values['editable'] ) : ?>
 									<td class="editable-html hidden" data-type="<?php echo esc_attr( $values['type'] ); ?>" data-metadataterm="<?php echo esc_attr( str_replace( 'editorial-metadata-', '', str_replace( 'tax_', '', $field ) ) ); ?>"><?php echo $this->get_editable_html( $values['type'], $values['value'] ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></td>
 								<?php endif; ?>
-							<?php else: ?>
+							<?php else : ?>
 								<td class="value"><?php echo esc_html( $values['value'] ); ?></td>
 							<?php endif; ?>
-						<?php elseif( $values['value'] ): ?>
+						<?php elseif ( $values['value'] ) : ?>
 							<td class="value"><?php echo esc_html( $values['value'] ); ?></td>
-						<?php else: ?>
+						<?php else : ?>
 						<td class="value"><em class="none"><?php esc_html_e( 'None', 'edit-flow' ); ?></em></td>
 						<?php endif; ?>
 					</tr>
@@ -1006,481 +1028,498 @@ class EF_Calendar extends EF_Module {
 			<?php
 				$post_type_object = get_post_type_object( $post->post_type );
 				$item_actions = array();
-				if ( $this->current_user_can_modify_post( $post ) ) {
-					// Edit this post
-					$item_actions['edit'] = '<a href="' . get_edit_post_link( $post->ID, true ) . '" title="' . esc_attr( __( 'Edit this item', 'edit-flow' ) ) . '">' . __( 'Edit', 'edit-flow' ) . '</a>';
-					// Trash this post
-					$item_actions['trash'] = '<a href="'. get_delete_post_link( $post->ID) . '" title="' . esc_attr( __( 'Trash this item' ), 'edit-flow' ) . '">' . __( 'Trash', 'edit-flow' ) . '</a>';
-					// Preview/view this post
-					if ( !in_array( $post->post_status, $this->published_statuses ) ) {
-						$item_actions['view'] = '<a href="' . esc_url( apply_filters( 'preview_post_link', add_query_arg( 'preview', 'true', get_permalink( $post->ID ) ), $post ) ) . '" title="' . esc_attr( sprintf( __( 'Preview &#8220;%s&#8221;', 'edit-flow' ), $post->post_title ) ) . '" rel="permalink">' . __( 'Preview', 'edit-flow' ) . '</a>';
-					} elseif ( 'trash' != $post->post_status ) {
-						$item_actions['view'] = '<a href="' . get_permalink( $post->ID ) . '" title="' . esc_attr( sprintf( __( 'View &#8220;%s&#8221;', 'edit-flow' ), $post->post_title ) ) . '" rel="permalink">' . __( 'View', 'edit-flow' ) . '</a>';
-					}
-					//Save metadata
-					$item_actions['save hidden'] = '<a href="#savemetadata" id="save-editorial-metadata" class="post-'. esc_attr( $post->ID ) .'" title="'. esc_attr( sprintf( __( 'Save &#8220;%s&#8221;', 'edit-flow' ), $post->post_title ) ) . '" >' . __( 'Save', 'edit-flow') . '</a>';
+			if ( $this->current_user_can_modify_post( $post ) ) {
+				// Edit this post
+				$item_actions['edit'] = '<a href="' . get_edit_post_link( $post->ID, true ) . '" title="' . esc_attr( __( 'Edit this item', 'edit-flow' ) ) . '">' . __( 'Edit', 'edit-flow' ) . '</a>';
+				// Trash this post
+				$item_actions['trash'] = '<a href="' . get_delete_post_link( $post->ID ) . '" title="' . esc_attr( __( 'Trash this item' ), 'edit-flow' ) . '">' . __( 'Trash', 'edit-flow' ) . '</a>';
+				// Preview/view this post
+				if ( ! in_array( $post->post_status, $this->published_statuses ) ) {
+					/* translators: %s: post title */
+					$item_actions['view'] = '<a href="' . esc_url( apply_filters( 'preview_post_link', add_query_arg( 'preview', 'true', get_permalink( $post->ID ) ), $post ) ) . '" title="' . esc_attr( sprintf( __( 'Preview &#8220;%s&#8221;', 'edit-flow' ), $post->post_title ) ) . '" rel="permalink">' . __( 'Preview', 'edit-flow' ) . '</a>';
+				} elseif ( 'trash' != $post->post_status ) {
+					/* translators: %s: post title */
+					$item_actions['view'] = '<a href="' . get_permalink( $post->ID ) . '" title="' . esc_attr( sprintf( __( 'View &#8220;%s&#8221;', 'edit-flow' ), $post->post_title ) ) . '" rel="permalink">' . __( 'View', 'edit-flow' ) . '</a>';
 				}
+				//Save metadata
+				/* translators: %s: post title */
+				$item_actions['save hidden'] = '<a href="#savemetadata" id="save-editorial-metadata" class="post-' . esc_attr( $post->ID ) . '" title="' . esc_attr( sprintf( __( 'Save &#8220;%s&#8221;', 'edit-flow' ), $post->post_title ) ) . '" >' . __( 'Save', 'edit-flow' ) . '</a>';
+			}
 				// Allow other plugins to add actions
 				$item_actions = apply_filters( 'ef_calendar_item_actions', $item_actions, $post->ID );
-				if ( count( $item_actions ) ) {
-					echo '<div class="item-actions">';
-					$html = '';
-					foreach ( $item_actions as $class => $item_action ) {
-						$html .= '<span class="' . esc_attr( $class ) . '">' . $item_action . ' | </span> '; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-					}
-					echo rtrim( $html, '| ' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-					echo '</div>';
+			if ( count( $item_actions ) ) {
+				echo '<div class="item-actions">';
+				$html = '';
+				foreach ( $item_actions as $class => $item_action ) {
+					$html .= '<span class="' . esc_attr( $class ) . '">' . $item_action . ' | </span> '; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 				}
+				echo rtrim( $html, '| ' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+				echo '</div>';
+			}
 			?>
 			<div style="clear:right;"></div>
-		<?php
+			<?php
+		} // generate_post_li_html()
 
-	} // generate_post_li_html()
+		public function get_editable_html( $type, $value ) {
 
-	function get_editable_html( $type, $value ) {
+			switch ( $type ) {
+				case 'text':
+				case 'location':
+				case 'number':
+					return '<input type="text" class="metadata-edit-' . esc_attr( $type ) . '" value="' . esc_attr( $value ) . '"/>';
+				break;
+				case 'paragraph':
+					return '<textarea type="text" class="metadata-edit-' . esc_attr( $type ) . '">' . esc_html( $value ) . '</textarea>';
+				break;
+				case 'date':
+					return '<input type="text" value="' . esc_attr( $value ) . '" class="date-time-pick metadata-edit-' . esc_attr( $type ) . '"/>';
+				break;
+				case 'checkbox':
+					$output = '<select class="metadata-edit">';
 
-		switch( $type ) {
-			case 'text':
-			case 'location':
-			case 'number':
-				return '<input type="text" class="metadata-edit-' . esc_attr( $type ) . '" value="' . esc_attr( $value ) . '"/>';
-			break;
-			case 'paragraph':
-				return '<textarea type="text" class="metadata-edit-' . esc_attr( $type ) . '">' . esc_html( $value ) . '</textarea>';
-			break;
-			case 'date':
-				return '<input type="text" value="' . esc_attr( $value ) . '" class="date-time-pick metadata-edit-' . esc_attr( $type ) . '"/>';
-			break;
-			case 'checkbox':
-				$output = '<select class="metadata-edit">';
+					if ( 'No' == $value ) {
+						$output .= '<option value="0">No</option><option value="1">Yes</option>';
+					} else {
+						$output .= '<option value="1">Yes</option><option value="0">No</option>';
+					}
 
-				if( $value == 'No' )
-					$output .= '<option value="0">No</option><option value="1">Yes</option>';
-				else
-					$output .= '<option value="1">Yes</option><option value="0">No</option>';
+					$output .= '</select>';
 
-				$output .= '</select>';
-
-				return $output;
-			break;
-			case 'user':
-				return wp_dropdown_users( array( 'echo' => false ) );
-			break;
-			case 'taxonomy':
-				return '<input type="text" class="metadata-edit-' . esc_attr( $type ) . '" value="' . esc_attr( $value ) . '" />';
-			break;
-			case 'taxonomy hierarchical':
-				return wp_dropdown_categories( array( 'echo' => 0, 'hide_empty' => 0 ) );
-			break;
-		}
-	}
-
-	/**
-	 * Get the information fields to be presented with each post popup
-	 *
-	 * @since 0.8
-	 *
-	 * @param obj $post Post to gather information fields for
-	 * @return array $information_fields All of the information fields to be presented
-	 */
-	function get_post_information_fields( $post ) {
-
-		$information_fields = array();
-		// Post author
-		$information_fields['author'] = array(
-			'label'        => __( 'Author', 'edit-flow' ),
-			'value'        => get_the_author_meta( 'display_name', $post->post_author ),
-			'type'         => 'author',
-		);
-
-		// If the calendar supports more than one post type, show the post type label
-		if ( count( $this->get_post_types_for_module( $this->module ) ) > 1 ) {
-			$information_fields['post_type'] = array(
-				'label' => __( 'Post Type', 'edit-flow' ),
-				'value' => get_post_type_object( $post->post_type )->labels->singular_name,
-			);
-		}
-		// Publication time for published statuses
-		$published_statuses = array(
-			'publish',
-			'future',
-			'private',
-		);
-		if ( in_array( $post->post_status, $published_statuses ) ) {
-			if ( $post->post_status == 'future' ) {
-				$information_fields['post_date'] = array(
-					'label' => __( 'Scheduled', 'edit-flow' ),
-					'value' => get_the_time( null, $post->ID ),
-				);
-			} else {
-				$information_fields['post_date'] = array(
-					'label' => __( 'Published', 'edit-flow' ),
-					'value' => get_the_time( null, $post->ID ),
-				);
+					return $output;
+				break;
+				case 'user':
+					return wp_dropdown_users( array( 'echo' => false ) );
+				break;
+				case 'taxonomy':
+					return '<input type="text" class="metadata-edit-' . esc_attr( $type ) . '" value="' . esc_attr( $value ) . '" />';
+				break;
+				case 'taxonomy hierarchical':
+					return wp_dropdown_categories( array(
+						'echo' => 0,
+						'hide_empty' => 0,
+					) );
+				break;
 			}
 		}
-		// Taxonomies and their values
-		$args = array(
-			'post_type' => $post->post_type,
-		);
-		$taxonomies = get_object_taxonomies( $args, 'object' );
-		foreach( (array)$taxonomies as $taxonomy ) {
-			// Sometimes taxonomies skip by, so let's make sure it has a label too
-			if ( !$taxonomy->public || !$taxonomy->label )
-				continue;
 
-			$terms = get_the_terms( $post->ID, $taxonomy->name );
-			if ( ! $terms || is_wp_error( $terms ) )
-				continue;
+		/**
+		 * Get the information fields to be presented with each post popup
+		 *
+		 * @since 0.8
+		 *
+		 * @param obj $post Post to gather information fields for
+		 * @return array $information_fields All of the information fields to be presented
+		 */
+		public function get_post_information_fields( $post ) {
 
-			$key = 'tax_' . $taxonomy->name;
-			if ( count( $terms ) ) {
-				$value = '';
-				foreach( (array)$terms as $term ) {
-					$value .= $term->name . ', ';
+			$information_fields = array();
+			// Post author
+			$information_fields['author'] = array(
+				'label'        => __( 'Author', 'edit-flow' ),
+				'value'        => get_the_author_meta( 'display_name', $post->post_author ),
+				'type'         => 'author',
+			);
+
+			// If the calendar supports more than one post type, show the post type label
+			if ( count( $this->get_post_types_for_module( $this->module ) ) > 1 ) {
+				$information_fields['post_type'] = array(
+					'label' => __( 'Post Type', 'edit-flow' ),
+					'value' => get_post_type_object( $post->post_type )->labels->singular_name,
+				);
+			}
+			// Publication time for published statuses
+			$published_statuses = array(
+				'publish',
+				'future',
+				'private',
+			);
+			if ( in_array( $post->post_status, $published_statuses ) ) {
+				if ( 'future' == $post->post_status ) {
+					$information_fields['post_date'] = array(
+						'label' => __( 'Scheduled', 'edit-flow' ),
+						'value' => get_the_time( null, $post->ID ),
+					);
+				} else {
+					$information_fields['post_date'] = array(
+						'label' => __( 'Published', 'edit-flow' ),
+						'value' => get_the_time( null, $post->ID ),
+					);
 				}
-				$value = rtrim( $value, ', ' );
-			} else {
-				$value = '';
 			}
-			 //Used when editing editorial metadata and post meta
-			if ( is_taxonomy_hierarchical( $taxonomy->name ) )
-				$type = 'taxonomy hierarchical';
-			else
-				$type = 'taxonomy';
+			// Taxonomies and their values
+			$args = array(
+				'post_type' => $post->post_type,
+			);
+			$taxonomies = get_object_taxonomies( $args, 'object' );
+			foreach ( (array) $taxonomies as $taxonomy ) {
+				// Sometimes taxonomies skip by, so let's make sure it has a label too
+				if ( ! $taxonomy->public || ! $taxonomy->label ) {
+					continue;
+				}
 
-			$information_fields[$key] = array(
-				'label' => $taxonomy->label,
-				'value' => $value,
-				'type' => $type,
+				$terms = get_the_terms( $post->ID, $taxonomy->name );
+				if ( ! $terms || is_wp_error( $terms ) ) {
+					continue;
+				}
+
+				$key = 'tax_' . $taxonomy->name;
+				if ( count( $terms ) ) {
+					$value = '';
+					foreach ( (array) $terms as $term ) {
+						$value .= $term->name . ', ';
+					}
+					$value = rtrim( $value, ', ' );
+				} else {
+					$value = '';
+				}
+				 //Used when editing editorial metadata and post meta
+				if ( is_taxonomy_hierarchical( $taxonomy->name ) ) {
+					$type = 'taxonomy hierarchical';
+				} else {
+					$type = 'taxonomy';
+				}
+
+				$information_fields[ $key ] = array(
+					'label' => $taxonomy->label,
+					'value' => $value,
+					'type' => $type,
+				);
+
+				if ( 'page' == $post->post_type ) {
+					$ed_cap = 'edit_page';
+				} else {
+					$ed_cap = 'edit_post';
+				}
+
+				if ( current_user_can( $ed_cap, $post->ID ) ) {
+					$information_fields[ $key ]['editable'] = true;
+				}
+			}
+
+			$information_fields = apply_filters( 'ef_calendar_item_information_fields', $information_fields, $post->ID );
+			foreach ( $information_fields as $field => $values ) {
+				// Allow filters to hide empty fields or to hide any given individual field. Hide empty fields by default.
+				if ( ( apply_filters( 'ef_calendar_hide_empty_item_information_fields', true, $post->ID ) && empty( $values['value'] ) )
+					|| apply_filters( "ef_calendar_hide_{$field}_item_information_field", false, $post->ID ) ) {
+					unset( $information_fields[ $field ] );
+				}
+			}
+			return $information_fields;
+		}
+
+		/**
+		 * Generate the calendar header for a given range of dates
+		 *
+		 * @param array $dates Date range for the header
+		 * @return string $html Generated HTML for the header
+		 */
+		public function get_time_period_header( $dates ) {
+
+			$html = '';
+			foreach ( $dates as $date ) {
+				$html .= '<th class="column-heading" >';
+				$html .= esc_html( date_i18n( 'l', strtotime( $date ) ) );
+				$html .= '</th>';
+			}
+
+			return $html;
+		}
+
+		/**
+		 * Query to get all of the calendar posts for a given day
+		 *
+		 * @param array $args Any filter arguments we want to pass
+		 * @param string $request_context Where the query is coming from, to distinguish dashboard and subscriptions
+		 * @return array $posts All of the posts as an array sorted by date
+		 */
+		public function get_calendar_posts_for_week( $args = array(), $context = 'dashboard' ) {
+
+			$supported_post_types = $this->get_post_types_for_module( $this->module );
+			$defaults = array(
+				'post_status'      => null,
+				'cat'              => null,
+				'author'           => null,
+				'post_type'        => $supported_post_types,
+				'posts_per_page'   => 200,
 			);
 
-			if( $post->post_type == 'page' )
-				$ed_cap = 'edit_page';
-			else
-				$ed_cap = 'edit_post';
+			$args = array_merge( $defaults, $args );
 
-			if( current_user_can( $ed_cap, $post->ID ) )
-				$information_fields[$key]['editable'] = true;
-		}
+			// Unpublished as a status is just an array of everything but 'publish'.
+			if ( 'unpublish' == $args['post_status'] ) {
+				$args['post_status'] = '';
+				$post_stati = wp_filter_object_list( $this->get_calendar_post_stati(), array( 'name' => 'publish' ), 'not' );
 
-		$information_fields = apply_filters( 'ef_calendar_item_information_fields', $information_fields, $post->ID );
-		foreach( $information_fields as $field => $values ) {
-			// Allow filters to hide empty fields or to hide any given individual field. Hide empty fields by default.
-			if ( ( apply_filters( 'ef_calendar_hide_empty_item_information_fields', true, $post->ID ) && empty( $values['value'] ) )
-					|| apply_filters( "ef_calendar_hide_{$field}_item_information_field", false, $post->ID ) )
-				unset( $information_fields[$field] );
-		}
-		return $information_fields;
-	}
+				if ( ! apply_filters( 'ef_show_scheduled_as_unpublished', false ) ) {
+					$post_stati = wp_filter_object_list( $post_stati, array( 'name' => 'future' ), 'not' );
+				}
 
-	/**
-	 * Generate the calendar header for a given range of dates
-	 *
-	 * @param array $dates Date range for the header
-	 * @return string $html Generated HTML for the header
-	 */
-	function get_time_period_header( $dates ) {
-
-		$html = '';
-		foreach( $dates as $date ) {
-			$html .= '<th class="column-heading" >';
-			$html .= esc_html( date_i18n('l', strtotime( $date ) ) );
-			$html .= '</th>';
-		}
-
-		return $html;
-
-	}
-
-	/**
-	 * Query to get all of the calendar posts for a given day
-	 *
-	 * @param array $args Any filter arguments we want to pass
-	 * @param string $request_context Where the query is coming from, to distinguish dashboard and subscriptions
-	 * @return array $posts All of the posts as an array sorted by date
-	 */
-	function get_calendar_posts_for_week( $args = array(), $context = 'dashboard' ) {
-
-		$supported_post_types = $this->get_post_types_for_module( $this->module );
-		$defaults = array(
-			'post_status'      => null,
-			'cat'              => null,
-			'author'           => null,
-			'post_type'        => $supported_post_types,
-			'posts_per_page'   => 200,
-		);
-
-		$args = array_merge( $defaults, $args );
-
-		// Unpublished as a status is just an array of everything but 'publish'.
-		if ( 'unpublish' == $args['post_status'] ) {
-			$args['post_status'] = '';
-			$post_stati = wp_filter_object_list( $this->get_calendar_post_stati(), array( 'name' => 'publish' ), 'not' );
-
-			if ( ! apply_filters( 'ef_show_scheduled_as_unpublished', false ) ) {
-				$post_stati = wp_filter_object_list( $post_stati, array( 'name' => 'future' ), 'not' );
+				$args['post_status'] .= implode( ',', wp_list_pluck( $post_stati, 'name' ) );
+			}
+			// The WP functions for printing the category and author assign a value of 0 to the default
+			// options, but passing this to the query is bad (trashed and auto-draft posts appear!), so
+			// unset those arguments.
+			if ( '0' === $args['cat'] ) {
+				unset( $args['cat'] );
+			}
+			if ( '0' === $args['author'] ) {
+				unset( $args['author'] );
 			}
 
-			$args['post_status'] .= implode( ',', wp_list_pluck( $post_stati, 'name' ) );
-		}
-		// The WP functions for printing the category and author assign a value of 0 to the default
-		// options, but passing this to the query is bad (trashed and auto-draft posts appear!), so
-		// unset those arguments.
-		if ( $args['cat'] === '0' ) {
-			unset( $args['cat'] );
-		}
-		if ( $args['author'] === '0' ) {
-			unset( $args['author'] );
-		}
+			if ( empty( $args['post_type'] ) || ! in_array( $args['post_type'], $supported_post_types ) ) {
+				$args['post_type'] = $supported_post_types;
+			}
 
-		if ( empty( $args['post_type'] ) || ! in_array( $args['post_type'], $supported_post_types ) ) {
-			$args['post_type'] = $supported_post_types;
-		}
+			$beginning_date = $this->get_beginning_of_week( $this->start_date, 'Y-m-d', $this->current_week );
+			$ending_date    = gmdate( 'Y-m-d', strtotime( $beginning_date ) + WEEK_IN_SECONDS );
 
-		$beginning_date = $this->get_beginning_of_week( $this->start_date, 'Y-m-d', $this->current_week );
-		$ending_date    = date( "Y-m-d", strtotime( $beginning_date ) + WEEK_IN_SECONDS );
+			$args['date_query'] = array(
+				'after'     => $beginning_date,
+				'before'    => $ending_date,
+				'inclusive' => true,
+			);
 
-		$args['date_query'] = array(
-			'after'     => $beginning_date,
-			'before'    => $ending_date,
-			'inclusive' => true,
-		);
+			// Filter for an end user to implement any of their own query args
+			$args = apply_filters( 'ef_calendar_posts_query_args', $args, $context );
+			$post_results = new WP_Query( $args );
 
-		// Filter for an end user to implement any of their own query args
-		$args = apply_filters( 'ef_calendar_posts_query_args', $args, $context );
-		$post_results = new WP_Query( $args );
+			$posts = array();
+			while ( $post_results->have_posts() ) {
+				$post_results->the_post();
+				global $post;
+				$key_date = gmdate( 'Y-m-d', strtotime( $post->post_date ) );
+				$posts[ $key_date ][] = $post;
+			}
 
-		$posts = array();
-		while ( $post_results->have_posts() ) {
-			$post_results->the_post();
-			global $post;
-			$key_date = date( 'Y-m-d', strtotime( $post->post_date ) );
-			$posts[$key_date][] = $post;
+			return $posts;
 		}
 
-		return $posts;
+		/**
+		 * Gets the link for the next time period
+		 *
+		 * @param string $direction 'previous' or 'next', direction to go in time
+		 * @param array $filters Any filters that need to be applied
+		 * @param int $weeks_offset Number of weeks we're offsetting the range
+		 * @return string $url The URL for the next page
+		 */
+		public function get_pagination_link( $direction = 'next', $filters = array(), $weeks_offset = null ) {
 
-	}
+			$supported_post_types = $this->get_post_types_for_module( $this->module );
 
-	/**
-	 * Gets the link for the next time period
-	 *
-	 * @param string $direction 'previous' or 'next', direction to go in time
-	 * @param array $filters Any filters that need to be applied
-	 * @param int $weeks_offset Number of weeks we're offsetting the range
-	 * @return string $url The URL for the next page
-	 */
-	function get_pagination_link( $direction = 'next', $filters = array(), $weeks_offset = null ) {
+			if ( ! isset( $weeks_offset ) ) {
+				$weeks_offset = $this->total_weeks;
+			} else if ( 0 == $weeks_offset ) {
+				$filters['start_date'] = $this->get_beginning_of_week( gmdate( 'Y-m-d', current_time( 'timestamp' ) ) );
+			}
 
-		$supported_post_types = $this->get_post_types_for_module( $this->module );
+			if ( 'previous' == $direction ) {
+				$weeks_offset = '-' . $weeks_offset;
+			}
 
-		if ( !isset( $weeks_offset ) )
-			$weeks_offset = $this->total_weeks;
-		else if ( $weeks_offset == 0 )
-			$filters['start_date'] = $this->get_beginning_of_week( date( 'Y-m-d', current_time( 'timestamp' ) ) );
+			$filters['start_date'] = gmdate( 'Y-m-d', strtotime( $weeks_offset . ' weeks', strtotime( $filters['start_date'] ) ) );
+			$url = add_query_arg( $filters, menu_page_url( $this->module->slug, false ) );
 
-		if ( $direction == 'previous' )
-			$weeks_offset = '-' . $weeks_offset;
+			if ( count( $supported_post_types ) > 1 ) {
+				$url = add_query_arg( 'cpt', $filters['cpt'], $url );
+			}
 
-		$filters['start_date'] = date( 'Y-m-d', strtotime( $weeks_offset . " weeks", strtotime( $filters['start_date'] ) ) );
-		$url = add_query_arg( $filters, menu_page_url( $this->module->slug, false ) );
+			return $url;
+		}
 
-		if ( count( $supported_post_types ) > 1 )
-			$url = add_query_arg( 'cpt', $filters['cpt'] , $url );
+		/**
+		 * Given a day in string format, returns the day at the beginning of that week, which can be the given date.
+		 * The beginning of the week is determined by the blog option, 'start_of_week'.
+		 *
+		 * @see http://www.php.net/manual/en/datetime.formats.date.php for valid date formats
+		 *
+		 * @param string $date String representing a date
+		 * @param string $format Date format in which the beginning of the week should be returned
+		 * @param int $week Number of weeks we're offsetting the range
+		 * @return string $formatted_start_of_week Beginning of the week
+		 */
+		public function get_beginning_of_week( $date, $format = 'Y-m-d', $week = 1 ) {
 
-		return $url;
+			$date = strtotime( $date );
+			$start_of_week = get_option( 'start_of_week' );
+			$day_of_week = gmdate( 'w', $date );
+			$date += ( ( $start_of_week - $day_of_week - 7 ) % 7 ) * 60 * 60 * 24;
+			$date = strtotime( '+' . ( $week - 1 ) . ' week', $date );
+				$formatted_start_of_week = gmdate( $format, $date );
+			return $formatted_start_of_week;
+		}
 
-	}
+		/**
+		 * Given a day in string format, returns the day at the end of that week, which can be the given date.
+		 * The end of the week is determined by the blog option, 'start_of_week'.
+		 *
+		 * @see http://www.php.net/manual/en/datetime.formats.date.php for valid date formats
+		 *
+		 * @param string $date String representing a date
+		 * @param string $format Date format in which the end of the week should be returned
+		 * @param int $week Number of weeks we're offsetting the range
+		 * @return string $formatted_end_of_week End of the week
+		 */
+		public function get_ending_of_week( $date, $format = 'Y-m-d', $week = 1 ) {
 
-	/**
-	 * Given a day in string format, returns the day at the beginning of that week, which can be the given date.
-	 * The beginning of the week is determined by the blog option, 'start_of_week'.
-	 *
-	 * @see http://www.php.net/manual/en/datetime.formats.date.php for valid date formats
-	 *
-	 * @param string $date String representing a date
-	 * @param string $format Date format in which the beginning of the week should be returned
-	 * @param int $week Number of weeks we're offsetting the range
-	 * @return string $formatted_start_of_week Beginning of the week
-	 */
-	function get_beginning_of_week( $date, $format = 'Y-m-d', $week = 1 ) {
+			$date = strtotime( $date );
+			$end_of_week = get_option( 'start_of_week' ) - 1;
+			$day_of_week = gmdate( 'w', $date );
+			$date += ( ( $end_of_week - $day_of_week + 7 ) % 7 ) * 60 * 60 * 24;
+			$date = strtotime( '+' . ( $week - 1 ) . ' week', $date );
+			$formatted_end_of_week = gmdate( $format, $date );
+			return $formatted_end_of_week;
+		}
 
-		$date = strtotime( $date );
-		$start_of_week = get_option( 'start_of_week' );
-		$day_of_week = date( 'w', $date );
-		$date += (( $start_of_week - $day_of_week - 7 ) % 7) * 60 * 60 * 24 ;
-		$date = strtotime ( '+' . ( $week - 1 ) . ' week', $date ) ;
-                $formatted_start_of_week = date( $format, $date );
-		return $formatted_start_of_week;
+		/**
+		 * Human-readable time range for the calendar
+		 * Shows something like "for October 30th through November 26th" for a four-week period
+		 *
+		 * @since 0.7
+		 */
+		public function calendar_time_range() {
 
-	}
+			$first_datetime = strtotime( $this->start_date );
+			$first_date = date_i18n( get_option( 'date_format' ), $first_datetime );
+			$total_days = ( $this->total_weeks * 7 ) - 1;
+			$last_datetime = strtotime( '+' . $total_days . ' days', gmdate( 'U', strtotime( $this->start_date ) ) );
+			$last_date = date_i18n( get_option( 'date_format' ), $last_datetime );
+			// translators: %1$s = first date, %2$s = last date
+			echo esc_html( sprintf( __( 'for %1$s through %2$s', 'edit-flow' ), $first_date, $last_date ) );
+		}
 
-	/**
-	 * Given a day in string format, returns the day at the end of that week, which can be the given date.
-	 * The end of the week is determined by the blog option, 'start_of_week'.
-	 *
-	 * @see http://www.php.net/manual/en/datetime.formats.date.php for valid date formats
-	 *
-	 * @param string $date String representing a date
-	 * @param string $format Date format in which the end of the week should be returned
-	 * @param int $week Number of weeks we're offsetting the range
-	 * @return string $formatted_end_of_week End of the week
-	 */
-	function get_ending_of_week( $date, $format = 'Y-m-d', $week = 1  ) {
+		/**
+		 * Check whether the current user should have the ability to modify the post
+		 *
+		 * @since 0.7
+		 *
+		 * @param object $post The post object we're checking
+		 * @return bool $can Whether or not the current user can modify the post
+		 */
+		public function current_user_can_modify_post( $post ) {
 
-		$date = strtotime( $date );
-		$end_of_week = get_option( 'start_of_week' ) - 1;
-		$day_of_week = date( 'w', $date );
-		$date += (( $end_of_week - $day_of_week + 7 ) % 7) * 60 * 60 * 24;
-		$date = strtotime ( '+' . ( $week - 1 ) . ' week', $date ) ;
-		$formatted_end_of_week = date( $format, $date );
-		return $formatted_end_of_week;
+			if ( ! $post ) {
+				return false;
+			}
 
-	}
+			$post_type_object = get_post_type_object( $post->post_type );
 
-	/**
-	 * Human-readable time range for the calendar
-	 * Shows something like "for October 30th through November 26th" for a four-week period
-	 *
-	 * @since 0.7
-	 */
-	function calendar_time_range() {
+			// Editors and admins are fine
+			if ( current_user_can( $post_type_object->cap->edit_others_posts, $post->ID ) ) {
+				return true;
+			}
+			// Authors and contributors can move their own stuff if it's not published
+			if ( current_user_can( $post_type_object->cap->edit_post, $post->ID ) && wp_get_current_user()->ID == $post->post_author && ! in_array( $post->post_status, $this->published_statuses ) ) {
+				return true;
+			}
+			// Those who can publish posts can move any of their own stuff
+			if ( current_user_can( $post_type_object->cap->publish_posts, $post->ID ) && wp_get_current_user()->ID == $post->post_author ) {
+				return true;
+			}
 
-		$first_datetime = strtotime( $this->start_date );
-		$first_date = date_i18n( get_option( 'date_format' ), $first_datetime );
-		$total_days = ( $this->total_weeks * 7 ) - 1;
-		$last_datetime = strtotime( "+" . $total_days . " days", date( 'U', strtotime( $this->start_date ) ) );
-		$last_date = date_i18n( get_option( 'date_format' ), $last_datetime );
-		echo esc_html( sprintf( __( 'for %1$s through %2$s', 'edit-flow' ), $first_date, $last_date ) );
-	}
-
-	/**
-	 * Check whether the current user should have the ability to modify the post
-	 *
-	 * @since 0.7
-	 *
-	 * @param object $post The post object we're checking
-	 * @return bool $can Whether or not the current user can modify the post
-	 */
-	function current_user_can_modify_post( $post ) {
-
-		if ( !$post )
 			return false;
+		}
 
-		$post_type_object = get_post_type_object( $post->post_type );
-
-		// Editors and admins are fine
-		if ( current_user_can( $post_type_object->cap->edit_others_posts, $post->ID ) )
-			return true;
-		// Authors and contributors can move their own stuff if it's not published
-		if ( current_user_can( $post_type_object->cap->edit_post, $post->ID ) && wp_get_current_user()->ID == $post->post_author && !in_array( $post->post_status, $this->published_statuses ) )
-			return true;
-		// Those who can publish posts can move any of their own stuff
-		if ( current_user_can( $post_type_object->cap->publish_posts, $post->ID ) && wp_get_current_user()->ID == $post->post_author )
-			return true;
-
-		return false;
-	}
-
-	/**
-	 * Register settings for notifications so we can partially use the Settings API
-	 * We use the Settings API for form generation, but not saving because we have our
-	 * own way of handling the data.
-	 *
-	 * @since 0.7
-	 */
-	function register_settings() {
+		/**
+		 * Register settings for notifications so we can partially use the Settings API
+		 * We use the Settings API for form generation, but not saving because we have our
+		 * own way of handling the data.
+		 *
+		 * @since 0.7
+		 */
+		public function register_settings() {
 
 			add_settings_section( $this->module->options_group_name . '_general', false, '__return_false', $this->module->options_group_name );
 			add_settings_field( 'post_types', __( 'Post types to show', 'edit-flow' ), array( $this, 'settings_post_types_option' ), $this->module->options_group_name, $this->module->options_group_name . '_general' );
 			add_settings_field( 'quick_create_post_type', __( 'Post type to create directly from calendar', 'edit-flow' ), array( $this, 'settings_quick_create_post_type_option' ), $this->module->options_group_name, $this->module->options_group_name . '_general' );
 			add_settings_field( 'ics_subscription', __( 'Subscription in iCal or Google Calendar', 'edit-flow' ), array( $this, 'settings_ics_subscription_option' ), $this->module->options_group_name, $this->module->options_group_name . '_general' );
-
-	}
-
-	/**
-	 * Choose the post types that should be displayed on the calendar
-	 *
-	 * @since 0.7
-	 */
-	function settings_post_types_option() {
-		global $edit_flow;
-		$edit_flow->settings->helper_option_custom_post_type( $this->module );
-	}
-
-	/**
-	 * Choose the post type that should be created on the calendar
-	 *
-	 * @since 0.8
-	 */
-	function settings_quick_create_post_type_option() {
-
-		$allowed_post_types = $this->get_all_post_types();
-
-		echo "<select name='" . esc_attr( $this->module->options_group_name ) . "[quick_create_post_type]'>";
-		foreach( $allowed_post_types as $post_type => $title )
-			echo "<option value='" . esc_attr( $post_type ) . "' " . selected( $post_type, $this->module->options->quick_create_post_type, false ) . ">".esc_html( $title )."</option>";
-		echo "</select>";
-
-	}
-
-	/**
-	 * Enable calendar subscriptions via .ics in iCal or Google Calendar
-	 *
-	 * @since 0.8
-	 */
-	function settings_ics_subscription_option() {
-		$options = array(
-			'off'       => __( 'Disabled', 'edit-flow' ),
-			'on'        => __( 'Enabled', 'edit-flow' ),
-		);
-		echo '<select id="ics_subscription" name="' . esc_attr( $this->module->options_group_name ) . '[ics_subscription]">';
-		foreach ( $options as $value => $label ) {
-			echo '<option value="' . esc_attr( $value ) . '"';
-			echo selected( $this->module->options->ics_subscription, $value );
-			echo '>' . esc_html( $label ) . '</option>';
 		}
-		echo '</select>';
+
+		/**
+		 * Choose the post types that should be displayed on the calendar
+		 *
+		 * @since 0.7
+		 */
+		public function settings_post_types_option() {
+			global $edit_flow;
+			$edit_flow->settings->helper_option_custom_post_type( $this->module );
+		}
+
+		/**
+		 * Choose the post type that should be created on the calendar
+		 *
+		 * @since 0.8
+		 */
+		public function settings_quick_create_post_type_option() {
+
+			$allowed_post_types = $this->get_all_post_types();
+
+			echo "<select name='" . esc_attr( $this->module->options_group_name ) . "[quick_create_post_type]'>";
+			foreach ( $allowed_post_types as $post_type => $title ) {
+				echo "<option value='" . esc_attr( $post_type ) . "' " . selected( $post_type, $this->module->options->quick_create_post_type, false ) . '>' . esc_html( $title ) . '</option>';
+			}
+			echo '</select>';
+		}
+
+		/**
+		 * Enable calendar subscriptions via .ics in iCal or Google Calendar
+		 *
+		 * @since 0.8
+		 */
+		public function settings_ics_subscription_option() {
+			$options = array(
+				'off'       => __( 'Disabled', 'edit-flow' ),
+				'on'        => __( 'Enabled', 'edit-flow' ),
+			);
+			echo '<select id="ics_subscription" name="' . esc_attr( $this->module->options_group_name ) . '[ics_subscription]">';
+			foreach ( $options as $value => $label ) {
+				echo '<option value="' . esc_attr( $value ) . '"';
+				echo selected( $this->module->options->ics_subscription, $value );
+				echo '>' . esc_html( $label ) . '</option>';
+			}
+			echo '</select>';
 
 
-		$regenerate_url = add_query_arg( 'action', 'ef_calendar_regenerate_calendar_feed_secret', admin_url( 'index.php' ) );
-		$regenerate_url = wp_nonce_url( $regenerate_url, 'ef-regenerate-ics-key' );
-		echo '&nbsp;&nbsp;&nbsp;<a href="' . esc_url( $regenerate_url ) . '">' . esc_html_e( 'Regenerate calendar feed secret', 'edit-flow' ) . '</a>';
+			$regenerate_url = add_query_arg( 'action', 'ef_calendar_regenerate_calendar_feed_secret', admin_url( 'index.php' ) );
+			$regenerate_url = wp_nonce_url( $regenerate_url, 'ef-regenerate-ics-key' );
+			echo '&nbsp;&nbsp;&nbsp;<a href="' . esc_url( $regenerate_url ) . '">' . esc_html_e( 'Regenerate calendar feed secret', 'edit-flow' ) . '</a>';
 
-		// If our secret key doesn't exist, create a new one
-		if ( empty( $this->module->options->ics_secret_key ) )
-			EditFlow()->update_module_option( $this->module->name, 'ics_secret_key', wp_generate_password() );
-	}
+			// If our secret key doesn't exist, create a new one
+			if ( empty( $this->module->options->ics_secret_key ) ) {
+				EditFlow()->update_module_option( $this->module->name, 'ics_secret_key', wp_generate_password() );
+			}
+		}
 
-	/**
-	 * Validate the data submitted by the user in calendar settings
-	 *
-	 * @since 0.7
-	 */
-	function settings_validate( $new_options ) {
+		/**
+		 * Validate the data submitted by the user in calendar settings
+		 *
+		 * @since 0.7
+		 */
+		public function settings_validate( $new_options ) {
 
-		$options = (array)$this->module->options;
+			$options = (array) $this->module->options;
 
-		$options['post_types'] = $this->clean_post_type_options( $new_options['post_types'], $this->module->post_type_support );
+			$options['post_types'] = $this->clean_post_type_options( $new_options['post_types'], $this->module->post_type_support );
 
-		if ( in_array( $new_options['quick_create_post_type'], array_keys( $this->get_all_post_types() ) ) )
-			$options['quick_create_post_type'] = $new_options['quick_create_post_type'];
+			if ( in_array( $new_options['quick_create_post_type'], array_keys( $this->get_all_post_types() ) ) ) {
+				$options['quick_create_post_type'] = $new_options['quick_create_post_type'];
+			}
 
-		if ( 'on' != $new_options['ics_subscription'] )
-			$options['ics_subscription'] = 'off';
-		else
-			$options['ics_subscription'] = 'on';
+			if ( 'on' != $new_options['ics_subscription'] ) {
+				$options['ics_subscription'] = 'off';
+			} else {
+				$options['ics_subscription'] = 'on';
+			}
 
-		return $options;
-	}
+			return $options;
+		}
 
-	/**
-	 * Settings page for calendar
-	 */
-	function print_configure_view() {
-		global $edit_flow;
-		?>
+		/**
+		 * Settings page for calendar
+		 */
+		public function print_configure_view() {
+			global $edit_flow;
+			?>
 		<form class="basic-settings" action="<?php echo esc_url( menu_page_url( $this->module->settings_slug, false ) ); ?>" method="post">
 			<?php settings_fields( $this->module->options_group_name ); ?>
 			<?php do_settings_sections( $this->module->options_group_name ); ?>
@@ -1489,380 +1528,392 @@ class EF_Calendar extends EF_Module {
 			?>
 			<p class="submit"><?php submit_button( null, 'primary', 'submit', false ); ?><a class="cancel-settings-link" href="<?php echo esc_url( EDIT_FLOW_SETTINGS_PAGE ); ?>"><?php esc_html_e( 'Back to Edit Flow', 'edit-flow' ); ?></a></p>
 		</form>
-		<?php
-	}
-
-	/**
-	 * Ajax callback to insert a post placeholder for a particular date
-	 *
-	 * @since 0.8
-	 */
-	function handle_ajax_insert_post() {
-
-		// Nonce check!
-		if ( !isset( $_POST['nonce'] ) || !wp_verify_nonce( $_POST['nonce'], 'ef-calendar-modify' ) ) {
-			$this->print_ajax_response( 'error', $this->module->messages['nonce-failed'] );
+			<?php
 		}
 
-		// Check that the user has the right capabilities to add posts to the calendar (defaults to 'edit_posts')
-		if ( !current_user_can( $this->create_post_cap ) )
-			$this->print_ajax_response( 'error', $this->module->messages['invalid-permissions'] );
+		/**
+		 * Ajax callback to insert a post placeholder for a particular date
+		 *
+		 * @since 0.8
+		 */
+		public function handle_ajax_insert_post() {
 
-		if ( empty( $_POST['ef_insert_date'] ) ) {
-			$this->print_ajax_response( 'error', __( 'No date supplied.', 'edit-flow' ) );
+			// Nonce check!
+			if ( ! isset( $_POST['nonce'] ) || ! wp_verify_nonce( $_POST['nonce'], 'ef-calendar-modify' ) ) {
+				$this->print_ajax_response( 'error', $this->module->messages['nonce-failed'] );
+			}
+
+			// Check that the user has the right capabilities to add posts to the calendar (defaults to 'edit_posts')
+			if ( ! current_user_can( $this->create_post_cap ) ) {
+				$this->print_ajax_response( 'error', $this->module->messages['invalid-permissions'] );
+			}
+
+			if ( empty( $_POST['ef_insert_date'] ) ) {
+				$this->print_ajax_response( 'error', __( 'No date supplied.', 'edit-flow' ) );
+			}
+
+			// Post type has to be visible on the calendar to create a placeholder
+			if ( ! in_array( $this->module->options->quick_create_post_type, $this->get_post_types_for_module( $this->module ) ) ) {
+				$this->print_ajax_response( 'error', __( 'Please change Quick Create to use a post type viewable on the calendar.', 'edit-flow' ) );
+			}
+
+			// Sanitize post values
+			$post_title = isset( $_POST['ef_insert_title'] ) ? sanitize_text_field( $_POST['ef_insert_title'] ) : null;
+
+			if ( ! $post_title ) {
+				$post_title = esc_html__( 'Untitled', 'edit-flow' );
+			}
+
+			$post_date = sanitize_text_field( $_POST['ef_insert_date'] );
+
+			$post_status = $this->get_default_post_status();
+
+			// Set new post parameters
+			$post_placeholder = array(
+				'post_title' => $post_title,
+				'post_status' => $post_status,
+				'post_date' => gmdate( 'Y-m-d H:i:s', strtotime( $post_date ) ),
+				'post_type' => $this->module->options->quick_create_post_type,
+			);
+
+			// By default, adding a post to the calendar won't set the timestamp.
+			// If the user desires that to be the behavior, they can set the result of this filter to 'true'
+			// With how WordPress works internally, setting 'post_date_gmt' will set the timestamp
+			if ( apply_filters( 'ef_calendar_allow_ajax_to_set_timestamp', false ) ) {
+				$post_placeholder['post_date_gmt'] = gmdate( 'Y-m-d H:i:s', strtotime( $post_date ) );
+			}
+
+			// Create the post
+			$post_id = wp_insert_post( $post_placeholder );
+
+			if ( $post_id ) { // success!
+
+				$post = get_post( $post_id );
+
+				// Generate the HTML for the post item so it can be injected
+				$post_li_html = $this->generate_post_li_html( $post, $post_date );
+
+				// announce success and send back the html to inject
+				$this->print_ajax_response( 'success', $post_li_html );
+
+			} else {
+				$this->print_ajax_response( 'error', __( 'Post could not be created', 'edit-flow' ) );
+			}
 		}
 
-		// Post type has to be visible on the calendar to create a placeholder
-		if ( ! in_array( $this->module->options->quick_create_post_type, $this->get_post_types_for_module( $this->module ) ) )
-			$this->print_ajax_response( 'error', __( 'Please change Quick Create to use a post type viewable on the calendar.', 'edit-flow' ) );
+		/**
+		 * Returns the singular label for the posts that are
+		 * quick-created on the calendar
+		 *
+		 * @return str Singular label for a post-type
+		 */
+		public function get_quick_create_post_type_name() {
 
-		// Sanitize post values
-		$post_title = isset( $_POST['ef_insert_title'] ) ? sanitize_text_field( $_POST['ef_insert_title'] ) : null;
+			$post_type_slug = $this->module->options->quick_create_post_type;
+			$post_type_obj = get_post_type_object( $post_type_slug );
 
-		if( ! $post_title ) {
-			$post_title = esc_html__( 'Untitled', 'edit-flow' );
+			return $post_type_obj->labels->singular_name ? $post_type_obj->labels->singular_name : $post_type_slug;
 		}
 
-		$post_date = sanitize_text_field( $_POST['ef_insert_date'] );
+		/**
+		 * ajax_ef_calendar_update_metadata
+		 * Update the metadata from the calendar.
+		 * @return string representing the overlay
+		 *
+		 * @since 0.8
+		 */
+		public function handle_ajax_update_metadata() {
+			global $wpdb;
 
-		$post_status = $this->get_default_post_status();
+			if ( ! isset( $_POST['nonce'] ) || ! wp_verify_nonce( $_POST['nonce'], 'ef-calendar-modify' ) ) {
+				$this->print_ajax_response( 'error', $this->module->messages['nonce-failed'] );
+			}
 
-		// Set new post parameters
-		$post_placeholder = array(
-			'post_title' => $post_title,
-			'post_status' => $post_status,
-			'post_date' => date( 'Y-m-d H:i:s', strtotime( $post_date ) ),
-			'post_type' => $this->module->options->quick_create_post_type,
-		);
+			if ( ! isset( $_POST['post_id'] ) ) {
+				$this->print_ajax_response( 'error', $this->module->messages['missing-post'] );
+			}
 
-		// By default, adding a post to the calendar won't set the timestamp.
-		// If the user desires that to be the behavior, they can set the result of this filter to 'true'
-		// With how WordPress works internally, setting 'post_date_gmt' will set the timestamp
-		if ( apply_filters( 'ef_calendar_allow_ajax_to_set_timestamp', false ) )
-			$post_placeholder['post_date_gmt'] = date( 'Y-m-d H:i:s', strtotime( $post_date ) );
-
-		// Create the post
-		$post_id = wp_insert_post( $post_placeholder );
-
-		if( $post_id ) { // success!
-
+			// Check that we got a proper post
+			$post_id = (int) $_POST['post_id'];
 			$post = get_post( $post_id );
 
-			// Generate the HTML for the post item so it can be injected
-			$post_li_html = $this->generate_post_li_html( $post, $post_date );
-
-			// announce success and send back the html to inject
-			$this->print_ajax_response( 'success', $post_li_html );
-
-		} else {
-			$this->print_ajax_response( 'error', __( 'Post could not be created', 'edit-flow' ) );
-		}
-	}
-
-	/**
-	 * Returns the singular label for the posts that are
-	 * quick-created on the calendar
-	 *
-	 * @return str Singular label for a post-type
-	 */
-	function get_quick_create_post_type_name(){
-
-		$post_type_slug = $this->module->options->quick_create_post_type;
-		$post_type_obj = get_post_type_object( $post_type_slug );
-
-		return $post_type_obj->labels->singular_name ? $post_type_obj->labels->singular_name : $post_type_slug;
-	}
-
-	/**
-	 * ajax_ef_calendar_update_metadata
-	 * Update the metadata from the calendar.
-	 * @return string representing the overlay
-	 *
-	 * @since 0.8
-	 */
-	function handle_ajax_update_metadata() {
-		global $wpdb;
-
-		if ( !isset( $_POST['nonce'] ) || ! wp_verify_nonce( $_POST['nonce'], 'ef-calendar-modify' ) ) {
-			$this->print_ajax_response( 'error', $this->module->messages['nonce-failed'] );
-		}
-
-		if ( !isset( $_POST['post_id'] ) ) {
-			$this->print_ajax_response( 'error', $this->module->messages['missing-post'] );
-		}
-
-		// Check that we got a proper post
-		$post_id = ( int )$_POST['post_id'];
-		$post = get_post( $post_id );
-
-		if ( ! $post )
-			$this->print_ajax_response( 'error', $this->module->messages['missing-post'] );
-
-
-		if( $post->post_type == 'page' )
-			$edit_check = 'edit_page';
-		else
-			$edit_check = 'edit_post';
-
-		if ( !current_user_can( $edit_check, $post->ID ) )
-			$this->print_ajax_response( 'error', $this->module->messages['invalid-permissions'] );
-
-		// Check that the user can modify the post
-		if ( ! $this->current_user_can_modify_post( $post ) )
-			$this->print_ajax_response( 'error', $this->module->messages['invalid-permissions'] );
-
-		$default_types = array(
-			'author',
-			'taxonomy',
-		);
-
-		$metadata_types = array();
-
-		if ( !$this->module_enabled( 'editorial_metadata' ) )
-			$this->print_ajax_response( 'error', $this->module->messages['update-error'] );
-
-		$metadata_types = array_keys( EditFlow()->editorial_metadata->get_supported_metadata_types() );
-
-		// Update an editorial metadata field
-		$metadata_term = isset( $_POST['metadata_term'] ) ? $_POST['metadata_term'] : '';
-		$metadata_type = isset( $_POST['metadata_type'] ) ? $_POST['metadata_type'] : '';
-		$incoming_metadata_value = isset( $_POST['metadata_value'] ) ? $_POST['metadata_value'] : '';
-
-		if ( isset( $_POST['metadata_type'] ) && in_array( $_POST['metadata_type'], $metadata_types ) ) {
-			$post_meta_key = sanitize_text_field( '_ef_editorial_meta_' . $_POST['metadata_type'] . '_' . $metadata_term );
-
-			//Javascript date parsing is terrible, so use strtotime in php
-			if ( $metadata_type == 'date' )
-				$metadata_value = strtotime( sanitize_text_field( $incoming_metadata_value ) );
-			else
-				$metadata_value = sanitize_text_field( $incoming_metadata_value );
-
-			update_post_meta( $post->ID, $post_meta_key, $metadata_value );
-			$response = 'success';
-		} else {
-			switch( $_POST['metadata_type'] ) {
-				case 'taxonomy':
-				case 'taxonomy hierarchical':
-					$response = wp_set_post_terms( $post->ID, $incoming_metadata_value, $metadata_term );
-				break;
-				default:
-					$response = new WP_Error( 'invalid-type', __( 'Invalid metadata type', 'edit-flow' ) );
-				break;
+			if ( ! $post ) {
+				$this->print_ajax_response( 'error', $this->module->messages['missing-post'] );
 			}
-		}
 
-		//Assuming we've got to this point, just regurgitate the value
-		if ( ! is_wp_error( $response ) )
-			$this->print_ajax_response( 'success', $incoming_metadata_value );
-		else
-			$this->print_ajax_response( 'error', __( 'Metadata could not be updated.', 'edit-flow' ) );
-	}
 
-	function calendar_filters() {
-		$select_filter_names = array();
+			if ( 'page' == $post->post_type ) {
+				$edit_check = 'edit_page';
+			} else {
+				$edit_check = 'edit_post';
+			}
 
-		$select_filter_names['post_status'] = 'post_status';
-		$select_filter_names['cat'] = 'cat';
-		$select_filter_names['author'] = 'author';
-		$select_filter_names['type'] = 'cpt';
-		$select_filter_name['num_weeks'] = 'num_weeks';
+			if ( ! current_user_can( $edit_check, $post->ID ) ) {
+				$this->print_ajax_response( 'error', $this->module->messages['invalid-permissions'] );
+			}
 
-		return apply_filters( 'ef_calendar_filter_names', $select_filter_names );
-	}
+			// Check that the user can modify the post
+			if ( ! $this->current_user_can_modify_post( $post ) ) {
+				$this->print_ajax_response( 'error', $this->module->messages['invalid-permissions'] );
+			}
 
-	/**
-	 * Sanitize a $_GET or similar filter being used on the calendar
-	 *
-	 * @since 0.8
-	 *
-	 * @param string $key Filter being sanitized
-	 * @param string $dirty_value Value to be sanitized
-	 * @return string $sanitized_value Safe to use value
-	 */
-	function sanitize_filter( $key, $dirty_value ) {
+			$default_types = array(
+				'author',
+				'taxonomy',
+			);
 
-		switch( $key ) {
-			case 'post_status':
-				// Whitelist-based validation for this parameter
-				$valid_statuses = wp_list_pluck( $this->get_calendar_post_stati(), 'name' );
-				$valid_statuses[] = 'unpublish';
+			$metadata_types = array();
 
-				if ( in_array( $dirty_value, $valid_statuses ) )
-					return $dirty_value;
-				else
-					return '';
-				break;
-			case 'cpt':
-				$cpt = sanitize_key( $dirty_value );
-				$supported_post_types = $this->get_post_types_for_module( $this->module );
-				if ( $cpt && in_array( $cpt, $supported_post_types ) )
-					return $cpt;
-				else
-					return '';
-				break;
-			case 'start_date':
-				return date( 'Y-m-d', strtotime( $dirty_value ) );
-				break;
-			case 'cat':
-			case 'author':
-				return intval( $dirty_value );
-				break;
-			case 'num_weeks':
-				$num_weeks = intval( $dirty_value );
-				if ( $num_weeks <= 0 ) {
-					return $this->total_weeks;
-				} else if ( $num_weeks > $this->max_weeks ) {
-					return $this->max_weeks;
+			if ( ! $this->module_enabled( 'editorial_metadata' ) ) {
+				$this->print_ajax_response( 'error', $this->module->messages['update-error'] );
+			}
+
+			$metadata_types = array_keys( EditFlow()->editorial_metadata->get_supported_metadata_types() );
+
+			// Update an editorial metadata field
+			$metadata_term = isset( $_POST['metadata_term'] ) ? $_POST['metadata_term'] : '';
+			$metadata_type = isset( $_POST['metadata_type'] ) ? $_POST['metadata_type'] : '';
+			$incoming_metadata_value = isset( $_POST['metadata_value'] ) ? $_POST['metadata_value'] : '';
+
+			if ( isset( $_POST['metadata_type'] ) && in_array( $_POST['metadata_type'], $metadata_types ) ) {
+				$post_meta_key = sanitize_text_field( '_ef_editorial_meta_' . $_POST['metadata_type'] . '_' . $metadata_term );
+
+				//Javascript date parsing is terrible, so use strtotime in php
+				if ( 'date' == $metadata_type ) {
+					$metadata_value = strtotime( sanitize_text_field( $incoming_metadata_value ) );
 				} else {
-					return $num_weeks;
+					$metadata_value = sanitize_text_field( $incoming_metadata_value );
 				}
-			default:
-				return false;
-				break;
-		}
-	}
 
-	/**
-	 * When a post is updated, clean the <li> html post cache for it
-	 */
-	public function action_clean_li_html_cache( $post_id ) {
+				update_post_meta( $post->ID, $post_meta_key, $metadata_value );
+				$response = 'success';
+			} else {
+				switch ( $_POST['metadata_type'] ) {
+					case 'taxonomy':
+					case 'taxonomy hierarchical':
+						$response = wp_set_post_terms( $post->ID, $incoming_metadata_value, $metadata_term );
+						break;
+					default:
+						$response = new WP_Error( 'invalid-type', __( 'Invalid metadata type', 'edit-flow' ) );
+						break;
+				}
+			}
 
-		wp_cache_delete( $post_id . 'can_modify', self::$post_li_html_cache_key );
-		wp_cache_delete( $post_id . 'read_only', self::$post_li_html_cache_key );
-	}
-
-	/**
-	 * This is a hack! hack! hack! until core is fixed
-	 *
-	 * The calendar uses 'post_date' field to store the position on the calendar
-	 * If a post has a core post status assigned (e.g. 'draft' or 'pending'), the `post_date`
-	 * field will be reset when `wp_update_post()`
-	 * is used: http://core.trac.wordpress.org/browser/tags/3.7.1/src/wp-includes/post.php#L2998
-	 *
-	 * This method temporarily caches the `post_date` field if it needs to be restored.
-	 *
-	 * @uses fix_post_date_on_update_part_two()
-	 */
-	public function fix_post_date_on_update_part_one( $post_ID, $data ) {
-
-		$post = get_post( $post_ID );
-
-		// `post_date` is only nooped for these three statuses,
-		// but don't try to persist if `post_date_gmt` is set
-		if ( ! in_array( $post->post_status, array( 'draft', 'pending', 'auto-draft' ) )
-			|| '0000-00-00 00:00:00' !== $post->post_date_gmt
-			|| '0000-00-00 00:00:00' !== $data['post_date_gmt'] )
-			return;
-
-		$this->post_date_cache[ $post_ID ] = $post->post_date;
-
-	}
-
-	/**
-	 * This is a hack! hack! hack! until core is fixed
-	 *
-	 * The calendar uses 'post_date' field to store the position on the calendar
-	 * If a post has a core post status assigned (e.g. 'draft' or 'pending'), the `post_date`
-	 * field will be reset when `wp_update_post()`
-	 * is used: http://core.trac.wordpress.org/browser/tags/3.7.1/src/wp-includes/post.php#L2998
-	 *
-	 * This method restores the `post_date` field if it needs to be restored.
-	 *
-	 * @uses fix_post_date_on_update_part_one()
-	 */
-	public function fix_post_date_on_update_part_two( $post_ID, $post_after, $post_before ) {
-		global $wpdb;
-
-		if ( empty( $this->post_date_cache[ $post_ID ] ) )
-			return;
-
-		$post_date = $this->post_date_cache[ $post_ID ];
-		unset( $this->post_date_cache[ $post_ID ] );
-		$wpdb->update( $wpdb->posts, array( 'post_date' => $post_date ), array( 'ID' => $post_ID ) );
-		clean_post_cache( $post_ID );
-	}
-
-	/**
-	 * Returns a list of custom status objects used by the calendar
-	 *
-	 * @return array An array of StdClass objects representing statuses
-	 */
-	public function get_calendar_post_stati() {
-		$post_stati = get_post_stati( array(), 'object' );
-		$custom_status_slugs = wp_list_pluck( $this->get_post_statuses(), 'slug' );
-		$custom_status_slugs[] = 'future';
-		$custom_status_slugs[] = 'publish';
-
-		$custom_status_slug_keys = array_flip( $custom_status_slugs );
-
-		$final_statuses = [];
-
-		foreach( $post_stati as $status ) {
-			if ( !empty( $custom_status_slug_keys[ $status->name ] ) ) {
-				$final_statuses[] = $status;
+			//Assuming we've got to this point, just regurgitate the value
+			if ( ! is_wp_error( $response ) ) {
+				$this->print_ajax_response( 'success', $incoming_metadata_value );
+			} else {
+				$this->print_ajax_response( 'error', __( 'Metadata could not be updated.', 'edit-flow' ) );
 			}
 		}
 
-		return apply_filters( 'ef_calendar_post_stati', $final_statuses );
-	}
+		public function calendar_filters() {
+			$select_filter_names = array();
 
-	public function get_calendar_users() {
-		$users_args = array(
-			'orderby'                 => 'display_name',
-			'order'                   => 'ASC',
-			'blog_id'                 => get_current_blog_id()
-		);
+			$select_filter_names['post_status'] = 'post_status';
+			$select_filter_names['cat'] = 'cat';
+			$select_filter_names['author'] = 'author';
+			$select_filter_names['type'] = 'cpt';
+			$select_filter_name['num_weeks'] = 'num_weeks';
 
-		$users_args = apply_filters( 'ef_calendar_dropdown_users_args', $users_args );
+			return apply_filters( 'ef_calendar_filter_names', $select_filter_names );
+		}
 
-		return get_users( $users_args );
-	}
+		/**
+		 * Sanitize a $_GET or similar filter being used on the calendar
+		 *
+		 * @since 0.8
+		 *
+		 * @param string $key Filter being sanitized
+		 * @param string $dirty_value Value to be sanitized
+		 * @return string $sanitized_value Safe to use value
+		 */
+		public function sanitize_filter( $key, $dirty_value ) {
 
-	public function get_calendar_categories() {
-		$categories_args = array(
-			'orderby'           => 'id',
-			'order'             => 'ASC',
-			'hide_empty'        => 0,
-			'hierarchical'      => 0,
-			'taxonomy'          => 'category'
-		);
+			switch ( $key ) {
+				case 'post_status':
+					// Whitelist-based validation for this parameter
+					$valid_statuses = wp_list_pluck( $this->get_calendar_post_stati(), 'name' );
+					$valid_statuses[] = 'unpublish';
 
-		return get_terms( $categories_args );
-	}
+					if ( in_array( $dirty_value, $valid_statuses ) ) {
+						return $dirty_value;
+					} else {
+						return '';
+					}
+					break;
+				case 'cpt':
+					$cpt = sanitize_key( $dirty_value );
+					$supported_post_types = $this->get_post_types_for_module( $this->module );
+					if ( $cpt && in_array( $cpt, $supported_post_types ) ) {
+						return $cpt;
+					} else {
+						return '';
+					}
+					break;
+				case 'start_date':
+					return gmdate( 'Y-m-d', strtotime( $dirty_value ) );
+				break;
+				case 'cat':
+				case 'author':
+					return intval( $dirty_value );
+				break;
+				case 'num_weeks':
+					$num_weeks = intval( $dirty_value );
+					if ( $num_weeks <= 0 ) {
+						return $this->total_weeks;
+					} else if ( $num_weeks > $this->max_weeks ) {
+						return $this->max_weeks;
+					} else {
+						return $num_weeks;
+					}
+				default:
+					return false;
+				break;
+			}
+		}
 
-	public function get_calendar_frontend_config() {
-		global $wp_version;
+		/**
+		 * When a post is updated, clean the <li> html post cache for it
+		 */
+		public function action_clean_li_html_cache( $post_id ) {
 
-		$all_post_types = get_post_types( null, 'objects' );
+			wp_cache_delete( $post_id . 'can_modify', self::$post_li_html_cache_key );
+			wp_cache_delete( $post_id . 'read_only', self::$post_li_html_cache_key );
+		}
 
-		$config = array(
-			'POST_STATI' => $this->get_calendar_post_stati(),
-			'USERS' => array_map(
-				function( $item ) {
-					return array(
-						'id' => $item->ID,
-						'display_name' => $item->display_name,
-					);
-				},
-				$this->get_calendar_users()
-			),
-			'CATEGORIES' => $this->get_calendar_categories(),
-			'POST_TYPES' => array_map( function ( $item ) use ( $all_post_types ) {
-				return $all_post_types[ $item ];
-			}, $this->get_post_types_for_module( $this->module ) ),
-			'NUM_WEEKS' => array(
-				'MAX' => $this->max_weeks,
-				'DEFAULT' => $this->total_weeks,
-			),
-			'BEGINNING_OF_WEEK' => $this->get_beginning_of_week( date( 'Y-m-d', current_time( 'timestamp' ) ) ),
-			'FILTERS' => $this->get_filters(),
-			'PAGE_URL' => menu_page_url( $this->module->slug, false ),
-			'WP_VERSION' => $wp_version
-		);
+		/**
+		 * This is a hack! hack! hack! until core is fixed
+		 *
+		 * The calendar uses 'post_date' field to store the position on the calendar
+		 * If a post has a core post status assigned (e.g. 'draft' or 'pending'), the `post_date`
+		 * field will be reset when `wp_update_post()`
+		 * is used: http://core.trac.wordpress.org/browser/tags/3.7.1/src/wp-includes/post.php#L2998
+		 *
+		 * This method temporarily caches the `post_date` field if it needs to be restored.
+		 *
+		 * @uses fix_post_date_on_update_part_two()
+		 */
+		public function fix_post_date_on_update_part_one( $post_ID, $data ) {
 
-		return apply_filters( 'ef_calendar_frontend_config', $config );
-	}
+			$post = get_post( $post_ID );
 
-} // EF_Calendar
+			// `post_date` is only nooped for these three statuses,
+			// but don't try to persist if `post_date_gmt` is set
+			if ( ! in_array( $post->post_status, array( 'draft', 'pending', 'auto-draft' ) )
+			|| '0000-00-00 00:00:00' !== $post->post_date_gmt
+			|| '0000-00-00 00:00:00' !== $data['post_date_gmt'] ) {
+				return;
+			}
+
+			$this->post_date_cache[ $post_ID ] = $post->post_date;
+		}
+
+		/**
+		 * This is a hack! hack! hack! until core is fixed
+		 *
+		 * The calendar uses 'post_date' field to store the position on the calendar
+		 * If a post has a core post status assigned (e.g. 'draft' or 'pending'), the `post_date`
+		 * field will be reset when `wp_update_post()`
+		 * is used: http://core.trac.wordpress.org/browser/tags/3.7.1/src/wp-includes/post.php#L2998
+		 *
+		 * This method restores the `post_date` field if it needs to be restored.
+		 *
+		 * @uses fix_post_date_on_update_part_one()
+		 */
+		public function fix_post_date_on_update_part_two( $post_ID, $post_after, $post_before ) {
+			global $wpdb;
+
+			if ( empty( $this->post_date_cache[ $post_ID ] ) ) {
+				return;
+			}
+
+			$post_date = $this->post_date_cache[ $post_ID ];
+			unset( $this->post_date_cache[ $post_ID ] );
+			$wpdb->update( $wpdb->posts, array( 'post_date' => $post_date ), array( 'ID' => $post_ID ) );
+			clean_post_cache( $post_ID );
+		}
+
+		/**
+		 * Returns a list of custom status objects used by the calendar
+		 *
+		 * @return array An array of StdClass objects representing statuses
+		 */
+		public function get_calendar_post_stati() {
+			$post_stati = get_post_stati( array(), 'object' );
+			$custom_status_slugs = wp_list_pluck( $this->get_post_statuses(), 'slug' );
+			$custom_status_slugs[] = 'future';
+			$custom_status_slugs[] = 'publish';
+
+			$custom_status_slug_keys = array_flip( $custom_status_slugs );
+
+			$final_statuses = [];
+
+			foreach ( $post_stati as $status ) {
+				if ( ! empty( $custom_status_slug_keys[ $status->name ] ) ) {
+					$final_statuses[] = $status;
+				}
+			}
+
+			return apply_filters( 'ef_calendar_post_stati', $final_statuses );
+		}
+
+		public function get_calendar_users() {
+			$users_args = array(
+				'orderby'                 => 'display_name',
+				'order'                   => 'ASC',
+				'blog_id'                 => get_current_blog_id(),
+			);
+
+			$users_args = apply_filters( 'ef_calendar_dropdown_users_args', $users_args );
+
+			return get_users( $users_args );
+		}
+
+		public function get_calendar_categories() {
+			$categories_args = array(
+				'orderby'           => 'id',
+				'order'             => 'ASC',
+				'hide_empty'        => 0,
+				'hierarchical'      => 0,
+				'taxonomy'          => 'category',
+			);
+
+			return get_terms( $categories_args );
+		}
+
+		public function get_calendar_frontend_config() {
+			global $wp_version;
+
+			$all_post_types = get_post_types( null, 'objects' );
+
+			$config = array(
+				'POST_STATI' => $this->get_calendar_post_stati(),
+				'USERS' => array_map(
+					function ( $item ) {
+						return array(
+							'id' => $item->ID,
+							'display_name' => $item->display_name,
+						);
+					},
+					$this->get_calendar_users()
+				),
+				'CATEGORIES' => $this->get_calendar_categories(),
+				'POST_TYPES' => array_map( function ( $item ) use ( $all_post_types ) {
+					return $all_post_types[ $item ];
+				}, $this->get_post_types_for_module( $this->module ) ),
+				'NUM_WEEKS' => array(
+					'MAX' => $this->max_weeks,
+					'DEFAULT' => $this->total_weeks,
+				),
+				'BEGINNING_OF_WEEK' => $this->get_beginning_of_week( gmdate( 'Y-m-d', current_time( 'timestamp' ) ) ),
+				'FILTERS' => $this->get_filters(),
+				'PAGE_URL' => menu_page_url( $this->module->slug, false ),
+				'WP_VERSION' => $wp_version,
+			);
+
+			return apply_filters( 'ef_calendar_frontend_config', $config );
+		}
+	} // EF_Calendar
 
 } // class_exists('EF_Calendar')

--- a/modules/calendar/calendar.php
+++ b/modules/calendar/calendar.php
@@ -357,10 +357,10 @@ if ( ! class_exists( 'EF_Calendar' ) ) {
 
 			// Persist the old hourstamp because we can't manipulate the exact time on the calendar
 			// Bump the last modified timestamps too
-			$existing_time = gmdate( 'H:i:s', strtotime( $post->post_date ) );
-			$existing_time_gmt = gmdate( 'H:i:s', strtotime( $post->post_date_gmt ) );
+			$existing_time = date( 'H:i:s', strtotime( $post->post_date ) );
+			$existing_time_gmt = date( 'H:i:s', strtotime( $post->post_date_gmt ) );
 			$new_values = array(
-				'post_date' => gmdate( 'Y-m-d', $next_date_full ) . ' ' . $existing_time,
+				'post_date' => date( 'Y-m-d', $next_date_full ) . ' ' . $existing_time,
 				'post_modified' => current_time( 'mysql' ),
 				'post_modified_gmt' => current_time( 'mysql', 1 ),
 			);
@@ -369,7 +369,7 @@ if ( ! class_exists( 'EF_Calendar' ) ) {
 			// If the user desires that to be the behaviour, they can set the result of this filter to 'true'
 			// With how WordPress works internally, setting 'post_date_gmt' will set the timestamp
 			if ( apply_filters( 'ef_calendar_allow_ajax_to_set_timestamp', false ) ) {
-				$new_values['post_date_gmt'] = gmdate( 'Y-m-d', $next_date_full ) . ' ' . $existing_time_gmt;
+				$new_values['post_date_gmt'] = date( 'Y-m-d', $next_date_full ) . ' ' . $existing_time_gmt;
 			}
 
 			// We have to do SQL unfortunately because of core bugginess
@@ -421,7 +421,7 @@ if ( ! class_exists( 'EF_Calendar' ) ) {
 			}
 
 			// Set the start date for the posts_where filter
-			$this->start_date = apply_filters( 'ef_calendar_ics_subscription_start_date', $this->get_beginning_of_week( gmdate( 'Y-m-d', current_time( 'timestamp' ) ) ) );
+			$this->start_date = apply_filters( 'ef_calendar_ics_subscription_start_date', $this->get_beginning_of_week( date( 'Y-m-d', current_time( 'timestamp' ) ) ) );
 
 			$this->total_weeks = apply_filters( 'ef_calendar_total_weeks', $this->total_weeks, 'ics_subscription' );
 
@@ -566,7 +566,7 @@ if ( ! class_exists( 'EF_Calendar' ) ) {
 			$timestamp += $offset_in_seconds;
 
 			// \T and \Z are escaped for literal T and Z characters
-			return gmdate( 'Ymd\THis\Z', $timestamp );
+			return date( 'Ymd\THis\Z', $timestamp );
 		}
 
 		/**
@@ -640,7 +640,7 @@ if ( ! class_exists( 'EF_Calendar' ) ) {
 				'cat' => '',
 				'author' => '',
 				'num_weeks' => $this->total_weeks,
-				'start_date' => gmdate( 'Y-m-d', current_time( 'timestamp' ) ),
+				'start_date' => date( 'Y-m-d', current_time( 'timestamp' ) ),
 			);
 			$old_filters = array_merge( $default_filters, isset( $screen_options['num_weeks'] ) ? array( 'num_weeks' => $screen_options['num_weeks'] ) : array(), (array) $old_filters );
 
@@ -699,7 +699,7 @@ if ( ! class_exists( 'EF_Calendar' ) ) {
 			$heading_date = $filters['start_date'];
 			for ( $i = 0; $i < 7; $i++ ) {
 				$dates[ $i ] = $heading_date;
-				$heading_date = gmdate( 'Y-m-d', strtotime( '+1 day', strtotime( $heading_date ) ) );
+				$heading_date = date( 'Y-m-d', strtotime( '+1 day', strtotime( $heading_date ) ) );
 			}
 
 			// we sort by post statuses....... eventually
@@ -776,7 +776,7 @@ if ( ! class_exists( 'EF_Calendar' ) ) {
 							$split_month = $single_date_month;
 							$current_month = $single_date_month;
 						}
-						$week_single_date = gmdate( 'Y-m-d', strtotime( '+1 day', strtotime( $week_single_date ) ) );
+						$week_single_date = date( 'Y-m-d', strtotime( '+1 day', strtotime( $week_single_date ) ) );
 					}
 					?>
 					<?php if ( $split_month ) : ?>
@@ -823,13 +823,13 @@ if ( ! class_exists( 'EF_Calendar' ) ) {
 						$td_classes = array(
 							'day-unit',
 						);
-						$day_name = gmdate( 'D', strtotime( $week_single_date ) );
+						$day_name = date( 'D', strtotime( $week_single_date ) );
 
 						if ( in_array( $day_name, $dotw ) ) {
 							$td_classes[] = 'weekend-day';
 						}
 
-						if ( gmdate( 'Y-m-d', current_time( 'timestamp' ) ) == $week_single_date ) {
+						if ( date( 'Y-m-d', current_time( 'timestamp' ) ) == $week_single_date ) {
 							$td_classes[] = 'today';
 						}
 
@@ -842,10 +842,10 @@ if ( ! class_exists( 'EF_Calendar' ) ) {
 						?>
 				<td class="<?php echo esc_attr( implode( ' ', $td_classes ) ); ?>" id="<?php echo esc_attr( $week_single_date ); ?>">
 					<button class='schedule-new-post-button'>+</button>
-						<?php if ( gmdate( 'Y-m-d', current_time( 'timestamp' ) ) == $week_single_date ) : ?>
+						<?php if ( date( 'Y-m-d', current_time( 'timestamp' ) ) == $week_single_date ) : ?>
 						<div class="day-unit-today"><?php esc_html_e( 'Today', 'edit-flow' ); ?></div>
 					<?php endif; ?>
-					<div class="day-unit-label"><?php echo esc_html( gmdate( 'j', strtotime( $week_single_date ) ) ); ?></div>
+					<div class="day-unit-label"><?php echo esc_html( date( 'j', strtotime( $week_single_date ) ) ); ?></div>
 					<ul class="post-list">
 						<?php
 						$this->hidden = 0;
@@ -869,7 +869,7 @@ if ( ! class_exists( 'EF_Calendar' ) ) {
 
 						<?php
 						if ( current_user_can( $this->create_post_cap ) ) :
-							$date_formatted = gmdate( 'D, M jS, Y', strtotime( $week_single_date ) );
+							$date_formatted = date( 'D, M jS, Y', strtotime( $week_single_date ) );
 							?>
 
 						<form method="POST" class="post-insert-dialog">
@@ -1272,7 +1272,7 @@ if ( ! class_exists( 'EF_Calendar' ) ) {
 			}
 
 			$beginning_date = $this->get_beginning_of_week( $this->start_date, 'Y-m-d', $this->current_week );
-			$ending_date    = gmdate( 'Y-m-d', strtotime( $beginning_date ) + WEEK_IN_SECONDS );
+			$ending_date    = date( 'Y-m-d', strtotime( $beginning_date ) + WEEK_IN_SECONDS );
 
 			$args['date_query'] = array(
 				'after'     => $beginning_date,
@@ -1288,7 +1288,7 @@ if ( ! class_exists( 'EF_Calendar' ) ) {
 			while ( $post_results->have_posts() ) {
 				$post_results->the_post();
 				global $post;
-				$key_date = gmdate( 'Y-m-d', strtotime( $post->post_date ) );
+				$key_date = date( 'Y-m-d', strtotime( $post->post_date ) );
 				$posts[ $key_date ][] = $post;
 			}
 
@@ -1310,14 +1310,14 @@ if ( ! class_exists( 'EF_Calendar' ) ) {
 			if ( ! isset( $weeks_offset ) ) {
 				$weeks_offset = $this->total_weeks;
 			} else if ( 0 == $weeks_offset ) {
-				$filters['start_date'] = $this->get_beginning_of_week( gmdate( 'Y-m-d', current_time( 'timestamp' ) ) );
+				$filters['start_date'] = $this->get_beginning_of_week( date( 'Y-m-d', current_time( 'timestamp' ) ) );
 			}
 
 			if ( 'previous' == $direction ) {
 				$weeks_offset = '-' . $weeks_offset;
 			}
 
-			$filters['start_date'] = gmdate( 'Y-m-d', strtotime( $weeks_offset . ' weeks', strtotime( $filters['start_date'] ) ) );
+			$filters['start_date'] = date( 'Y-m-d', strtotime( $weeks_offset . ' weeks', strtotime( $filters['start_date'] ) ) );
 			$url = add_query_arg( $filters, menu_page_url( $this->module->slug, false ) );
 
 			if ( count( $supported_post_types ) > 1 ) {
@@ -1342,10 +1342,10 @@ if ( ! class_exists( 'EF_Calendar' ) ) {
 
 			$date = strtotime( $date );
 			$start_of_week = get_option( 'start_of_week' );
-			$day_of_week = gmdate( 'w', $date );
+			$day_of_week = date( 'w', $date );
 			$date += ( ( $start_of_week - $day_of_week - 7 ) % 7 ) * 60 * 60 * 24;
 			$date = strtotime( '+' . ( $week - 1 ) . ' week', $date );
-				$formatted_start_of_week = gmdate( $format, $date );
+				$formatted_start_of_week = date( $format, $date );
 			return $formatted_start_of_week;
 		}
 
@@ -1364,10 +1364,10 @@ if ( ! class_exists( 'EF_Calendar' ) ) {
 
 			$date = strtotime( $date );
 			$end_of_week = get_option( 'start_of_week' ) - 1;
-			$day_of_week = gmdate( 'w', $date );
+			$day_of_week = date( 'w', $date );
 			$date += ( ( $end_of_week - $day_of_week + 7 ) % 7 ) * 60 * 60 * 24;
 			$date = strtotime( '+' . ( $week - 1 ) . ' week', $date );
-			$formatted_end_of_week = gmdate( $format, $date );
+			$formatted_end_of_week = date( $format, $date );
 			return $formatted_end_of_week;
 		}
 
@@ -1382,7 +1382,7 @@ if ( ! class_exists( 'EF_Calendar' ) ) {
 			$first_datetime = strtotime( $this->start_date );
 			$first_date = date_i18n( get_option( 'date_format' ), $first_datetime );
 			$total_days = ( $this->total_weeks * 7 ) - 1;
-			$last_datetime = strtotime( '+' . $total_days . ' days', gmdate( 'U', strtotime( $this->start_date ) ) );
+			$last_datetime = strtotime( '+' . $total_days . ' days', date( 'U', strtotime( $this->start_date ) ) );
 			$last_date = date_i18n( get_option( 'date_format' ), $last_datetime );
 			// translators: %1$s = first date, %2$s = last date
 			echo esc_html( sprintf( __( 'for %1$s through %2$s', 'edit-flow' ), $first_date, $last_date ) );
@@ -1572,7 +1572,7 @@ if ( ! class_exists( 'EF_Calendar' ) ) {
 			$post_placeholder = array(
 				'post_title' => $post_title,
 				'post_status' => $post_status,
-				'post_date' => gmdate( 'Y-m-d H:i:s', strtotime( $post_date ) ),
+				'post_date' => date( 'Y-m-d H:i:s', strtotime( $post_date ) ),
 				'post_type' => $this->module->options->quick_create_post_type,
 			);
 
@@ -1580,7 +1580,7 @@ if ( ! class_exists( 'EF_Calendar' ) ) {
 			// If the user desires that to be the behavior, they can set the result of this filter to 'true'
 			// With how WordPress works internally, setting 'post_date_gmt' will set the timestamp
 			if ( apply_filters( 'ef_calendar_allow_ajax_to_set_timestamp', false ) ) {
-				$post_placeholder['post_date_gmt'] = gmdate( 'Y-m-d H:i:s', strtotime( $post_date ) );
+				$post_placeholder['post_date_gmt'] = date( 'Y-m-d H:i:s', strtotime( $post_date ) );
 			}
 
 			// Create the post
@@ -1752,7 +1752,7 @@ if ( ! class_exists( 'EF_Calendar' ) ) {
 					}
 					break;
 				case 'start_date':
-					return gmdate( 'Y-m-d', strtotime( $dirty_value ) );
+					return date( 'Y-m-d', strtotime( $dirty_value ) );
 				break;
 				case 'cat':
 				case 'author':
@@ -1906,7 +1906,7 @@ if ( ! class_exists( 'EF_Calendar' ) ) {
 					'MAX' => $this->max_weeks,
 					'DEFAULT' => $this->total_weeks,
 				),
-				'BEGINNING_OF_WEEK' => $this->get_beginning_of_week( gmdate( 'Y-m-d', current_time( 'timestamp' ) ) ),
+				'BEGINNING_OF_WEEK' => $this->get_beginning_of_week( date( 'Y-m-d', current_time( 'timestamp' ) ) ),
 				'FILTERS' => $this->get_filters(),
 				'PAGE_URL' => menu_page_url( $this->module->slug, false ),
 				'WP_VERSION' => $wp_version,

--- a/modules/calendar/calendar.php
+++ b/modules/calendar/calendar.php
@@ -1005,11 +1005,8 @@ if ( ! class_exists( 'EF_Calendar' ) ) {
 						<th class="label"><?php echo esc_html( $values['label'] ); ?>:</th>
 						<?php if ( $values['value'] && isset( $values['type'] ) ) : ?>
 							<?php if ( isset( $values['editable'] ) && $this->current_user_can_modify_post( $post ) ) : ?>
-								<td class="value
-								<?php
-								if ( $values['editable'] ) {
-									?>
-									editable-value<?php } ?>"><?php echo esc_html( $values['value'] ); ?></td>
+								<?php $editable_class = $values['editable'] ? 'editable-value' : ''; ?>
+								<td class="value <?php echo esc_attr( $editable_class ); ?>"><?php echo esc_html( $values['value'] ); ?></td>
 								<?php if ( $values['editable'] ) : ?>
 									<td class="editable-html hidden" data-type="<?php echo esc_attr( $values['type'] ); ?>" data-metadataterm="<?php echo esc_attr( str_replace( 'editorial-metadata-', '', str_replace( 'tax_', '', $field ) ) ); ?>"><?php echo $this->get_editable_html( $values['type'], $values['value'] ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></td>
 								<?php endif; ?>

--- a/modules/custom-status/custom-status.php
+++ b/modules/custom-status/custom-status.php
@@ -844,7 +844,8 @@ if ( ! class_exists( 'EF_Custom_Status' ) ) {
 			);
 			$return = $this->add_custom_status( $status_name, $status_args );
 			if ( is_wp_error( $return ) ) {
-				wp_die( esc_textarea( __( 'Could not add status: ', 'edit-flow' ) . $return->get_error_message() ) );
+				/* translators: %s: error message */
+				wp_die( esc_html( sprintf( __( 'Could not add status: %s', 'edit-flow' ), $return->get_error_message() ) ) );
 			}
 			// Redirect if successful
 			$redirect_url = $this->get_link( array( 'message' => 'status-added' ) );
@@ -929,7 +930,7 @@ if ( ! class_exists( 'EF_Custom_Status' ) ) {
 			);
 			$return = $this->update_custom_status( $existing_status->term_id, $args );
 			if ( is_wp_error( $return ) ) {
-				wp_die( esc_textarea( __( 'Error updating post status.', 'edit-flow' ) ) );
+				wp_die( esc_html__( 'Error updating post status.', 'edit-flow' ) );
 			}
 
 			$redirect_url = $this->get_link( array( 'message' => 'status-updated' ) );
@@ -1151,8 +1152,8 @@ if ( ! class_exists( 'EF_Custom_Status' ) ) {
 				die();
 			} else {
 				/* translators: 1: the status's name */
-				$change_error = new WP_Error( 'invalid', wp_kses( sprintf( __( 'Could not update the status: <strong>%s</strong>', 'edit-flow' ), $status_name ), 'strong' ) );
-				die( esc_html( $change_error->get_error_message() ) );
+				$change_error = new WP_Error( 'invalid', sprintf( __( 'Could not update the status: <strong>%s</strong>', 'edit-flow' ), $status_name ) );
+				die( wp_kses( $change_error->get_error_message(), 'strong' ) );
 			}
 		}
 
@@ -1260,12 +1261,8 @@ if ( ! class_exists( 'EF_Custom_Status' ) ) {
 		<table class="form-table">
 			<tr class="form-field form-required">
 				<th scope="row" valign="top"><label for="name"><?php _e( 'Custom Status', 'edit-flow' ); ?></label></th>
-				<td><input name="name" id="name" type="text" value="<?php echo esc_attr( $name ); ?>" size="40" aria-required="true"
-																			   <?php
-																				if ( 'draft' === $status->slug ) {
-																					echo 'readonly="readonly"';}
-																				?>
-				/>
+				<?php $readonly_attr = 'draft' === $status->slug ? 'readonly="readonly"' : ''; ?>
+				<td><input name="name" id="name" type="text" value="<?php echo esc_attr( $name ); ?>" size="40" aria-required="true" <?php echo esc_attr( $readonly_attr ); ?> />
 				<?php $edit_flow->settings->helper_print_error_or_description( 'name', __( 'The name is used to identify the status. (Max: 20 characters)', 'edit-flow' ) ); ?>
 				</td>
 			</tr>
@@ -1309,18 +1306,10 @@ if ( ! class_exists( 'EF_Custom_Status' ) ) {
 				<div class="col-wrap">
 				<div class="form-wrap">
 				<h3 class="nav-tab-wrapper">
-					<a href="<?php echo esc_url( $this->get_link() ); ?>" class="nav-tab
-										<?php
-										if ( ! isset( $_GET['action'] ) || 'change-options' != $_GET['action'] ) {
-											echo ' nav-tab-active';}
-										?>
-					"><?php _e( 'Add New', 'edit-flow' ); ?></a>
-					<a href="<?php echo esc_url( $this->get_link( array( 'action' => 'change-options' ) ) ); ?>" class="nav-tab
-										<?php
-										if ( isset( $_GET['action'] ) && 'change-options' == $_GET['action'] ) {
-											echo ' nav-tab-active';}
-										?>
-					"><?php _e( 'Options', 'edit-flow' ); ?></a>
+					<?php $add_new_nav_class = ! isset( $_GET['action'] ) || 'change-options' != $_GET['action'] ? 'nav-tab-active' : ''; ?>
+					<a href="<?php echo esc_url( $this->get_link() ); ?>" class="nav-tab <?php echo esc_attr( $add_new_nav_class ); ?>"><?php esc_html_e( 'Add New', 'edit-flow' ); ?></a>
+					<?php $options_nav_class = isset( $_GET['action'] ) && 'change-options' == $_GET['action'] ? 'nav-tab-active' : ''; ?>
+					<a href="<?php echo esc_url( $this->get_link( array( 'action' => 'change-options' ) ) ); ?>" class="nav-tab <?php echo esc_attr( $options_nav_class ); ?>"><?php esc_html_e( 'Options', 'edit-flow' ); ?></a>
 				</h3>
 				<?php if ( isset( $_GET['action'] ) && 'change-options' == $_GET['action'] ) : ?>
 				<form class="basic-settings" action="<?php echo esc_url( $this->get_link( array( 'action' => 'change-options' ) ) ); ?>" method="post">
@@ -1334,12 +1323,12 @@ if ( ! class_exists( 'EF_Custom_Status' ) ) {
 					<form class="add:the-list:" action="<?php echo esc_url( $this->get_link() ); ?>" method="post" id="addstatus" name="addstatus">
 					<div class="form-field form-required">
 						<label for="status_name"><?php _e( 'Name', 'edit-flow' ); ?></label>
-						<input type="text" aria-required="true" size="20" maxlength="20" id="status_name" name="status_name" value="<?php /* phpcs:ignore Generic.ControlStructures.InlineControlStructure.NotAllowed */ if ( ! empty( $_POST['status_name'] ) ) echo esc_attr( $_POST['status_name'] ); ?>" />
+						<input type="text" aria-required="true" size="20" maxlength="20" id="status_name" name="status_name" value="<?php echo ( empty( $_POST['status_name'] ) ? '' : esc_attr( $_POST['status_name'] ) ); ?>" />
 						<?php $edit_flow->settings->helper_print_error_or_description( 'name', __( 'The name is used to identify the status. (Max: 20 characters)', 'edit-flow' ) ); ?>
 					</div>
 					<div class="form-field">
 						<label for="status_description"><?php _e( 'Description', 'edit-flow' ); ?></label>
-						<textarea cols="40" rows="5" id="status_description" name="status_description"><?php /* phpcs:ignore Generic.ControlStructures.InlineControlStructure.NotAllowed */ if ( ! empty( $_POST['status_description'] ) ) echo esc_textarea( $_POST['status_description'] ); ?></textarea>
+						<textarea cols="40" rows="5" id="status_description" name="status_description"><?php echo ( empty( $_POST['status_description'] ) ? '' : esc_textarea( $_POST['status_description'] ) ); ?></textarea>
 						<?php $edit_flow->settings->helper_print_error_or_description( 'description', __( 'The description is primarily for administrative use, to give you some context on what the custom status is to be used for.', 'edit-flow' ) ); ?>
 					</div>
 					<?php wp_nonce_field( 'custom-status-add-nonce' ); ?>

--- a/modules/custom-status/custom-status.php
+++ b/modules/custom-status/custom-status.php
@@ -9,332 +9,337 @@
  * - Ensure all of the form processing uses our messages functionality
  */
 
+if ( ! class_exists( 'EF_Custom_Status' ) ) {
 
- if ( !class_exists( 'EF_Custom_Status' ) ) {
+	class EF_Custom_Status extends EF_Module {
 
-class EF_Custom_Status extends EF_Module {
+		public $module;
 
-	var $module;
+		private $custom_statuses_cache = array();
 
-	private $custom_statuses_cache = array();
+		// This is taxonomy name used to store all our custom statuses
+		// phpcs:ignore Generic.NamingConventions.UpperCaseConstantName.ClassConstantNotUpperCase
+		const taxonomy_key = 'post_status';
 
-	// This is taxonomy name used to store all our custom statuses
-	const taxonomy_key = 'post_status';
+		/**
+		 * Register the module with Edit Flow but don't do anything else
+		 */
+		public function __construct() {
 
-	/**
-	 * Register the module with Edit Flow but don't do anything else
-	 */
-	function __construct() {
-
-		$this->module_url = $this->get_module_url( __FILE__ );
-		// Register the module with Edit Flow
-		$args = array(
-			'title' => __( 'Custom Statuses', 'edit-flow' ),
-			'short_description' => __( 'Create custom post statuses to define the stages of your workflow.', 'edit-flow' ),
-			'extended_description' => __( 'Create your own post statuses to add structure your publishing workflow. You can change existing or add new ones anytime, and drag and drop to change their order.', 'edit-flow' ),
-			'module_url' => $this->module_url,
-			'img_url' => $this->module_url . 'lib/custom_status_s128.png',
-			'slug' => 'custom-status',
-			'default_options' => array(
-				'enabled' => 'on',
-				'default_status' => 'pitch',
-				'always_show_dropdown' => 'off',
-				'post_types' => array(
-					'post' => 'on',
-					'page' => 'on',
+			$this->module_url = $this->get_module_url( __FILE__ );
+			// Register the module with Edit Flow
+			$args = array(
+				'title' => __( 'Custom Statuses', 'edit-flow' ),
+				'short_description' => __( 'Create custom post statuses to define the stages of your workflow.', 'edit-flow' ),
+				'extended_description' => __( 'Create your own post statuses to add structure your publishing workflow. You can change existing or add new ones anytime, and drag and drop to change their order.', 'edit-flow' ),
+				'module_url' => $this->module_url,
+				'img_url' => $this->module_url . 'lib/custom_status_s128.png',
+				'slug' => 'custom-status',
+				'default_options' => array(
+					'enabled' => 'on',
+					'default_status' => 'pitch',
+					'always_show_dropdown' => 'off',
+					'post_types' => array(
+						'post' => 'on',
+						'page' => 'on',
+					),
 				),
-			),
-			'post_type_support' => 'ef_custom_statuses', // This has been plural in all of our docs
-			'configure_page_cb' => 'print_configure_view',
-			'configure_link_text' => __( 'Edit Statuses', 'edit-flow' ),
-			'messages' => array(
-				'status-added' => __( 'Post status created.', 'edit-flow' ),
-				'status-missing' => __( "Post status doesn't exist.", 'edit-flow' ),
-				'default-status-changed' => __( 'Default post status has been changed.', 'edit-flow'),
-				'term-updated' => __( "Post status updated.", 'edit-flow' ),
-				'status-deleted' => __( 'Post status deleted.', 'edit-flow' ),
-				'status-position-updated' => __( "Status order updated.", 'edit-flow' ),
-			),
-			'autoload' => false,
-			'settings_help_tab' => array(
-				'id' => 'ef-custom-status-overview',
-				'title' => __('Overview', 'edit-flow'),
-				'content' => __('<p>Edit Flow’s custom statuses allow you to define the most important stages of your editorial workflow. Out of the box, WordPress only offers “Draft” and “Pending Review” as post states. With custom statuses, you can create your own post states like “In Progress”, “Pitch”, or “Waiting for Edit” and keep or delete the originals. You can also drag and drop statuses to set the best order for your workflow.</p><p>Custom statuses are fully integrated into the rest of Edit Flow and the WordPress admin. On the calendar and story budget, you can filter your view to see only posts of a specific post state. Furthermore, email notifications can be sent to a specific group of users when a post changes state.</p>', 'edit-flow'),
+				'post_type_support' => 'ef_custom_statuses', // This has been plural in all of our docs
+				'configure_page_cb' => 'print_configure_view',
+				'configure_link_text' => __( 'Edit Statuses', 'edit-flow' ),
+				'messages' => array(
+					'status-added' => __( 'Post status created.', 'edit-flow' ),
+					'status-missing' => __( "Post status doesn't exist.", 'edit-flow' ),
+					'default-status-changed' => __( 'Default post status has been changed.', 'edit-flow' ),
+					'term-updated' => __( 'Post status updated.', 'edit-flow' ),
+					'status-deleted' => __( 'Post status deleted.', 'edit-flow' ),
+					'status-position-updated' => __( 'Status order updated.', 'edit-flow' ),
 				),
-			'settings_help_sidebar' => __( '<p><strong>For more information:</strong></p><p><a href="http://editflow.org/features/custom-statuses/">Custom Status Documentation</a></p><p><a href="http://wordpress.org/tags/edit-flow?forum_id=10">Edit Flow Forum</a></p><p><a href="https://github.com/Automattic/Edit-Flow">Edit Flow on Github</a></p>', 'edit-flow' ),
-		);
-		$this->module = EditFlow()->register_module( 'custom_status', $args );
-	}
-
-	/**
-	 * Initialize the EF_Custom_Status class if the module is active
-	 */
-	function init() {
-		global $edit_flow;
-
-		// Register custom statuses as a taxonomy
-		$this->register_custom_statuses();
-
-		// Register our settings
-		add_action( 'admin_init', array( $this, 'register_settings' ) );
-
-		if ( ! $this->disable_custom_statuses_for_post_type() ) {
-			// Load CSS and JS resources that we probably need in the admin page
-			add_action( 'admin_enqueue_scripts', array( $this, 'action_admin_enqueue_scripts' ) );
-
-			// Assets for block editor UI.
-			add_action( 'enqueue_block_editor_assets', array( $this, 'load_scripts_for_block_editor') );
-
-			// Assets for iframed block editor and editor UI.
-			add_action( 'enqueue_block_editor_assets', array( $this, 'load_styles_for_block_editor') );
+				'autoload' => false,
+				'settings_help_tab' => array(
+					'id' => 'ef-custom-status-overview',
+					'title' => __( 'Overview', 'edit-flow' ),
+					'content' => __( '<p>Edit Flow’s custom statuses allow you to define the most important stages of your editorial workflow. Out of the box, WordPress only offers “Draft” and “Pending Review” as post states. With custom statuses, you can create your own post states like “In Progress”, “Pitch”, or “Waiting for Edit” and keep or delete the originals. You can also drag and drop statuses to set the best order for your workflow.</p><p>Custom statuses are fully integrated into the rest of Edit Flow and the WordPress admin. On the calendar and story budget, you can filter your view to see only posts of a specific post state. Furthermore, email notifications can be sent to a specific group of users when a post changes state.</p>', 'edit-flow' ),
+				),
+				'settings_help_sidebar' => __( '<p><strong>For more information:</strong></p><p><a href="http://editflow.org/features/custom-statuses/">Custom Status Documentation</a></p><p><a href="http://wordpress.org/tags/edit-flow?forum_id=10">Edit Flow Forum</a></p><p><a href="https://github.com/Automattic/Edit-Flow">Edit Flow on Github</a></p>', 'edit-flow' ),
+			);
+			$this->module = EditFlow()->register_module( 'custom_status', $args );
 		}
 
-		add_action( 'admin_notices', array( $this, 'no_js_notice' ) );
-		add_action( 'admin_print_scripts', array( $this, 'post_admin_header' ) );
+		/**
+		 * Initialize the EF_Custom_Status class if the module is active
+		 */
+		public function init() {
+			global $edit_flow;
 
-		// Add custom statuses to the post states.
-		add_filter( 'display_post_states', array( $this, 'add_status_to_post_states' ), 10, 2 );
+			// Register custom statuses as a taxonomy
+			$this->register_custom_statuses();
 
-		// Methods for handling the actions of creating, making default, and deleting post stati
-		add_action( 'admin_init', array( $this, 'handle_add_custom_status' ) );
-		add_action( 'admin_init', array( $this, 'handle_edit_custom_status' ) );
-		add_action( 'admin_init', array( $this, 'handle_make_default_custom_status' ) );
-		add_action( 'admin_init', array( $this, 'handle_delete_custom_status' ) );
-		add_action( 'wp_ajax_update_status_positions', array( $this, 'handle_ajax_update_status_positions' ) );
-		add_action( 'wp_ajax_inline_save_status', array( $this, 'ajax_inline_save_status' ) );
+			// Register our settings
+			add_action( 'admin_init', array( $this, 'register_settings' ) );
 
-		// These seven-ish methods are hacks for fixing bugs in WordPress core
-		add_action( 'admin_init', array( $this, 'check_timestamp_on_publish' ) );
-		add_filter( 'wp_insert_post_data', array( $this, 'fix_custom_status_timestamp' ), 10, 2 );
-		add_filter( 'wp_insert_post_data', array( $this, 'maybe_keep_post_name_empty' ), 10, 2 );
-		add_filter( 'pre_wp_unique_post_slug', array( $this, 'fix_unique_post_slug' ), 10, 6 );
-		add_filter( 'preview_post_link', array( $this, 'fix_preview_link_part_one' ) );
-		add_filter( 'post_link', array( $this, 'fix_preview_link_part_two' ), 10, 3 );
-		add_filter( 'page_link', array( $this, 'fix_preview_link_part_two' ), 10, 3 );
-		add_filter( 'post_type_link', array( $this, 'fix_preview_link_part_two' ), 10, 3 );
-		add_filter( 'preview_post_link', array( $this, 'fix_preview_link_part_three' ), 11, 2 );
-		add_filter( 'get_sample_permalink', array( $this, 'fix_get_sample_permalink' ), 10, 5 );
-		add_filter( 'get_sample_permalink_html', array( $this, 'fix_get_sample_permalink_html' ), 10, 5);
-		add_filter( 'post_row_actions', array( $this, 'fix_post_row_actions' ), 10, 2 );
-		add_filter( 'page_row_actions', array( $this, 'fix_post_row_actions' ), 10, 2 );
+			if ( ! $this->disable_custom_statuses_for_post_type() ) {
+				// Load CSS and JS resources that we probably need in the admin page
+				add_action( 'admin_enqueue_scripts', array( $this, 'action_admin_enqueue_scripts' ) );
 
-		// Pagination for custom post statuses when previewing posts
-		add_filter( 'wp_link_pages_link', array( $this, 'modify_preview_link_pagination_url' ), 10, 2 );
-	}
+				// Assets for block editor UI.
+				add_action( 'enqueue_block_editor_assets', array( $this, 'load_scripts_for_block_editor' ) );
 
-	/**
-	 * Create the default set of custom statuses the first time the module is loaded
-	 *
-	 * @since 0.7
-	 */
-	function install() {
+				// Assets for iframed block editor and editor UI.
+				add_action( 'enqueue_block_editor_assets', array( $this, 'load_styles_for_block_editor' ) );
+			}
 
-		$default_terms = array(
-			array(
-				'term' => __( 'Pitch', 'edit-flow' ),
-				'args' => array(
-					'slug' => 'pitch',
-					'description' => __( 'Idea proposed; waiting for acceptance.', 'edit-flow' ),
-					'position' => 1,
-				),
-			),
-			array(
-				'term' => __( 'Assigned', 'edit-flow' ),
-				'args' => array(
-					'slug' => 'assigned',
-					'description' => __( 'Post idea assigned to writer.', 'edit-flow' ),
-					'position' => 2,
-				),
-			),
-			array(
-				'term' => __( 'In Progress', 'edit-flow' ),
-				'args' => array(
-					'slug' => 'in-progress',
-					'description' => __( 'Writer is working on the post.', 'edit-flow' ),
-					'position' => 3,
-				),
-			),
-			array(
-				'term' => __( 'Draft', 'edit-flow' ),
-				'args' => array(
-					'slug' => 'draft',
-					'description' => __( 'Post is a draft; not ready for review or publication.', 'edit-flow' ),
-					'position' => 4,
-				),
-			),
-			array(
-				'term' => __( 'Pending Review' ),
-				'args' => array(
-					'slug' => 'pending',
-					'description' => __( 'Post needs to be reviewed by an editor.', 'edit-flow' ),
-					'position' => 5,
-				),
-			),
-		);
+			add_action( 'admin_notices', array( $this, 'no_js_notice' ) );
+			add_action( 'admin_print_scripts', array( $this, 'post_admin_header' ) );
 
-		// Okay, now add the default statuses to the db if they don't already exist
-		foreach( $default_terms as $term ) {
-			if( !term_exists( $term['term'], self::taxonomy_key ) )
-				$this->add_custom_status( $term['term'], $term['args'] );
+			// Add custom statuses to the post states.
+			add_filter( 'display_post_states', array( $this, 'add_status_to_post_states' ), 10, 2 );
+
+			// Methods for handling the actions of creating, making default, and deleting post stati
+			add_action( 'admin_init', array( $this, 'handle_add_custom_status' ) );
+			add_action( 'admin_init', array( $this, 'handle_edit_custom_status' ) );
+			add_action( 'admin_init', array( $this, 'handle_make_default_custom_status' ) );
+			add_action( 'admin_init', array( $this, 'handle_delete_custom_status' ) );
+			add_action( 'wp_ajax_update_status_positions', array( $this, 'handle_ajax_update_status_positions' ) );
+			add_action( 'wp_ajax_inline_save_status', array( $this, 'ajax_inline_save_status' ) );
+
+			// These seven-ish methods are hacks for fixing bugs in WordPress core
+			add_action( 'admin_init', array( $this, 'check_timestamp_on_publish' ) );
+			add_filter( 'wp_insert_post_data', array( $this, 'fix_custom_status_timestamp' ), 10, 2 );
+			add_filter( 'wp_insert_post_data', array( $this, 'maybe_keep_post_name_empty' ), 10, 2 );
+			add_filter( 'pre_wp_unique_post_slug', array( $this, 'fix_unique_post_slug' ), 10, 6 );
+			add_filter( 'preview_post_link', array( $this, 'fix_preview_link_part_one' ) );
+			add_filter( 'post_link', array( $this, 'fix_preview_link_part_two' ), 10, 3 );
+			add_filter( 'page_link', array( $this, 'fix_preview_link_part_two' ), 10, 3 );
+			add_filter( 'post_type_link', array( $this, 'fix_preview_link_part_two' ), 10, 3 );
+			add_filter( 'preview_post_link', array( $this, 'fix_preview_link_part_three' ), 11, 2 );
+			add_filter( 'get_sample_permalink', array( $this, 'fix_get_sample_permalink' ), 10, 5 );
+			add_filter( 'get_sample_permalink_html', array( $this, 'fix_get_sample_permalink_html' ), 10, 5 );
+			add_filter( 'post_row_actions', array( $this, 'fix_post_row_actions' ), 10, 2 );
+			add_filter( 'page_row_actions', array( $this, 'fix_post_row_actions' ), 10, 2 );
+
+			// Pagination for custom post statuses when previewing posts
+			add_filter( 'wp_link_pages_link', array( $this, 'modify_preview_link_pagination_url' ), 10, 2 );
 		}
 
-	}
+		/**
+		 * Create the default set of custom statuses the first time the module is loaded
+		 *
+		 * @since 0.7
+		 */
+		public function install() {
 
-	/**
-	 * Upgrade our data in case we need to
-	 *
-	 * @since 0.7
-	 */
-	function upgrade( $previous_version ) {
-		global $edit_flow;
+			$default_terms = array(
+				array(
+					'term' => __( 'Pitch', 'edit-flow' ),
+					'args' => array(
+						'slug' => 'pitch',
+						'description' => __( 'Idea proposed; waiting for acceptance.', 'edit-flow' ),
+						'position' => 1,
+					),
+				),
+				array(
+					'term' => __( 'Assigned', 'edit-flow' ),
+					'args' => array(
+						'slug' => 'assigned',
+						'description' => __( 'Post idea assigned to writer.', 'edit-flow' ),
+						'position' => 2,
+					),
+				),
+				array(
+					'term' => __( 'In Progress', 'edit-flow' ),
+					'args' => array(
+						'slug' => 'in-progress',
+						'description' => __( 'Writer is working on the post.', 'edit-flow' ),
+						'position' => 3,
+					),
+				),
+				array(
+					'term' => __( 'Draft', 'edit-flow' ),
+					'args' => array(
+						'slug' => 'draft',
+						'description' => __( 'Post is a draft; not ready for review or publication.', 'edit-flow' ),
+						'position' => 4,
+					),
+				),
+				array(
+					'term' => __( 'Pending Review' ),
+					'args' => array(
+						'slug' => 'pending',
+						'description' => __( 'Post needs to be reviewed by an editor.', 'edit-flow' ),
+						'position' => 5,
+					),
+				),
+			);
 
-		// Upgrade path to v0.7
-		if ( version_compare( $previous_version, '0.7' , '<' ) ) {
-			// Migrate dropdown visibility option
-			if ( $dropdown_visible = get_option( 'edit_flow_status_dropdown_visible' ) )
-				$dropdown_visible = 'on';
-			else
-				$dropdown_visible = 'off';
-			$edit_flow->update_module_option( $this->module->name, 'always_show_dropdown', $dropdown_visible );
-			delete_option( 'edit_flow_status_dropdown_visible' );
-			// Migrate default status option
-			if ( $default_status = get_option( 'edit_flow_custom_status_default_status' ) )
-				$edit_flow->update_module_option( $this->module->name, 'default_status', $default_status );
-			delete_option( 'edit_flow_custom_status_default_status' );
-
-			// Technically we've run this code before so we don't want to auto-install new data
-			$edit_flow->update_module_option( $this->module->name, 'loaded_once', true );
-		}
-		// Upgrade path to v0.7.4
-		if ( version_compare( $previous_version, '0.7.4', '<' ) ) {
-			// Custom status descriptions become base64_encoded, instead of maybe json_encoded.
-			$this->upgrade_074_term_descriptions( self::taxonomy_key );
-		}
-
-	}
-
-	/**
-	 * Makes the call to register_post_status to register the user's custom statuses.
-	 * Also unregisters draft and pending, in case the user doesn't want them.
-	 */
-	function register_custom_statuses() {
-		global $wp_post_statuses;
-
-		if ( $this->disable_custom_statuses_for_post_type() )
-			return;
-
-		// Register new taxonomy so that we can store all our fancy new custom statuses (or is it stati?)
-		if ( !taxonomy_exists( self::taxonomy_key ) ) {
-			$args = array(	'hierarchical' => false,
-							'update_count_callback' => '_update_post_term_count',
-							'label' => false,
-							'query_var' => false,
-							'rewrite' => false,
-							'show_ui' => false
-					);
-			register_taxonomy( self::taxonomy_key, 'post', $args );
-		}
-
-		if ( function_exists( 'register_post_status' ) ) {
-			// Users can delete draft and pending statuses if they want, so let's get rid of them
-			// They'll get re-added if the user hasn't "deleted" them
-			unset( $wp_post_statuses[ 'draft' ] );
-			unset( $wp_post_statuses[ 'pending' ] );
-
-			$custom_statuses = $this->get_custom_statuses();
-
-			// Unfortunately, register_post_status() doesn't accept a
-			// post type argument, so we have to register the post
-			// statuses for all post types. This results in
-			// all post statuses for a post type appearing at the top
-			// of manage posts if there is a post with the status
-			foreach ( $custom_statuses as $status ) {
-				register_post_status( $status->slug, array(
-					'label'       => $status->name
-					, 'protected'   => true
-					, '_builtin'    => false
-					, 'label_count' => _n_noop( "{$status->name} <span class='count'>(%s)</span>", "{$status->name} <span class='count'>(%s)</span>" )
-				) );
+			// Okay, now add the default statuses to the db if they don't already exist
+			foreach ( $default_terms as $term ) {
+				if ( ! term_exists( $term['term'], self::taxonomy_key ) ) {
+					$this->add_custom_status( $term['term'], $term['args'] );
+				}
 			}
 		}
-	}
 
-	/**
-	 * Whether custom post statuses should be disabled for this post type.
-	 * Used to stop custom statuses from being registered for post types that don't support them.
-	 *
-	 * @since 0.7.5
-	 *
-	 * @return bool
-	 */
-	function disable_custom_statuses_for_post_type( $post_type = null ) {
-		global $pagenow;
+		/**
+		 * Upgrade our data in case we need to
+		 *
+		 * @since 0.7
+		 */
+		public function upgrade( $previous_version ) {
+			global $edit_flow;
 
-		// Only allow deregistering on 'edit.php' and 'post.php'
-		if ( ! in_array( $pagenow, array( 'edit.php', 'post.php', 'post-new.php' ) ) )
+			// Upgrade path to v0.7
+			if ( version_compare( $previous_version, '0.7', '<' ) ) {
+				// Migrate dropdown visibility option
+				$dropdown_visible = get_option( 'edit_flow_status_dropdown_visible' );
+				if ( $dropdown_visible ) {
+					$dropdown_visible = 'on';
+				} else {
+					$dropdown_visible = 'off';
+				}
+				$edit_flow->update_module_option( $this->module->name, 'always_show_dropdown', $dropdown_visible );
+				delete_option( 'edit_flow_status_dropdown_visible' );
+				// Migrate default status option
+				$default_status = get_option( 'edit_flow_custom_status_default_status' );
+				if ( $default_status ) {
+					$edit_flow->update_module_option( $this->module->name, 'default_status', $default_status );
+				}
+				delete_option( 'edit_flow_custom_status_default_status' );
+
+				// Technically we've run this code before so we don't want to auto-install new data
+				$edit_flow->update_module_option( $this->module->name, 'loaded_once', true );
+			}
+			// Upgrade path to v0.7.4
+			if ( version_compare( $previous_version, '0.7.4', '<' ) ) {
+				// Custom status descriptions become base64_encoded, instead of maybe json_encoded.
+				$this->upgrade_074_term_descriptions( self::taxonomy_key );
+			}
+		}
+
+		/**
+		 * Makes the call to register_post_status to register the user's custom statuses.
+		 * Also unregisters draft and pending, in case the user doesn't want them.
+		 */
+		public function register_custom_statuses() {
+			global $wp_post_statuses;
+
+			if ( $this->disable_custom_statuses_for_post_type() ) {
+				return;
+			}
+
+			// Register new taxonomy so that we can store all our fancy new custom statuses (or is it stati?)
+			if ( ! taxonomy_exists( self::taxonomy_key ) ) {
+				$args = array(
+					'hierarchical' => false,
+					'update_count_callback' => '_update_post_term_count',
+					'label' => false,
+					'query_var' => false,
+					'rewrite' => false,
+					'show_ui' => false,
+				);
+				register_taxonomy( self::taxonomy_key, 'post', $args );
+			}
+
+			if ( function_exists( 'register_post_status' ) ) {
+				// Users can delete draft and pending statuses if they want, so let's get rid of them
+				// They'll get re-added if the user hasn't "deleted" them
+				unset( $wp_post_statuses['draft'] );
+				unset( $wp_post_statuses['pending'] );
+
+				$custom_statuses = $this->get_custom_statuses();
+
+				// Unfortunately, register_post_status() doesn't accept a
+				// post type argument, so we have to register the post
+				// statuses for all post types. This results in
+				// all post statuses for a post type appearing at the top
+				// of manage posts if there is a post with the status
+				foreach ( $custom_statuses as $status ) {
+					register_post_status( $status->slug, array(
+						'label'       => $status->name,
+						'protected'   => true,
+						'_builtin'    => false,
+						'label_count' => _n_noop( "{$status->name} <span class='count'>(%s)</span>", "{$status->name} <span class='count'>(%s)</span>" ),
+					) );
+				}
+			}
+		}
+
+		/**
+		 * Whether custom post statuses should be disabled for this post type.
+		 * Used to stop custom statuses from being registered for post types that don't support them.
+		 *
+		 * @since 0.7.5
+		 *
+		 * @return bool
+		 */
+		public function disable_custom_statuses_for_post_type( $post_type = null ) {
+			global $pagenow;
+
+			// Only allow deregistering on 'edit.php' and 'post.php'
+			if ( ! in_array( $pagenow, array( 'edit.php', 'post.php', 'post-new.php' ) ) ) {
+				return false;
+			}
+
+			if ( is_null( $post_type ) ) {
+				$post_type = $this->get_current_post_type();
+			}
+
+			if ( $post_type && ! in_array( $post_type, $this->get_post_types_for_module( $this->module ) ) ) {
+				return true;
+			}
+
 			return false;
-
-		if ( is_null( $post_type ) ) {
-			$post_type = $this->get_current_post_type();
 		}
 
-		if ( $post_type && ! in_array( $post_type, $this->get_post_types_for_module( $this->module ) ) ) {
-			return true;
+		/**
+		 * Enqueue Javascript resources that we need in the admin:
+		 * - Primary use of Javascript is to manipulate the post status dropdown on Edit Post and Manage Posts
+		 * - jQuery Sortable plugin is used for drag and dropping custom statuses
+		 * - We have other custom code for Quick Edit and JS niceties
+		 */
+		public function action_admin_enqueue_scripts() {
+			// Load Javascript we need to use on the configuration views (jQuery Sortable and Quick Edit)
+			if ( $this->is_whitelisted_settings_view( $this->module->name ) ) {
+				wp_enqueue_script( 'jquery-ui-sortable' );
+				wp_enqueue_script( 'edit-flow-custom-status-configure', $this->module_url . 'lib/custom-status-configure.js', array( 'jquery', 'jquery-ui-sortable', 'edit-flow-settings-js' ), EDIT_FLOW_VERSION, true );
+			}
+
+			// Custom javascript to modify the post status dropdown where it shows up
+			if ( $this->is_whitelisted_page() ) {
+				wp_enqueue_script( 'edit_flow-custom_status', $this->module_url . 'lib/custom-status.js', array( 'jquery', 'post' ), EDIT_FLOW_VERSION, true );
+				wp_localize_script('edit_flow-custom_status', '__ef_localize_custom_status', array(
+					'no_change' => esc_html__( '&mdash; No Change &mdash;', 'edit-flow' ),
+					'published' => esc_html__( 'Published', 'edit-flow' ),
+					'save_as'   => esc_html__( 'Save as', 'edit-flow' ),
+					'save'      => esc_html__( 'Save', 'edit-flow' ),
+					'edit'      => esc_html__( 'Edit', 'edit-flow' ),
+					'ok'        => esc_html__( 'OK', 'edit-flow' ),
+					'cancel'    => esc_html__( 'Cancel', 'edit-flow' ),
+				));
+			}
 		}
 
-		return false;
-	}
+		public function load_scripts_for_block_editor() {
+			global $post;
 
-	/**
-	 * Enqueue Javascript resources that we need in the admin:
-	 * - Primary use of Javascript is to manipulate the post status dropdown on Edit Post and Manage Posts
-	 * - jQuery Sortable plugin is used for drag and dropping custom statuses
-	 * - We have other custom code for Quick Edit and JS niceties
-	 */
-	function action_admin_enqueue_scripts() {
-		// Load Javascript we need to use on the configuration views (jQuery Sortable and Quick Edit)
-		if ( $this->is_whitelisted_settings_view( $this->module->name ) ) {
-			wp_enqueue_script( 'jquery-ui-sortable' );
-			wp_enqueue_script( 'edit-flow-custom-status-configure', $this->module_url . 'lib/custom-status-configure.js', array( 'jquery', 'jquery-ui-sortable', 'edit-flow-settings-js' ), EDIT_FLOW_VERSION, true );
+			wp_enqueue_script( 'edit-flow-block-custom-status-script', EDIT_FLOW_URL . 'dist/custom-status.build.js', array( 'wp-blocks', 'wp-element', 'wp-edit-post', 'wp-plugins', 'wp-components' ), EDIT_FLOW_VERSION );
+
+			$custom_statuses = apply_filters( 'ef_custom_status_list', $this->get_custom_statuses(), $post );
+
+			wp_localize_script( 'edit-flow-block-custom-status-script', 'EditFlowCustomStatuses', array_values( $custom_statuses ) );
 		}
 
-		// Custom javascript to modify the post status dropdown where it shows up
-		if ( $this->is_whitelisted_page() ) {
-			wp_enqueue_script( 'edit_flow-custom_status', $this->module_url . 'lib/custom-status.js', array( 'jquery','post' ), EDIT_FLOW_VERSION, true );
-			wp_localize_script('edit_flow-custom_status', '__ef_localize_custom_status', array(
-				'no_change' => esc_html__( "&mdash; No Change &mdash;", 'edit-flow' ),
-				'published' => esc_html__( 'Published', 'edit-flow' ),
-				'save_as'   => esc_html__( 'Save as', 'edit-flow' ),
-				'save'      => esc_html__( 'Save', 'edit-flow' ),
-				'edit'      => esc_html__( 'Edit', 'edit-flow' ),
-				'ok'        => esc_html__( 'OK', 'edit-flow' ),
-				'cancel'    => esc_html__( 'Cancel', 'edit-flow' ),
-			));
+		public function load_styles_for_block_editor() {
+			wp_enqueue_style( 'edit-flow-block-custom-status-styles', EDIT_FLOW_URL . 'dist/custom-status.editor.build.css', false, EDIT_FLOW_VERSION );
 		}
 
-	}
-
-	function load_scripts_for_block_editor(){
-		global $post;
-
-		wp_enqueue_script( 'edit-flow-block-custom-status-script', EDIT_FLOW_URL . 'dist/custom-status.build.js', array( 'wp-blocks', 'wp-element', 'wp-edit-post', 'wp-plugins', 'wp-components' ), EDIT_FLOW_VERSION );
-
-		$custom_statuses = apply_filters( 'ef_custom_status_list', $this->get_custom_statuses(), $post );
-
-		wp_localize_script( 'edit-flow-block-custom-status-script', 'EditFlowCustomStatuses', array_values( $custom_statuses ) );
-	}
-
-	function load_styles_for_block_editor(){
-		wp_enqueue_style( 'edit-flow-block-custom-status-styles', EDIT_FLOW_URL . 'dist/custom-status.editor.build.css', false, EDIT_FLOW_VERSION );
-	}
-
-	/**
-	 * Displays a notice to users if they have JS disabled
-	 * Javascript is needed for custom statuses to be fully functional
-	 */
-	function no_js_notice() {
-		if( $this->is_whitelisted_page() ) :
-			?>
+		/**
+		 * Displays a notice to users if they have JS disabled
+		 * Javascript is needed for custom statuses to be fully functional
+		 */
+		public function no_js_notice() {
+			if ( $this->is_whitelisted_page() ) :
+				?>
 			<style type="text/css">
 			/* Hide post status dropdown by default in case of JS issues **/
 			label[for=post_status],
@@ -347,108 +352,110 @@ class EF_Custom_Status extends EF_Module {
 			<div class="update-nag hide-if-js">
 				<?php _e( '<strong>Note:</strong> Your browser does not support JavaScript or has JavaScript disabled. You will not be able to access or change the post status.', 'edit-flow' ); ?>
 			</div>
-			<?php
-		endif;
-	}
+				<?php
+			endif;
+		}
 
-	/**
-	 * Check whether custom status stuff should be loaded on this page
-	 *
-	 * @todo migrate this to the base module class
-	 */
-	function is_whitelisted_page() {
-		global $pagenow;
+		/**
+		 * Check whether custom status stuff should be loaded on this page
+		 *
+		 * @todo migrate this to the base module class
+		 */
+		public function is_whitelisted_page() {
+			global $pagenow;
 
-		if ( !in_array( $this->get_current_post_type(), $this->get_post_types_for_module( $this->module ) ) )
-			return false;
+			if ( ! in_array( $this->get_current_post_type(), $this->get_post_types_for_module( $this->module ) ) ) {
+				return false;
+			}
 
-		$post_type_obj = get_post_type_object( $this->get_current_post_type() );
+			$post_type_obj = get_post_type_object( $this->get_current_post_type() );
 
-		if( ! current_user_can( $post_type_obj->cap->edit_posts ) )
-			return false;
+			if ( ! current_user_can( $post_type_obj->cap->edit_posts ) ) {
+				return false;
+			}
 
-		// Only add the script to Edit Post and Edit Page pages -- don't want to bog down the rest of the admin with unnecessary javascript
-		return in_array( $pagenow, array( 'post.php', 'edit.php', 'post-new.php', 'page.php', 'edit-pages.php', 'page-new.php' ) );
-	}
+			// Only add the script to Edit Post and Edit Page pages -- don't want to bog down the rest of the admin with unnecessary javascript
+			return in_array( $pagenow, array( 'post.php', 'edit.php', 'post-new.php', 'page.php', 'edit-pages.php', 'page-new.php' ) );
+		}
 
-	/**
-	 * Adds all necessary javascripts to make custom statuses work
-	 *
-	 * @todo Support private and future posts on edit.php view
-	 */
-	function post_admin_header() {
-		global $post, $edit_flow, $pagenow, $current_user;
+		/**
+		 * Adds all necessary javascripts to make custom statuses work
+		 *
+		 * @todo Support private and future posts on edit.php view
+		 */
+		public function post_admin_header() {
+			global $post, $edit_flow, $pagenow, $current_user;
 
-		if ( $this->disable_custom_statuses_for_post_type() )
-			return;
+			if ( $this->disable_custom_statuses_for_post_type() ) {
+				return;
+			}
 
-		// Get current user
-		wp_get_current_user() ;
+			// Get current user
+			wp_get_current_user();
 
-		// Only add the script to Edit Post and Edit Page pages -- don't want to bog down the rest of the admin with unnecessary javascript
-		if ( $this->is_whitelisted_page() ) {
+			// Only add the script to Edit Post and Edit Page pages -- don't want to bog down the rest of the admin with unnecessary javascript
+			if ( $this->is_whitelisted_page() ) {
 
-			$custom_statuses = $this->get_custom_statuses();
+				$custom_statuses = $this->get_custom_statuses();
 
-			// $selected can be empty, but must be set because it's used as a JS variable
-			$selected = '';
-			$selected_name = '';
+				// $selected can be empty, but must be set because it's used as a JS variable
+				$selected = '';
+				$selected_name = '';
 
-			if( ! empty( $post ) ) {
-				// Get the status of the current post
-				if ( $post->ID == 0 || $post->post_status == 'auto-draft' || $pagenow == 'edit.php' ) {
-					// TODO: check to make sure that the default exists
-					$selected = $this->get_default_custom_status()->slug;
+				if ( ! empty( $post ) ) {
+					// Get the status of the current post
+					if ( 0 == $post->ID || 'auto-draft' == $post->post_status || 'edit.php' == $pagenow ) {
+						// TODO: check to make sure that the default exists
+						$selected = $this->get_default_custom_status()->slug;
+					} else {
+						$selected = $post->post_status;
+					}
 
-				} else {
-					$selected = $post->post_status;
-				}
-
-				// Get the label of current status
-				foreach ( $custom_statuses as $status ) {
-					if ( $status->slug == $selected ) {
-						$selected_name = $status->name;
+					// Get the label of current status
+					foreach ( $custom_statuses as $status ) {
+						if ( $status->slug == $selected ) {
+							$selected_name = $status->name;
+						}
 					}
 				}
-			}
 
-			$custom_statuses = apply_filters( 'ef_custom_status_list', $custom_statuses, $post );
+				$custom_statuses = apply_filters( 'ef_custom_status_list', $custom_statuses, $post );
 
-			// All right, we want to set up the JS var which contains all custom statuses
-			$all_statuses = array();
+				// All right, we want to set up the JS var which contains all custom statuses
+				$all_statuses = array();
 
-			// The default statuses from WordPress
-			$all_statuses[] = array(
-				'name' => __( 'Published', 'edit-flow' ),
-				'slug' => 'publish',
-				'description' => '',
-			);
-			$all_statuses[] = array(
-				'name' => __( 'Privately Published', 'edit-flow' ),
-				'slug' => 'private',
-				'description' => '',
-			);
-			$all_statuses[] = array(
-				'name' => __( 'Scheduled', 'edit-flow' ),
-				'slug' => 'future',
-				'description' => '',
-			);
-
-			// Load the custom statuses
-			foreach( $custom_statuses as $status ) {
+				// The default statuses from WordPress
 				$all_statuses[] = array(
-					'name' => esc_js( $status->name ),
-					'slug' => esc_js( $status->slug ),
-					'description' => esc_js( $status->description ),
+					'name' => __( 'Published', 'edit-flow' ),
+					'slug' => 'publish',
+					'description' => '',
 				);
-			}
+				$all_statuses[] = array(
+					'name' => __( 'Privately Published', 'edit-flow' ),
+					'slug' => 'private',
+					'description' => '',
+				);
+				$all_statuses[] = array(
+					'name' => __( 'Scheduled', 'edit-flow' ),
+					'slug' => 'future',
+					'description' => '',
+				);
 
- 			$always_show_dropdown = ( $this->module->options->always_show_dropdown == 'on' ) ? 1 : 0;
+				// Load the custom statuses
+				foreach ( $custom_statuses as $status ) {
+					$all_statuses[] = array(
+						'name' => esc_js( $status->name ),
+						'slug' => esc_js( $status->slug ),
+						'description' => esc_js( $status->description ),
+					);
+				}
 
- 			$post_type_obj = get_post_type_object( $this->get_current_post_type() );
+				$always_show_dropdown = ( 'on' == $this->module->options->always_show_dropdown ) ? 1 : 0;
 
-			// Now, let's print the JS vars
-			?>
+				$post_type_obj = get_post_type_object( $this->get_current_post_type() );
+
+				// Now, let's print the JS vars
+				?>
 			<script type="text/javascript">
 				var custom_statuses = <?php echo json_encode( $all_statuses ); ?>;
 				var ef_default_custom_status = '<?php echo esc_js( $this->get_default_custom_status()->slug ); ?>';
@@ -459,747 +466,806 @@ class EF_Custom_Status extends EF_Module {
 				var current_user_can_edit_published_posts = <?php echo current_user_can( $post_type_obj->cap->edit_published_posts ) ? 1 : 0; ?>;
 			</script>
 
-			<?php
+				<?php
 
+			}
 		}
 
-	}
+		/**
+		 * Adds a new custom status as a term in the wp_terms table.
+		 * Basically a wrapper for the wp_insert_term class.
+		 *
+		 * The arguments decide how the term is handled based on the $args parameter.
+		 * The following is a list of the available overrides and the defaults.
+		 *
+		 * 'description'. There is no default. If exists, will be added to the database
+		 * along with the term. Expected to be a string.
+		 *
+		 * 'slug'. Expected to be a string. There is no default.
+		 *
+		 * @param int|string $term The status to add or update
+		 * @param array|string $args Change the values of the inserted term
+		 * @return array|WP_Error $response The Term ID and Term Taxonomy ID
+		 */
+		public function add_custom_status( $term, $args = array() ) {
+			$slug = ( ! empty( $args['slug'] ) ) ? $args['slug'] : sanitize_title( $term );
+			unset( $args['slug'] );
+			$encoded_description = $this->get_encoded_description( $args );
+			$response = wp_insert_term( $term, self::taxonomy_key, array(
+				'slug' => $slug,
+				'description' => $encoded_description,
+			) );
 
-	/**
-	 * Adds a new custom status as a term in the wp_terms table.
-	 * Basically a wrapper for the wp_insert_term class.
-	 *
-	 * The arguments decide how the term is handled based on the $args parameter.
-	 * The following is a list of the available overrides and the defaults.
-	 *
-	 * 'description'. There is no default. If exists, will be added to the database
-	 * along with the term. Expected to be a string.
-	 *
-	 * 'slug'. Expected to be a string. There is no default.
-	 *
-	 * @param int|string $term The status to add or update
-	 * @param array|string $args Change the values of the inserted term
-	 * @return array|WP_Error $response The Term ID and Term Taxonomy ID
-	 */
-	function add_custom_status( $term, $args = array() ) {
-		$slug = ( ! empty( $args['slug'] ) ) ? $args['slug'] : sanitize_title( $term );
-		unset( $args['slug'] );
-		$encoded_description = $this->get_encoded_description( $args );
-		$response = wp_insert_term( $term, self::taxonomy_key, array( 'slug' => $slug, 'description' => $encoded_description ) );
+			// Reset our internal object cache
+			$this->custom_statuses_cache = array();
 
-		// Reset our internal object cache
-		$this->custom_statuses_cache = array();
-
-		return $response;
-
-	}
-
-	/**
-	 * Update an existing custom status
-	 *
-	 * @param int @status_id ID for the status
-	 * @param array $args Any arguments to be updated
-	 * @return object $updated_status Newly updated status object
-	 */
-	function update_custom_status( $status_id, $args = array() ) {
-		global $edit_flow;
-
-		$old_status = $this->get_custom_status_by( 'id', $status_id );
-		if ( !$old_status || is_wp_error( $old_status ) )
-			return new WP_Error( 'invalid', __( "Custom status doesn't exist.", 'edit-flow' ) );
-
-		// Reset our internal object cache
-		$this->custom_statuses_cache = array();
-
-		// Prevent user from changing draft name or slug
-		if ( 'draft' === $old_status->slug
-		     && (
-			     ( isset( $args['name'] ) && $args['name'] !== $old_status->name )
-			     ||
-			     ( isset( $args['slug'] ) && $args['slug'] !== $old_status->slug )
-		     ) ) {
-			return new WP_Error( 'invalid', __( 'Changing the name and slug of "Draft" is not allowed', 'edit-flow' ) );
+			return $response;
 		}
 
-		// If the name was changed, we need to change the slug
-		if ( isset( $args['name'] ) && $args['name'] != $old_status->name )
-			$args['slug'] = sanitize_title( $args['name'] );
+		/**
+		 * Update an existing custom status
+		 *
+		 * @param int @status_id ID for the status
+		 * @param array $args Any arguments to be updated
+		 * @return object $updated_status Newly updated status object
+		 */
+		public function update_custom_status( $status_id, $args = array() ) {
+			global $edit_flow;
 
-		// Reassign posts to new status slug if the slug changed and isn't restricted
-		if ( isset( $args['slug'] ) && $args['slug'] != $old_status->slug && !$this->is_restricted_status( $old_status->slug ) ) {
-			$new_status = $args['slug'];
-			$this->reassign_post_status( $old_status->slug, $new_status );
-
-			$default_status = $this->get_default_custom_status()->slug;
-			if ( $old_status->slug == $default_status )
-				$edit_flow->update_module_option( $this->module->name, 'default_status', $new_status );
-		}
-		// We're encoding metadata that isn't supported by default in the term's description field
-		$args_to_encode = array();
-		$args_to_encode['description'] = ( isset( $args['description'] ) ) ? $args['description'] : $old_status->description;
-		$args_to_encode['position'] = ( isset( $args['position'] ) ) ? $args['position'] : $old_status->position;
-		$encoded_description = $this->get_encoded_description( $args_to_encode );
-		$args['description'] = $encoded_description;
-
-		$updated_status_array = wp_update_term( $status_id, self::taxonomy_key, $args );
-		$updated_status = $this->get_custom_status_by( 'id', $updated_status_array['term_id'] );
-
-		return $updated_status;
-
-	}
-
-	/**
-	 * Deletes a custom status from the wp_terms table.
-	 *
-	 * Partly a wrapper for the wp_delete_term function.
-	 * BUT, also reassigns posts that currently have the deleted status assigned.
-	 */
-	function delete_custom_status( $status_id, $args = array(), $reassign = '' ) {
-		global $edit_flow;
-		// Reassign posts to alternate status
-
-		// Get slug for the old status
-		$old_status = $this->get_custom_status_by( 'id', $status_id )->slug;
-
-		if ( $reassign == $old_status )
-			return new WP_Error( 'invalid', __( 'Cannot reassign to the status you want to delete', 'edit-flow' ) );
-
-		// Reset our internal object cache
-		$this->custom_statuses_cache = array();
-
-		if( !$this->is_restricted_status( $old_status ) && 'draft' !== $old_status ) {
-			$default_status = $this->get_default_custom_status()->slug;
-			// If new status in $reassign, use that for all posts of the old_status
-			if( !empty( $reassign ) )
-				$new_status = $this->get_custom_status_by( 'id', $reassign )->slug;
-			else
-				$new_status = $default_status;
-			if ( $old_status == $default_status && $this->get_custom_status_by( 'slug', 'draft' ) ) { // Deleting default status
-				$new_status = 'draft';
-				$edit_flow->update_module_option( $this->module->name, 'default_status', $new_status );
+			$old_status = $this->get_custom_status_by( 'id', $status_id );
+			if ( ! $old_status || is_wp_error( $old_status ) ) {
+				return new WP_Error( 'invalid', __( "Custom status doesn't exist.", 'edit-flow' ) );
 			}
 
-			$this->reassign_post_status( $old_status, $new_status );
+			// Reset our internal object cache
+			$this->custom_statuses_cache = array();
 
-			return wp_delete_term( $status_id, self::taxonomy_key, $args );
-		} else
-			return new WP_Error( 'restricted', __( 'Restricted status ', 'edit-flow' ) . '(' . $this->get_custom_status_by( 'id', $status_id )->name . ')' );
+			// Prevent user from changing draft name or slug
+			if ( 'draft' === $old_status->slug
+			 && (
+				 ( isset( $args['name'] ) && $args['name'] !== $old_status->name )
+				 ||
+				 ( isset( $args['slug'] ) && $args['slug'] !== $old_status->slug )
+			 ) ) {
+				return new WP_Error( 'invalid', __( 'Changing the name and slug of "Draft" is not allowed', 'edit-flow' ) );
+			}
 
-	}
+			// If the name was changed, we need to change the slug
+			if ( isset( $args['name'] ) && $args['name'] != $old_status->name ) {
+				$args['slug'] = sanitize_title( $args['name'] );
+			}
 
-	/**
-	 * Get all custom statuses as an ordered array
-	 *
-	 * @param array|string $statuses
-	 * @param array $args
-	 * @return array $statuses All of the statuses
-	 */
-	function get_custom_statuses( $args = array() ) {
-		global $wp_post_statuses;
+			// Reassign posts to new status slug if the slug changed and isn't restricted
+			if ( isset( $args['slug'] ) && $args['slug'] != $old_status->slug && ! $this->is_restricted_status( $old_status->slug ) ) {
+				$new_status = $args['slug'];
+				$this->reassign_post_status( $old_status->slug, $new_status );
 
-		if ( $this->disable_custom_statuses_for_post_type() ) {
-			return $this->get_core_post_statuses();
-		}
-
-		// Internal object cache for repeat requests
-		$arg_hash = md5( serialize( $args ) );
-		if ( ! empty( $this->custom_statuses_cache[ $arg_hash ] ) ) {
-			return $this->custom_statuses_cache[ $arg_hash ];
-		}
-
-		// Handle if the requested taxonomy doesn't exist
-		$args     = array_merge( array( 'hide_empty' => false ), $args );
-		$statuses = get_terms( self::taxonomy_key, $args );
-
-		if ( is_wp_error( $statuses ) || empty( $statuses ) ) {
-			$statuses = array();
-		}
-
-		// Expand and order the statuses
-		$ordered_statuses = array();
-		$hold_to_end = array();
-		foreach ( $statuses as $key => $status ) {
-			// Unencode and set all of our psuedo term meta because we need the position if it exists
-			$unencoded_description = $this->get_unencoded_description( $status->description );
-			if ( is_array( $unencoded_description ) ) {
-				foreach( $unencoded_description as $key => $value ) {
-					$status->$key = $value;
+				$default_status = $this->get_default_custom_status()->slug;
+				if ( $old_status->slug == $default_status ) {
+					$edit_flow->update_module_option( $this->module->name, 'default_status', $new_status );
 				}
 			}
-			// We require the position key later on (e.g. management table)
-			if ( !isset( $status->position ) )
-				$status->position = false;
-			// Only add the status to the ordered array if it has a set position and doesn't conflict with another key
-			// Otherwise, hold it for later
-			if ( $status->position && !array_key_exists( $status->position, $ordered_statuses ) ) {
-				$ordered_statuses[(int)$status->position] = $status;
+			// We're encoding metadata that isn't supported by default in the term's description field
+			$args_to_encode = array();
+			$args_to_encode['description'] = ( isset( $args['description'] ) ) ? $args['description'] : $old_status->description;
+			$args_to_encode['position'] = ( isset( $args['position'] ) ) ? $args['position'] : $old_status->position;
+			$encoded_description = $this->get_encoded_description( $args_to_encode );
+			$args['description'] = $encoded_description;
+
+			$updated_status_array = wp_update_term( $status_id, self::taxonomy_key, $args );
+			$updated_status = $this->get_custom_status_by( 'id', $updated_status_array['term_id'] );
+
+			return $updated_status;
+		}
+
+		/**
+		 * Deletes a custom status from the wp_terms table.
+		 *
+		 * Partly a wrapper for the wp_delete_term function.
+		 * BUT, also reassigns posts that currently have the deleted status assigned.
+		 */
+		public function delete_custom_status( $status_id, $args = array(), $reassign = '' ) {
+			global $edit_flow;
+			// Reassign posts to alternate status
+
+			// Get slug for the old status
+			$old_status = $this->get_custom_status_by( 'id', $status_id )->slug;
+
+			if ( $reassign == $old_status ) {
+				return new WP_Error( 'invalid', __( 'Cannot reassign to the status you want to delete', 'edit-flow' ) );
+			}
+
+			// Reset our internal object cache
+			$this->custom_statuses_cache = array();
+
+			if ( ! $this->is_restricted_status( $old_status ) && 'draft' !== $old_status ) {
+				$default_status = $this->get_default_custom_status()->slug;
+				// If new status in $reassign, use that for all posts of the old_status
+				if ( ! empty( $reassign ) ) {
+					$new_status = $this->get_custom_status_by( 'id', $reassign )->slug;
+				} else {
+					$new_status = $default_status;
+				}
+				if ( $old_status == $default_status && $this->get_custom_status_by( 'slug', 'draft' ) ) { // Deleting default status
+					$new_status = 'draft';
+					$edit_flow->update_module_option( $this->module->name, 'default_status', $new_status );
+				}
+
+				$this->reassign_post_status( $old_status, $new_status );
+
+				return wp_delete_term( $status_id, self::taxonomy_key, $args );
 			} else {
-				$hold_to_end[] = $status;
+				return new WP_Error( 'restricted', __( 'Restricted status ', 'edit-flow' ) . '(' . $this->get_custom_status_by( 'id', $status_id )->name . ')' );
 			}
 		}
-		// Sort the items numerically by key
-		ksort( $ordered_statuses, SORT_NUMERIC );
-		// Append all of the statuses that didn't have an existing position
-		foreach( $hold_to_end as $unpositioned_status )
-			$ordered_statuses[] = $unpositioned_status;
-
-		$this->custom_statuses_cache[ $arg_hash ] = $ordered_statuses;
-
-		return $ordered_statuses;
-	}
-
-	/**
-	 * Returns the a single status object based on ID, title, or slug
-	 *
-	 * @param string|int $string_or_int The status to search for, either by slug, name or ID
-	 * @return object|WP_Error $status The object for the matching status
-	 */
-	function get_custom_status_by( $field, $value ) {
-
-		if ( ! in_array( $field, array( 'id', 'slug', 'name' ) ) )
-			return false;
-
-		if ( 'id' == $field )
-			$field = 'term_id';
-
-		$custom_statuses = $this->get_custom_statuses();
-		$custom_status = wp_filter_object_list( $custom_statuses, array( $field => $value ) );
-
-		if ( ! empty( $custom_status ) )
-			return array_shift( $custom_status );
-		else
-			return false;
-	}
-
-	/**
-	 * Get the term object for the default custom post status
-	 *
-	 * @return object $default_status Default post status object
-	 */
-	function get_default_custom_status() {
-		$default_status = $this->get_custom_status_by( 'slug', $this->module->options->default_status );
-		if ( ! $default_status ) {
-			$custom_statuses = $this->get_custom_statuses();
-			$default_status = array_shift( $custom_statuses );
-		}
-		return $default_status;
-
-	}
-
-	/**
-	 * Assign new statuses to posts using value provided or the default
-	 *
-	 * @param string $old_status Slug for the old status
-	 * @param string $new_status Slug for the new status
-	 */
-	function reassign_post_status( $old_status, $new_status = '' ) {
-		global $wpdb;
-
-		if ( empty( $new_status ) )
-			$new_status = $this->get_default_custom_status()->slug;
-
-		// Make the database call
-		$result = $wpdb->update( $wpdb->posts, array( 'post_status' => $new_status ), array( 'post_status' => $old_status ), array( '%s' ));
-	}
-
-	/**
-	 * Display our custom post statuses in post listings when needed.
-	 *
-	 * @param array   $post_states An array of post display states.
-	 * @param WP_Post $post The current post object.
-	 *
-	 * @return array $post_states
-	 */
-	public function add_status_to_post_states( $post_states, $post ) {
-		if ( ! in_array( $post->post_type, $this->get_post_types_for_module( $this->module ), true ) ) {
-			// Return early if this post type doesn't support custom statuses.
-			return $post_states;
-		}
-
-		$post_status = get_post_status_object( get_post_status( $post->ID ) );
-
-		$filtered_status = isset( $_REQUEST['post_status'] ) ? $_REQUEST['post_status'] : '';
-		if ( $filtered_status === $post_status->name ) {
-			// No need to display the post status if a specific status was already requested.
-			return $post_states;
-		}
-
-		$statuses_to_ignore = array( 'future', 'trash', 'publish' );
-		if ( in_array( $post_status->name, $statuses_to_ignore, true ) ) {
-			// Let WP core handle these more gracefully.
-			return $post_states;
-		}
-
-		// Add the post status to display. Will also ensure the same status isn't shown twice.
-		$post_states[ $post_status->name ] = $post_status->label;
-
-		return $post_states;
-	}
-
-	/**
-	 * Determines whether the slug indicated belongs to a restricted status or not
-	 *
-	 * @param string $slug Slug of the status
-	 * @return bool $restricted True if restricted, false if not
-	 */
-	function is_restricted_status( $slug ) {
-
-		switch( $slug ) {
-			case 'publish':
-			case 'private':
-			case 'future':
-			case 'new':
-			case 'inherit':
-			case 'auto-draft':
-			case 'trash':
-				$restricted = true;
-				break;
-
-			default:
-				$restricted = false;
-				break;
-		}
-		return $restricted;
-
-	}
-
-	/**
-	 * Handles a form's POST request to add a custom status
-	 *
-	 * @since 0.7
-	 */
-	function handle_add_custom_status() {
-
-		// Check that the current POST request is our POST request
-		if ( !isset( $_POST['submit'], $_GET['page'], $_POST['action'] )
-			|| $_GET['page'] != $this->module->settings_slug || $_POST['action'] != 'add-new' )
-				return;
-
-		if ( !wp_verify_nonce( $_POST['_wpnonce'], 'custom-status-add-nonce' ) )
-			wp_die( $this->module->messages['nonce-failed'] );
-
-		// Validate and sanitize the form data
-		$status_name = sanitize_text_field( trim( $_POST['status_name'] ) );
-		$status_slug = sanitize_title( $status_name );
-		$status_description = stripslashes( wp_filter_nohtml_kses( trim( $_POST['status_description'] ) ) );
 
 		/**
-		 * Form validation
-		 * - Name is required and can't conflict with an existing name or slug
-		 * - Description is optional
-		 */
-		$_REQUEST['form-errors'] = array();
-		// Check if name field was filled in
-		if( empty( $status_name ) )
-			$_REQUEST['form-errors']['name'] = __( 'Please enter a name for the status', 'edit-flow' );
-		// Check that the name isn't numeric
-		if ( (int)$status_name != 0 )
-			$_REQUEST['form-errors']['name'] = __( 'Please enter a valid, non-numeric name for the status.', 'edit-flow' );
-		// Check that the status name doesn't exceed 20 chars
-		if ( strlen( $status_name ) > 20 )
-			$_REQUEST['form-errors']['name'] = __( 'Status name cannot exceed 20 characters. Please try a shorter name.', 'edit-flow' );
-		// Check to make sure the status doesn't already exist as another term because otherwise we'd get a weird slug
-		if ( term_exists( $status_slug, self::taxonomy_key ) )
-			$_REQUEST['form-errors']['name'] = __( 'Status name conflicts with existing term. Please choose another.', 'edit-flow' );
-		// Check to make sure the name is not restricted
-		if ( $this->is_restricted_status( strtolower( $status_slug ) ) )
-			$_REQUEST['form-errors']['name'] = __( 'Status name is restricted. Please choose another name.', 'edit-flow' );
-
-		// If there were any form errors, kick out and return them
-		if ( count( $_REQUEST['form-errors'] ) ) {
-			$_REQUEST['error'] = 'form-error';
-			return;
-		}
-
-		// Try to add the status
-		$status_args = array(
-			'description' => $status_description,
-			'slug' => $status_slug,
-		);
-		$return = $this->add_custom_status( $status_name, $status_args );
-		if ( is_wp_error( $return ) )
-			wp_die( __( 'Could not add status: ', 'edit-flow' ) . $return->get_error_message() );
-		// Redirect if successful
-		$redirect_url = $this->get_link( array( 'message' => 'status-added' ) );
-		wp_redirect( $redirect_url );
-		exit;
-
-	}
-
-	/**
-	 * Handles a POST request to edit an custom status
-	 *
-	 * @since 0.7
-	 */
-	function handle_edit_custom_status() {
-		if ( !isset( $_POST['submit'], $_GET['page'], $_GET['action'], $_GET['term-id'] )
-			|| $_GET['page'] != $this->module->settings_slug || $_GET['action'] != 'edit-status' )
-				return;
-
-		if ( !wp_verify_nonce( $_POST['_wpnonce'], 'edit-status' ) )
-			wp_die( $this->module->messages['nonce-failed'] );
-
-		if ( !current_user_can( 'manage_options' ) )
-			wp_die( $this->module->messages['invalid-permissions'] );
-
-		if ( !$existing_status = $this->get_custom_status_by( 'id', (int)$_GET['term-id'] ) )
-			wp_die( $this->module->messages['status-missing'] );
-
-		$name = sanitize_text_field( trim( $_POST['name'] ) );
-		$description = stripslashes( wp_filter_nohtml_kses( trim( $_POST['description'] ) ) );
-
-		/**
-		 * Form validation for editing custom status
+		 * Get all custom statuses as an ordered array
 		 *
-		 * Details
-		 * - 'name' is a required field and can't conflict with existing name or slug
-		 * - 'description' is optional
+		 * @param array|string $statuses
+		 * @param array $args
+		 * @return array $statuses All of the statuses
 		 */
-		$_REQUEST['form-errors'] = array();
-		// Check if name field was filled in
-		if( empty( $name ) )
-			$_REQUEST['form-errors']['name'] = __( 'Please enter a name for the status', 'edit-flow' );
-		// Check that the name isn't numeric
-		if ( is_numeric( $name ) )
-			$_REQUEST['form-errors']['name'] = __( 'Please enter a valid, non-numeric name for the status.', 'edit-flow' );
-		// Check that the status name doesn't exceed 20 chars
-		if ( strlen( $name ) > 20 )
-			$_REQUEST['form-errors']['name'] = __( 'Status name cannot exceed 20 characters. Please try a shorter name.', 'edit-flow' );
-		// Check to make sure the status doesn't already exist as another term because otherwise we'd get a weird slug
-		$term_exists = term_exists( sanitize_title( $name ), self::taxonomy_key );
-		if ( $term_exists && isset( $term_exists['term_id'] ) && $term_exists['term_id'] != $existing_status->term_id )
-			$_REQUEST['form-errors']['name'] = __( 'Status name conflicts with existing term. Please choose another.', 'edit-flow' );
-		// Check to make sure the status doesn't already exist
-		$search_status = $this->get_custom_status_by( 'slug', sanitize_title( $name ) );
-		if ( $search_status && $search_status->term_id != $existing_status->term_id )
-			$_REQUEST['form-errors']['name'] = __( 'Status name conflicts with existing status. Please choose another.', 'edit-flow' );
-		// Check to make sure the name is not restricted
-		if ( $this->is_restricted_status( strtolower( sanitize_title( $name ) ) ) )
-			$_REQUEST['form-errors']['name'] = __( 'Status name is restricted. Please choose another name.', 'edit-flow' );
+		public function get_custom_statuses( $args = array() ) {
+			global $wp_post_statuses;
 
-		// Kick out if there are any errors
-		if ( count( $_REQUEST['form-errors'] ) ) {
-			$_REQUEST['error'] = 'form-error';
-			return;
+			if ( $this->disable_custom_statuses_for_post_type() ) {
+				return $this->get_core_post_statuses();
+			}
+
+			// Internal object cache for repeat requests
+			$arg_hash = md5( serialize( $args ) );
+			if ( ! empty( $this->custom_statuses_cache[ $arg_hash ] ) ) {
+				return $this->custom_statuses_cache[ $arg_hash ];
+			}
+
+			// Handle if the requested taxonomy doesn't exist
+			$statuses = get_terms( array(
+				'taxonomy'   => self::taxonomy_key,
+				'hide_empty' => false,
+			));
+
+			if ( is_wp_error( $statuses ) || empty( $statuses ) ) {
+				$statuses = array();
+			}
+
+			// Expand and order the statuses
+			$ordered_statuses = array();
+			$hold_to_end = array();
+			foreach ( $statuses as $key => $status ) {
+				// Unencode and set all of our psuedo term meta because we need the position if it exists
+				$unencoded_description = $this->get_unencoded_description( $status->description );
+				if ( is_array( $unencoded_description ) ) {
+					foreach ( $unencoded_description as $key => $value ) {
+						$status->$key = $value;
+					}
+				}
+				// We require the position key later on (e.g. management table)
+				if ( ! isset( $status->position ) ) {
+					$status->position = false;
+				}
+				// Only add the status to the ordered array if it has a set position and doesn't conflict with another key
+				// Otherwise, hold it for later
+				if ( $status->position && ! array_key_exists( $status->position, $ordered_statuses ) ) {
+					$ordered_statuses[ (int) $status->position ] = $status;
+				} else {
+					$hold_to_end[] = $status;
+				}
+			}
+			// Sort the items numerically by key
+			ksort( $ordered_statuses, SORT_NUMERIC );
+			// Append all of the statuses that didn't have an existing position
+			foreach ( $hold_to_end as $unpositioned_status ) {
+				$ordered_statuses[] = $unpositioned_status;
+			}
+
+			$this->custom_statuses_cache[ $arg_hash ] = $ordered_statuses;
+
+			return $ordered_statuses;
 		}
 
-		// Try to add the new post status
-		$args = array(
-			'name' => $name,
-			'slug' => sanitize_title( $name ),
-			'description' => $description,
-		);
-		$return = $this->update_custom_status( $existing_status->term_id, $args );
-		if ( is_wp_error( $return ) )
-			wp_die( __( 'Error updating post status.', 'edit-flow' ) );
+		/**
+		 * Returns the a single status object based on ID, title, or slug
+		 *
+		 * @param string|int $string_or_int The status to search for, either by slug, name or ID
+		 * @return object|WP_Error $status The object for the matching status
+		 */
+		public function get_custom_status_by( $field, $value ) {
 
-		$redirect_url = $this->get_link( array( 'message' => 'status-updated' ) );
-		wp_redirect( $redirect_url );
-		exit;
-	}
+			if ( ! in_array( $field, array( 'id', 'slug', 'name' ) ) ) {
+				return false;
+			}
 
-	/**
-	 * Handles a GET request to make the identified status default
-	 *
-	 * @since 0.7
-	 */
-	function handle_make_default_custom_status() {
-		global $edit_flow;
+			if ( 'id' == $field ) {
+				$field = 'term_id';
+			}
 
-		// Check that the current GET request is our GET request
-		if ( !isset( $_GET['page'], $_GET['action'], $_GET['term-id'], $_GET['nonce'] )
-			|| $_GET['page'] != $this->module->settings_slug || $_GET['action'] != 'make-default' )
-			return;
+			$custom_statuses = $this->get_custom_statuses();
+			$custom_status = wp_filter_object_list( $custom_statuses, array( $field => $value ) );
 
-		// Check for proper nonce
-		if ( !wp_verify_nonce( $_GET['nonce'], 'make-default' ) )
-			wp_die( __( 'Invalid nonce for submission.', 'edit-flow' ) );
+			if ( ! empty( $custom_status ) ) {
+				return array_shift( $custom_status );
+			} else {
+				return false;
+			}
+		}
 
-		// Only allow users with the proper caps
-		if ( !current_user_can( 'manage_options' ) )
-			wp_die( __( 'Sorry, you do not have permission to edit custom statuses.', 'edit-flow' ) );
+		/**
+		 * Get the term object for the default custom post status
+		 *
+		 * @return object $default_status Default post status object
+		 */
+		public function get_default_custom_status() {
+			$default_status = $this->get_custom_status_by( 'slug', $this->module->options->default_status );
+			if ( ! $default_status ) {
+				$custom_statuses = $this->get_custom_statuses();
+				$default_status = array_shift( $custom_statuses );
+			}
+			return $default_status;
+		}
 
-		$term_id = (int)$_GET['term-id'];
-		$term = $this->get_custom_status_by( 'id', $term_id );
-		if ( is_object( $term ) ) {
-			$edit_flow->update_module_option( $this->module->name, 'default_status', $term->slug );
-			// @todo How do we want to handle users who click the link from "Add New Status"
-			$redirect_url = $this->get_link( array( 'message' => 'default-status-changed' ) );
+		/**
+		 * Assign new statuses to posts using value provided or the default
+		 *
+		 * @param string $old_status Slug for the old status
+		 * @param string $new_status Slug for the new status
+		 */
+		public function reassign_post_status( $old_status, $new_status = '' ) {
+			global $wpdb;
+
+			if ( empty( $new_status ) ) {
+				$new_status = $this->get_default_custom_status()->slug;
+			}
+
+			// Make the database call
+			$result = $wpdb->update( $wpdb->posts, array( 'post_status' => $new_status ), array( 'post_status' => $old_status ), array( '%s' ) );
+		}
+
+		/**
+		 * Display our custom post statuses in post listings when needed.
+		 *
+		 * @param array   $post_states An array of post display states.
+		 * @param WP_Post $post The current post object.
+		 *
+		 * @return array $post_states
+		 */
+		public function add_status_to_post_states( $post_states, $post ) {
+			if ( ! in_array( $post->post_type, $this->get_post_types_for_module( $this->module ), true ) ) {
+				// Return early if this post type doesn't support custom statuses.
+				return $post_states;
+			}
+
+			$post_status = get_post_status_object( get_post_status( $post->ID ) );
+
+			$filtered_status = isset( $_REQUEST['post_status'] ) ? $_REQUEST['post_status'] : '';
+			if ( $filtered_status === $post_status->name ) {
+				// No need to display the post status if a specific status was already requested.
+				return $post_states;
+			}
+
+			$statuses_to_ignore = array( 'future', 'trash', 'publish' );
+			if ( in_array( $post_status->name, $statuses_to_ignore, true ) ) {
+				// Let WP core handle these more gracefully.
+				return $post_states;
+			}
+
+			// Add the post status to display. Will also ensure the same status isn't shown twice.
+			$post_states[ $post_status->name ] = $post_status->label;
+
+			return $post_states;
+		}
+
+		/**
+		 * Determines whether the slug indicated belongs to a restricted status or not
+		 *
+		 * @param string $slug Slug of the status
+		 * @return bool $restricted True if restricted, false if not
+		 */
+		public function is_restricted_status( $slug ) {
+
+			switch ( $slug ) {
+				case 'publish':
+				case 'private':
+				case 'future':
+				case 'new':
+				case 'inherit':
+				case 'auto-draft':
+				case 'trash':
+					$restricted = true;
+					break;
+
+				default:
+					$restricted = false;
+					break;
+			}
+			return $restricted;
+		}
+
+		/**
+		 * Handles a form's POST request to add a custom status
+		 *
+		 * @since 0.7
+		 */
+		public function handle_add_custom_status() {
+
+			// Check that the current POST request is our POST request
+			if ( ! isset( $_POST['submit'], $_GET['page'], $_POST['action'] )
+			|| $_GET['page'] != $this->module->settings_slug || 'add-new' != $_POST['action'] ) {
+				return;
+			}
+
+			if ( ! isset( $_POST['_wpnonce'] ) || ! wp_verify_nonce( $_POST['_wpnonce'], 'custom-status-add-nonce' ) ) {
+				wp_die( esc_html( $this->module->messages['nonce-failed'] ) );
+			}
+
+			// Validate and sanitize the form data
+			$status_name = isset( $_POST['status_name'] ) ? sanitize_text_field( trim( $_POST['status_name'] ) ) : '';
+			$status_slug = sanitize_title( $status_name );
+			$status_description = isset( $_POST['status_description'] ) ? stripslashes( wp_filter_nohtml_kses( trim( $_POST['status_description'] ) ) ) : '';
+
+			/**
+			 * Form validation
+			 * - Name is required and can't conflict with an existing name or slug
+			 * - Description is optional
+			 */
+			$_REQUEST['form-errors'] = array();
+			// Check if name field was filled in
+			if ( empty( $status_name ) ) {
+				$_REQUEST['form-errors']['name'] = __( 'Please enter a name for the status', 'edit-flow' );
+			}
+			// Check that the name isn't numeric
+			if ( 0 != (int) $status_name ) {
+				$_REQUEST['form-errors']['name'] = __( 'Please enter a valid, non-numeric name for the status.', 'edit-flow' );
+			}
+			// Check that the status name doesn't exceed 20 chars
+			if ( strlen( $status_name ) > 20 ) {
+				$_REQUEST['form-errors']['name'] = __( 'Status name cannot exceed 20 characters. Please try a shorter name.', 'edit-flow' );
+			}
+			// Check to make sure the status doesn't already exist as another term because otherwise we'd get a weird slug
+			if ( term_exists( $status_slug, self::taxonomy_key ) ) {
+				$_REQUEST['form-errors']['name'] = __( 'Status name conflicts with existing term. Please choose another.', 'edit-flow' );
+			}
+			// Check to make sure the name is not restricted
+			if ( $this->is_restricted_status( strtolower( $status_slug ) ) ) {
+				$_REQUEST['form-errors']['name'] = __( 'Status name is restricted. Please choose another name.', 'edit-flow' );
+			}
+
+			// If there were any form errors, kick out and return them
+			// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotValidated
+			if ( count( $_REQUEST['form-errors'] ) ) {
+				$_REQUEST['error'] = 'form-error';
+				return;
+			}
+
+			// Try to add the status
+			$status_args = array(
+				'description' => $status_description,
+				'slug' => $status_slug,
+			);
+			$return = $this->add_custom_status( $status_name, $status_args );
+			if ( is_wp_error( $return ) ) {
+				wp_die( esc_textarea( __( 'Could not add status: ', 'edit-flow' ) . $return->get_error_message() ) );
+			}
+			// Redirect if successful
+			$redirect_url = $this->get_link( array( 'message' => 'status-added' ) );
 			wp_redirect( $redirect_url );
 			exit;
-		} else {
-			wp_die( __( 'Status doesn&#39;t exist.', 'edit-flow' ) );
 		}
 
-	}
+		/**
+		 * Handles a POST request to edit an custom status
+		 *
+		 * @since 0.7
+		 */
+		public function handle_edit_custom_status() {
+			if ( ! isset( $_POST['submit'], $_GET['page'], $_GET['action'], $_GET['term-id'] )
+			|| $_GET['page'] != $this->module->settings_slug || 'edit-status' != $_GET['action'] ) {
+				return;
+			}
 
-	/**
-	 * Handles a GET request to delete a specific term
-	 *
-	 * @since 0.7
-	 */
-	function handle_delete_custom_status() {
+			if ( ! isset( $_POST['_wpnonce'] ) || ! wp_verify_nonce( $_POST['_wpnonce'], 'edit-status' ) ) {
+				wp_die( esc_html( $this->module->messages['nonce-failed'] ) );
+			}
 
-		// Check that this GET request is our GET request
-		if ( !isset( $_GET['page'], $_GET['action'], $_GET['term-id'], $_GET['nonce'] )
-			|| $_GET['page'] != $this->module->settings_slug || $_GET['action'] != 'delete-status' )
-			return;
+			if ( ! current_user_can( 'manage_options' ) ) {
+				wp_die( esc_html( $this->module->messages['invalid-permissions'] ) );
+			}
 
-		// Check for proper nonce
-		if ( !wp_verify_nonce( $_GET['nonce'], 'delete-status' ) )
-			wp_die( __( 'Invalid nonce for submission.', 'edit-flow' ) );
+			$existing_status = $this->get_custom_status_by( 'id', (int) $_GET['term-id'] );
+			if ( ! $existing_status ) {
+				wp_die( esc_html( $this->module->messages['status-missing'] ) );
+			}
 
-		// Only allow users with the proper caps
-		if ( !current_user_can( 'manage_options' ) )
-			wp_die( __( 'Sorry, you do not have permission to edit custom statuses.', 'edit-flow' ) );
+			$name = isset( $_POST['name'] ) ? sanitize_text_field( trim( $_POST['name'] ) ) : '';
+			$description = isset( $_POST['description'] ) ? stripslashes( wp_filter_nohtml_kses( trim( $_POST['description'] ) ) ) : '';
 
-		// Check to make sure the status isn't already deleted
-		$term_id = (int)$_GET['term-id'];
-		$term = $this->get_custom_status_by( 'id', $term_id );
-		if( !$term )
- 			wp_die( __( 'Status does not exist.', 'edit-flow' ) );
+			/**
+			 * Form validation for editing custom status
+			 *
+			 * Details
+			 * - 'name' is a required field and can't conflict with existing name or slug
+			 * - 'description' is optional
+			 */
+			$_REQUEST['form-errors'] = array();
+			// Check if name field was filled in
+			if ( empty( $name ) ) {
+				$_REQUEST['form-errors']['name'] = __( 'Please enter a name for the status', 'edit-flow' );
+			}
+			// Check that the name isn't numeric
+			if ( is_numeric( $name ) ) {
+				$_REQUEST['form-errors']['name'] = __( 'Please enter a valid, non-numeric name for the status.', 'edit-flow' );
+			}
+			// Check that the status name doesn't exceed 20 chars
+			if ( strlen( $name ) > 20 ) {
+				$_REQUEST['form-errors']['name'] = __( 'Status name cannot exceed 20 characters. Please try a shorter name.', 'edit-flow' );
+			}
+			// Check to make sure the status doesn't already exist as another term because otherwise we'd get a weird slug
+			$term_exists = term_exists( sanitize_title( $name ), self::taxonomy_key );
+			if ( $term_exists && isset( $term_exists['term_id'] ) && $term_exists['term_id'] != $existing_status->term_id ) {
+				$_REQUEST['form-errors']['name'] = __( 'Status name conflicts with existing term. Please choose another.', 'edit-flow' );
+			}
+			// Check to make sure the status doesn't already exist
+			$search_status = $this->get_custom_status_by( 'slug', sanitize_title( $name ) );
+			if ( $search_status && $search_status->term_id != $existing_status->term_id ) {
+				$_REQUEST['form-errors']['name'] = __( 'Status name conflicts with existing status. Please choose another.', 'edit-flow' );
+			}
+			// Check to make sure the name is not restricted
+			if ( $this->is_restricted_status( strtolower( sanitize_title( $name ) ) ) ) {
+				$_REQUEST['form-errors']['name'] = __( 'Status name is restricted. Please choose another name.', 'edit-flow' );
+			}
 
-		// Don't allow deletion of default status
-		if ( $term->slug == $this->get_default_custom_status()->slug )
-			wp_die( __( 'Cannot delete default status.', 'edit-flow' ) );
+			// Kick out if there are any errors
+			// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotValidated
+			if ( count( $_REQUEST['form-errors'] ) ) {
+				$_REQUEST['error'] = 'form-error';
+				return;
+			}
 
-		$return = $this->delete_custom_status( $term_id );
-		if ( is_wp_error( $return ) )
-			wp_die( __( 'Could not delete the status: ', 'edit-flow' ) . $return->get_error_message() );
-
-		$redirect_url = $this->get_link( array( 'message' => 'status-deleted' ) );
-		wp_redirect( $redirect_url );
-		exit;
-
-	}
-
-	/**
-	 * Generate a link to one of the custom status actions
-	 *
-	 * @since 0.7
-	 *
-	 * @param array $args (optional) Action and any query args to add to the URL
-	 * @return string $link Direct link to complete the action
-	 */
-	function get_link( $args = array() ) {
-		if ( !isset( $args['action'] ) )
-			$args['action'] = '';
-		if ( !isset( $args['page'] ) )
-			$args['page'] = $this->module->settings_slug;
-		// Add other things we may need depending on the action
-		switch( $args['action'] ) {
-			case 'make-default':
-			case 'delete-status':
-				$args['nonce'] = wp_create_nonce( $args['action'] );
-				break;
-			default:
-				break;
-		}
-		return add_query_arg( $args, get_admin_url( null, 'admin.php' ) );
-	}
-
-	/**
-	 * Handle an ajax request to update the order of custom statuses
-	 *
-	 * @since 0.7
-	 */
-	function handle_ajax_update_status_positions() {
-
-		if ( !wp_verify_nonce( $_POST['custom_status_sortable_nonce'], 'custom-status-sortable' ) )
-			$this->print_ajax_response( 'error', $this->module->messages['nonce-failed'] );
-
-		if ( !current_user_can( 'manage_options') )
-			$this->print_ajax_response( 'error', $this->module->messages['invalid-permissions'] );
-
-		if ( !isset( $_POST['status_positions'] ) || !is_array( $_POST['status_positions'] ) )
-			$this->print_ajax_response( 'error', __( 'Terms not set.', 'edit-flow' ) );
-
-		// Update each custom status with its new position
-		foreach ( $_POST['status_positions'] as $position => $term_id ) {
-
-			// Have to add 1 to the position because the index started with zero
+			// Try to add the new post status
 			$args = array(
-				'position' => (int)$position + 1,
+				'name' => $name,
+				'slug' => sanitize_title( $name ),
+				'description' => $description,
 			);
-			$return = $this->update_custom_status( (int)$term_id, $args );
-			// @todo check that this was a valid return
-		}
-		$this->print_ajax_response( 'success', $this->module->messages['status-position-updated'] );
-	}
+			$return = $this->update_custom_status( $existing_status->term_id, $args );
+			if ( is_wp_error( $return ) ) {
+				wp_die( esc_textarea( __( 'Error updating post status.', 'edit-flow' ) ) );
+			}
 
-	/**
-	 * Handle an Inline Edit POST request to update status values
-	 *
-	 * @since 0.7
-	 */
-	function ajax_inline_save_status() {
-		global $edit_flow;
-
-		if ( !wp_verify_nonce( $_POST['inline_edit'], 'custom-status-inline-edit-nonce' ) )
-			die( $this->module->messages['nonce-failed'] );
-
-		if ( !current_user_can( 'manage_options') )
-			die( $this->module->messages['invalid-permissions'] );
-
-		$term_id = (int) $_POST['status_id'];
-		$status_name = sanitize_text_field( trim( $_POST['name'] ) );
-		$status_slug = sanitize_title( $_POST['name'] );
-		$status_description = stripslashes( wp_filter_nohtml_kses( trim( $_POST['description'] ) ) );
-
-		// Check if name field was filled in
-		if ( empty( $status_name ) ) {
-			$change_error = new WP_Error( 'invalid', __( 'Please enter a name for the status.', 'edit-flow' ) );
-			die( $change_error->get_error_message() );
+			$redirect_url = $this->get_link( array( 'message' => 'status-updated' ) );
+			wp_redirect( $redirect_url );
+			exit;
 		}
 
-		// Check that the name isn't numeric
-		if( is_numeric( $status_name) ) {
-			$change_error = new WP_Error( 'invalid', __( 'Please enter a valid, non-numeric name for the status.', 'edit-flow' ) );
-			die( $change_error->get_error_message() );
+		/**
+		 * Handles a GET request to make the identified status default
+		 *
+		 * @since 0.7
+		 */
+		public function handle_make_default_custom_status() {
+			global $edit_flow;
+
+			// Check that the current GET request is our GET request
+			if ( ! isset( $_GET['page'], $_GET['action'], $_GET['term-id'], $_GET['nonce'] )
+			|| $_GET['page'] != $this->module->settings_slug || 'make-default' != $_GET['action'] ) {
+				return;
+			}
+
+			// Check for proper nonce
+			if ( ! isset( $_GET['nonce'] ) || ! wp_verify_nonce( $_GET['nonce'], 'make-default' ) ) {
+				wp_die( esc_html__( 'Invalid nonce for submission.', 'edit-flow' ) );
+			}
+
+			// Only allow users with the proper caps
+			if ( ! current_user_can( 'manage_options' ) ) {
+				wp_die( esc_html__( 'Sorry, you do not have permission to edit custom statuses.', 'edit-flow' ) );
+			}
+
+			$term_id = (int) $_GET['term-id'];
+			$term = $this->get_custom_status_by( 'id', $term_id );
+			if ( is_object( $term ) ) {
+				$edit_flow->update_module_option( $this->module->name, 'default_status', $term->slug );
+				// @todo How do we want to handle users who click the link from "Add New Status"
+				$redirect_url = $this->get_link( array( 'message' => 'default-status-changed' ) );
+				wp_redirect( $redirect_url );
+				exit;
+			} else {
+				wp_die( esc_html__( 'Status doesn&#39;t exist.', 'edit-flow' ) );
+			}
 		}
 
-		// Check that the status name doesn't exceed 20 chars
-		if ( strlen( $status_name ) > 20 ) {
-			$change_error = new WP_Error( 'invalid', __( 'Status name cannot exceed 20 characters. Please try a shorter name.', 'edit-flow' ) );
-			die( $change_error->get_error_message() );
+		/**
+		 * Handles a GET request to delete a specific term
+		 *
+		 * @since 0.7
+		 */
+		public function handle_delete_custom_status() {
+
+			// Check that this GET request is our GET request
+			if ( ! isset( $_GET['page'], $_GET['action'], $_GET['term-id'], $_GET['nonce'] )
+			|| $_GET['page'] != $this->module->settings_slug || 'delete-status' != $_GET['action'] ) {
+				return;
+			}
+
+			// Check for proper nonce
+			if ( ! isset( $_GET['nonce'] ) || ! wp_verify_nonce( $_GET['nonce'], 'delete-status' ) ) {
+				wp_die( esc_html__( 'Invalid nonce for submission.', 'edit-flow' ) );
+			}
+
+			// Only allow users with the proper caps
+			if ( ! current_user_can( 'manage_options' ) ) {
+				wp_die( esc_html__( 'Sorry, you do not have permission to edit custom statuses.', 'edit-flow' ) );
+			}
+
+			// Check to make sure the status isn't already deleted
+			$term_id = (int) $_GET['term-id'];
+			$term = $this->get_custom_status_by( 'id', $term_id );
+			if ( ! $term ) {
+				wp_die( esc_html__( 'Status does not exist.', 'edit-flow' ) );
+			}
+
+			// Don't allow deletion of default status
+			if ( $term->slug == $this->get_default_custom_status()->slug ) {
+				wp_die( esc_html__( 'Cannot delete default status.', 'edit-flow' ) );
+			}
+
+			$return = $this->delete_custom_status( $term_id );
+			if ( is_wp_error( $return ) ) {
+				wp_die( esc_html( __( 'Could not delete the status: ', 'edit-flow' ) . $return->get_error_message() ) );
+			}
+
+			$redirect_url = $this->get_link( array( 'message' => 'status-deleted' ) );
+			wp_redirect( $redirect_url );
+			exit;
 		}
 
-		// Check to make sure the name is not restricted
-		if ( $edit_flow->custom_status->is_restricted_status( strtolower( $status_name ) ) ) {
-			$change_error = new WP_Error( 'invalid', __( 'Status name is restricted. Please chose another name.', 'edit-flow' ) );
-			die( $change_error->get_error_message() );
+		/**
+		 * Generate a link to one of the custom status actions
+		 *
+		 * @since 0.7
+		 *
+		 * @param array $args (optional) Action and any query args to add to the URL
+		 * @return string $link Direct link to complete the action
+		 */
+		public function get_link( $args = array() ) {
+			if ( ! isset( $args['action'] ) ) {
+				$args['action'] = '';
+			}
+			if ( ! isset( $args['page'] ) ) {
+				$args['page'] = $this->module->settings_slug;
+			}
+			// Add other things we may need depending on the action
+			switch ( $args['action'] ) {
+				case 'make-default':
+				case 'delete-status':
+					$args['nonce'] = wp_create_nonce( $args['action'] );
+					break;
+				default:
+					break;
+			}
+			return add_query_arg( $args, get_admin_url( null, 'admin.php' ) );
 		}
 
-		// Check to make sure the status doesn't already exist
-		if ( $this->get_custom_status_by( 'slug', $status_slug ) && ( $this->get_custom_status_by( 'id', $term_id )->slug != $status_slug ) ) {
-			$change_error = new WP_Error( 'invalid', __( 'Status already exists. Please choose another name.', 'edit-flow' ) );
-			die( $change_error->get_error_message() );
+		/**
+		 * Handle an ajax request to update the order of custom statuses
+		 *
+		 * @since 0.7
+		 */
+		public function handle_ajax_update_status_positions() {
+
+			if ( ! isset( $_POST['custom_status_sortable_nonce'] ) || ! wp_verify_nonce( $_POST['custom_status_sortable_nonce'], 'custom-status-sortable' ) ) {
+				$this->print_ajax_response( 'error', esc_html( $this->module->messages['nonce-failed'] ) );
+			}
+
+			if ( ! current_user_can( 'manage_options' ) ) {
+				$this->print_ajax_response( 'error', esc_html( $this->module->messages['invalid-permissions'] ) );
+			}
+
+			if ( ! isset( $_POST['status_positions'] ) || ! is_array( $_POST['status_positions'] ) ) {
+				$this->print_ajax_response( 'error', esc_html__( 'Terms not set.', 'edit-flow' ) );
+			}
+
+			// Update each custom status with its new position
+			foreach ( $_POST['status_positions'] as $position => $term_id ) {
+
+				// Have to add 1 to the position because the index started with zero
+				$args = array(
+					'position' => (int) $position + 1,
+				);
+				$return = $this->update_custom_status( (int) $term_id, $args );
+				// @todo check that this was a valid return
+			}
+			$this->print_ajax_response( 'success', $this->module->messages['status-position-updated'] );
 		}
 
-		// Check to make sure the status doesn't already exist as another term because otherwise we'd get a fatal error
-		$term_exists = term_exists( sanitize_title( $status_name ), self::taxonomy_key );
-		if ( $term_exists && isset( $term_exists['term_id'] ) && $term_exists['term_id'] != $term_id ) {
-			$change_error = new WP_Error( 'invalid', __( 'Status name conflicts with existing term. Please choose another.', 'edit-flow' ) );
-			die( $change_error->get_error_message() );
+		/**
+		 * Handle an Inline Edit POST request to update status values
+		 *
+		 * @since 0.7
+		 */
+		public function ajax_inline_save_status() {
+			global $edit_flow;
+
+			if ( ! isset( $_POST['inline_edit'] ) || ! wp_verify_nonce( $_POST['inline_edit'], 'custom-status-inline-edit-nonce' ) ) {
+				die( esc_html( $this->module->messages['nonce-failed'] ) );
+			}
+
+			if ( ! current_user_can( 'manage_options' ) ) {
+				die( esc_html( $this->module->messages['invalid-permissions'] ) );
+			}
+
+			$term_id = isset( $_POST['status_id'] ) ? (int) $_POST['status_id'] : 0;
+			$status_name = isset( $_POST['name'] ) ? sanitize_text_field( trim( $_POST['name'] ) ) : '';
+			$status_slug = isset( $_POST['name'] ) ? sanitize_title( trim( $_POST['name'] ) ) : '';
+			$status_description = isset( $_POST['description'] ) ? stripslashes( wp_filter_nohtml_kses( trim( $_POST['description'] ) ) ) : '';
+
+			// Check if name field was filled in
+			if ( empty( $status_name ) ) {
+				$change_error = new WP_Error( 'invalid', esc_html__( 'Please enter a name for the status.', 'edit-flow' ) );
+				die( esc_html( $change_error->get_error_message() ) );
+			}
+
+			// Check that the name isn't numeric
+			if ( is_numeric( $status_name ) ) {
+				$change_error = new WP_Error( 'invalid', esc_html__( 'Please enter a valid, non-numeric name for the status.', 'edit-flow' ) );
+				die( esc_html( $change_error->get_error_message() ) );
+			}
+
+			// Check that the status name doesn't exceed 20 chars
+			if ( strlen( $status_name ) > 20 ) {
+				$change_error = new WP_Error( 'invalid', esc_html__( 'Status name cannot exceed 20 characters. Please try a shorter name.', 'edit-flow' ) );
+				die( esc_html( $change_error->get_error_message() ) );
+			}
+
+			// Check to make sure the name is not restricted
+			if ( $edit_flow->custom_status->is_restricted_status( strtolower( $status_name ) ) ) {
+				$change_error = new WP_Error( 'invalid', esc_html__( 'Status name is restricted. Please chose another name.', 'edit-flow' ) );
+				die( esc_html( $change_error->get_error_message() ) );
+			}
+
+			// Check to make sure the status doesn't already exist
+			if ( $this->get_custom_status_by( 'slug', $status_slug ) && ( $this->get_custom_status_by( 'id', $term_id )->slug != $status_slug ) ) {
+				$change_error = new WP_Error( 'invalid', esc_html__( 'Status already exists. Please choose another name.', 'edit-flow' ) );
+				die( esc_html( $change_error->get_error_message() ) );
+			}
+
+			// Check to make sure the status doesn't already exist as another term because otherwise we'd get a fatal error
+			$term_exists = term_exists( sanitize_title( $status_name ), self::taxonomy_key );
+			if ( $term_exists && isset( $term_exists['term_id'] ) && $term_exists['term_id'] != $term_id ) {
+				$change_error = new WP_Error( 'invalid', esc_html__( 'Status name conflicts with existing term. Please choose another.', 'edit-flow' ) );
+				die( esc_html( $change_error->get_error_message() ) );
+			}
+
+			// get status_name & status_description
+			$args = array(
+				'name' => $status_name,
+				'description' => $status_description,
+				'slug' => $status_slug,
+			);
+			$return = $this->update_custom_status( $term_id, $args );
+			if ( ! is_wp_error( $return ) ) {
+				set_current_screen( 'edit-custom-status' );
+				$wp_list_table = new EF_Custom_Status_List_Table();
+				$wp_list_table->prepare_items();
+				echo wp_kses_post( $wp_list_table->single_row( $return ) );
+				die();
+			} else {
+				/* translators: 1: the status's name */
+				$change_error = new WP_Error( 'invalid', wp_kses( sprintf( __( 'Could not update the status: <strong>%s</strong>', 'edit-flow' ), $status_name ), 'strong' ) );
+				die( esc_html( $change_error->get_error_message() ) );
+			}
 		}
 
-		// get status_name & status_description
-		$args = array(
-			'name' => $status_name,
-			'description' => $status_description,
-			'slug' => $status_slug,
-		);
-		$return = $this->update_custom_status( $term_id, $args );
-		if( !is_wp_error( $return ) ) {
-			set_current_screen( 'edit-custom-status' );
-			$wp_list_table = new EF_Custom_Status_List_Table();
-			$wp_list_table->prepare_items();
-			echo $wp_list_table->single_row( $return );
-			die();
-		} else {
-			$change_error = new WP_Error( 'invalid', sprintf( __( 'Could not update the status: <strong>%s</strong>', 'edit-flow' ), $status_name ) );
-			die( $change_error->get_error_message() );
-		}
-
-	}
-
-	/**
-	 * Register settings for notifications so we can partially use the Settings API
-	 * (We use the Settings API for form generation, but not saving)
-	 *
-	 * @since 0.7
-	 */
-	function register_settings() {
+		/**
+		 * Register settings for notifications so we can partially use the Settings API
+		 * (We use the Settings API for form generation, but not saving)
+		 *
+		 * @since 0.7
+		 */
+		public function register_settings() {
 
 			add_settings_section( $this->module->options_group_name . '_general', false, '__return_false', $this->module->options_group_name );
 			add_settings_field( 'post_types', __( 'Use on these post types:', 'edit-flow' ), array( $this, 'settings_post_types_option' ), $this->module->options_group_name, $this->module->options_group_name . '_general' );
-			add_settings_field( 'always_show_dropdown', __( 'Always show dropdown:', 'edit-flow' ), array( $this, 'settings_always_show_dropdown_option'), $this->module->options_group_name, $this->module->options_group_name . '_general' );
-
-	}
-
-	/**
-	 * Choose the post types that should be displayed on the calendar
-	 *
-	 * @since 0.7
-	 */
-	function settings_post_types_option() {
-		global $edit_flow;
-		$edit_flow->settings->helper_option_custom_post_type( $this->module );
-	}
-
-	/**
-	 * Option for whether the blog admin email address should be always notified or not
-	 *
-	 * @since 0.7
-	 */
-	function settings_always_show_dropdown_option() {
-		$options = array(
-			'off' => __( 'Disabled', 'edit-flow' ),
-			'on' => __( 'Enabled', 'edit-flow' ),
-		);
-		echo '<select id="always_show_dropdown" name="' . $this->module->options_group_name . '[always_show_dropdown]">';
-		foreach ( $options as $value => $label ) {
-			echo '<option value="' . esc_attr( $value ) . '"';
-			echo selected( $this->module->options->always_show_dropdown, $value );
-			echo '>' . esc_html( $label ) . '</option>';
+			add_settings_field( 'always_show_dropdown', __( 'Always show dropdown:', 'edit-flow' ), array( $this, 'settings_always_show_dropdown_option' ), $this->module->options_group_name, $this->module->options_group_name . '_general' );
 		}
-		echo '</select>';
-	}
 
-	/**
-	 * Validate input from the end user
-	 *
-	 * @since 0.7
-	 */
-	function settings_validate( $new_options ) {
+		/**
+		 * Choose the post types that should be displayed on the calendar
+		 *
+		 * @since 0.7
+		 */
+		public function settings_post_types_option() {
+			global $edit_flow;
+			$edit_flow->settings->helper_option_custom_post_type( $this->module );
+		}
 
-		// Whitelist validation for the post type options
-		if ( !isset( $new_options['post_types'] ) )
-			$new_options['post_types'] = array();
-		$new_options['post_types'] = $this->clean_post_type_options( $new_options['post_types'], $this->module->post_type_support );
-
-		// Whitelist validation for the 'always_show_dropdown' optoins
-		if ( !isset( $new_options['always_show_dropdown'] ) || $new_options['always_show_dropdown'] != 'on' )
-			$new_options['always_show_dropdown'] = 'off';
-
-		return $new_options;
-	}
-
-	/**
-	 * Primary configuration page for custom status class.
-	 * Shows form to add new custom statuses on the left and a
-	 * WP_List_Table with the custom status terms on the right
-	 */
-	function print_configure_view() {
-		global $edit_flow;
-
-		/** Full width view for editing a custom status **/
-		if ( isset( $_GET['action'], $_GET['term-id'] ) && $_GET['action'] == 'edit-status' ): ?>
-		<?php
-			// Check whether the term exists
-			$term_id = (int)$_GET['term-id'];
-			$status = $this->get_custom_status_by( 'id', $term_id  );
-			if ( !$status ) {
-				echo '<div class="error"><p>' . $this->module->messages['status-missing'] . '</p></div>';
-				return;
+		/**
+		 * Option for whether the blog admin email address should be always notified or not
+		 *
+		 * @since 0.7
+		 */
+		public function settings_always_show_dropdown_option() {
+			$options = array(
+				'off' => __( 'Disabled', 'edit-flow' ),
+				'on' => __( 'Enabled', 'edit-flow' ),
+			);
+			echo '<select id="always_show_dropdown" name="' . esc_attr( $this->module->options_group_name ) . '[always_show_dropdown]">';
+			foreach ( $options as $value => $label ) {
+				echo '<option value="' . esc_attr( $value ) . '"';
+				echo selected( $this->module->options->always_show_dropdown, $value );
+				echo '>' . esc_html( $label ) . '</option>';
 			}
-			$edit_status_link = $this->get_link( array( 'action' => 'edit-status', 'term-id' => $term_id ) );
+			echo '</select>';
+		}
 
-			$name = ( isset( $_POST['name'] ) ) ? stripslashes( $_POST['name'] ) : $status->name;
-			$description = ( isset( $_POST['description'] ) ) ? strip_tags( stripslashes( $_POST['description'] ) ) : $status->description;
-		?>
+		/**
+		 * Validate input from the end user
+		 *
+		 * @since 0.7
+		 */
+		public function settings_validate( $new_options ) {
+
+			// Whitelist validation for the post type options
+			if ( ! isset( $new_options['post_types'] ) ) {
+				$new_options['post_types'] = array();
+			}
+			$new_options['post_types'] = $this->clean_post_type_options( $new_options['post_types'], $this->module->post_type_support );
+
+			// Whitelist validation for the 'always_show_dropdown' optoins
+			if ( ! isset( $new_options['always_show_dropdown'] ) || 'on' != $new_options['always_show_dropdown'] ) {
+				$new_options['always_show_dropdown'] = 'off';
+			}
+
+			return $new_options;
+		}
+
+		/**
+		 * Primary configuration page for custom status class.
+		 * Shows form to add new custom statuses on the left and a
+		 * WP_List_Table with the custom status terms on the right
+		 *
+		 * Disabling nonce verification because that is not available here, it's just rendering it. The actual save is done in helper_settings_validate_and_save and that's guarded well.
+		 * phpcs:disable:WordPress.Security.NonceVerification.Missing
+		 */
+		public function print_configure_view() {
+			global $edit_flow;
+
+			/** Full width view for editing a custom status **/
+			if ( isset( $_GET['action'], $_GET['term-id'] ) && 'edit-status' == $_GET['action'] ) :
+				?>
+				<?php
+				// Check whether the term exists
+				$term_id = (int) $_GET['term-id'];
+				$status = $this->get_custom_status_by( 'id', $term_id );
+				if ( ! $status ) {
+					echo '<div class="error"><p>' . esc_html( $this->module->messages['status-missing'] ) . '</p></div>';
+					return;
+				}
+				$edit_status_link = $this->get_link( array(
+					'action' => 'edit-status',
+					'term-id' => $term_id,
+				) );
+
+				$name = ( isset( $_POST['name'] ) ) ? stripslashes( $_POST['name'] ) : $status->name;
+				$description = ( isset( $_POST['description'] ) ) ? strip_tags( stripslashes( $_POST['description'] ) ) : $status->description;
+				?>
 
 		<div id="ajax-response"></div>
-		<form method="post" action="<?php echo esc_attr( $edit_status_link ); ?>" >
+		<form method="post" action="<?php echo esc_url( $edit_status_link ); ?>" >
 		<input type="hidden" name="term-id" value="<?php echo esc_attr( $term_id ); ?>" />
-		<?php
-			wp_original_referer_field();
-			wp_nonce_field( 'edit-status' );
-		?>
+				<?php
+				wp_original_referer_field();
+				wp_nonce_field( 'edit-status' );
+				?>
 		<table class="form-table">
 			<tr class="form-field form-required">
 				<th scope="row" valign="top"><label for="name"><?php _e( 'Custom Status', 'edit-flow' ); ?></label></th>
-				<td><input name="name" id="name" type="text" value="<?php echo esc_attr( $name ); ?>" size="40" aria-required="true" <?php if( 'draft' === $status->slug ) echo 'readonly="readonly"' ?> />
+				<td><input name="name" id="name" type="text" value="<?php echo esc_attr( $name ); ?>" size="40" aria-required="true"
+																			   <?php
+																				if ( 'draft' === $status->slug ) {
+																					echo 'readonly="readonly"';}
+																				?>
+				/>
 				<?php $edit_flow->settings->helper_print_error_or_description( 'name', __( 'The name is used to identify the status. (Max: 20 characters)', 'edit-flow' ) ); ?>
 				</td>
 			</tr>
@@ -1219,16 +1285,16 @@ class EF_Custom_Status extends EF_Module {
 			</tr>
 		</table>
 		<p class="submit">
-		<?php submit_button( __( 'Update Status', 'edit-flow' ), 'primary', 'submit', false ); ?>
+				<?php submit_button( __( 'Update Status', 'edit-flow' ), 'primary', 'submit', false ); ?>
 		<a class="cancel-settings-link" href="<?php echo esc_url( $this->get_link() ); ?>"><?php _e( 'Cancel', 'edit-flow' ); ?></a>
 		</p>
 		</form>
 
-		<?php else: ?>
-		<?php
-		$wp_list_table = new EF_Custom_Status_List_Table();
-		$wp_list_table->prepare_items();
-		?>
+		<?php else : ?>
+			<?php
+			$wp_list_table = new EF_Custom_Status_List_Table();
+			$wp_list_table->prepare_items();
+			?>
 		<script type="text/javascript">
 			var ef_confirm_delete_status_string = "<?php echo esc_js( __( 'Are you sure you want to delete the post status? All posts with this status will be assigned to the default status.', 'edit-flow' ) ); ?>";
 		</script>
@@ -1243,32 +1309,52 @@ class EF_Custom_Status extends EF_Module {
 				<div class="col-wrap">
 				<div class="form-wrap">
 				<h3 class="nav-tab-wrapper">
-					<a href="<?php echo esc_url( $this->get_link() ); ?>" class="nav-tab<?php if ( !isset( $_GET['action'] ) || $_GET['action'] != 'change-options' ) echo ' nav-tab-active'; ?>"><?php _e( 'Add New', 'edit-flow' ); ?></a>
-					<a href="<?php echo esc_url( $this->get_link( array( 'action' => 'change-options' ) ) ); ?>" class="nav-tab<?php if ( isset( $_GET['action'] ) && $_GET['action'] == 'change-options' ) echo ' nav-tab-active'; ?>"><?php _e( 'Options', 'edit-flow' ); ?></a>
+					<a href="<?php echo esc_url( $this->get_link() ); ?>" class="nav-tab
+										<?php
+										if ( ! isset( $_GET['action'] ) || 'change-options' != $_GET['action'] ) {
+											echo ' nav-tab-active';}
+										?>
+					"><?php _e( 'Add New', 'edit-flow' ); ?></a>
+					<a href="<?php echo esc_url( $this->get_link( array( 'action' => 'change-options' ) ) ); ?>" class="nav-tab
+										<?php
+										if ( isset( $_GET['action'] ) && 'change-options' == $_GET['action'] ) {
+											echo ' nav-tab-active';}
+										?>
+					"><?php _e( 'Options', 'edit-flow' ); ?></a>
 				</h3>
-				<?php if ( isset( $_GET['action'] ) && $_GET['action'] == 'change-options' ): ?>
+				<?php if ( isset( $_GET['action'] ) && 'change-options' == $_GET['action'] ) : ?>
 				<form class="basic-settings" action="<?php echo esc_url( $this->get_link( array( 'action' => 'change-options' ) ) ); ?>" method="post">
 					<?php settings_fields( $this->module->options_group_name ); ?>
 					<?php do_settings_sections( $this->module->options_group_name ); ?>
 					<?php echo '<input id="edit_flow_module_name" name="edit_flow_module_name" type="hidden" value="' . esc_attr( $this->module->name ) . '" />'; ?>
 					<?php submit_button(); ?>
 				</form>
-				<?php else: ?>
-				<?php /** Custom form for adding a new Custom Status term **/ ?>
+				<?php else : ?>
+					<?php /** Custom form for adding a new Custom Status term **/ ?>
 					<form class="add:the-list:" action="<?php echo esc_url( $this->get_link() ); ?>" method="post" id="addstatus" name="addstatus">
 					<div class="form-field form-required">
 						<label for="status_name"><?php _e( 'Name', 'edit-flow' ); ?></label>
-						<input type="text" aria-required="true" size="20" maxlength="20" id="status_name" name="status_name" value="<?php if ( !empty( $_POST['status_name'] ) ) echo esc_attr( $_POST['status_name'] ) ?>" />
+						<input type="text" aria-required="true" size="20" maxlength="20" id="status_name" name="status_name" value="
+						<?php
+						if ( ! empty( $_POST['status_name'] ) ) {
+							echo esc_attr( $_POST['status_name'] );}
+						?>
+						" />
 						<?php $edit_flow->settings->helper_print_error_or_description( 'name', __( 'The name is used to identify the status. (Max: 20 characters)', 'edit-flow' ) ); ?>
 					</div>
 					<div class="form-field">
 						<label for="status_description"><?php _e( 'Description', 'edit-flow' ); ?></label>
-						<textarea cols="40" rows="5" id="status_description" name="status_description"><?php if ( !empty( $_POST['status_description'] ) ) echo esc_textarea( $_POST['status_description'] ) ?></textarea>
+						<textarea cols="40" rows="5" id="status_description" name="status_description">
+						<?php
+						if ( ! empty( $_POST['status_description'] ) ) {
+							echo esc_textarea( $_POST['status_description'] );}
+						?>
+						</textarea>
 						<?php $edit_flow->settings->helper_print_error_or_description( 'description', __( 'The description is primarily for administrative use, to give you some context on what the custom status is to be used for.', 'edit-flow' ) ); ?>
 					</div>
 					<?php wp_nonce_field( 'custom-status-add-nonce' ); ?>
 					<?php echo '<input id="action" name="action" type="hidden" value="add-new" />'; ?>
-					<p class="submit"><?php submit_button( __( 'Add New Status', 'edit-flow' ), 'primary', 'submit', false ); ?><a class="cancel-settings-link" href="<?php echo EDIT_FLOW_SETTINGS_PAGE; ?>"><?php _e( 'Back to Edit Flow', 'edit-flow' ); ?></a></p>
+					<p class="submit"><?php submit_button( __( 'Add New Status', 'edit-flow' ), 'primary', 'submit', false ); ?><a class="cancel-settings-link" href="<?php echo esc_url( EDIT_FLOW_SETTINGS_PAGE ); ?>"><?php _e( 'Back to Edit Flow', 'edit-flow' ); ?></a></p>
 					</form>
 				<?php endif; ?>
 				</div>
@@ -1276,466 +1362,485 @@ class EF_Custom_Status extends EF_Module {
 			</div>
 			<?php $wp_list_table->inline_edit(); ?>
 			<?php endif; ?>
-		<?php
-	}
-
-	/**
-	 * This is a hack! hack! hack! until core is fixed/better supports custom statuses
-	 *
-	 * When publishing a post with a custom status, set the status to 'pending' temporarily
-	 * @see Works around this limitation: http://core.trac.wordpress.org/browser/tags/3.2.1/wp-includes/post.php#L2694
-	 * @see Original thread: http://wordpress.org/support/topic/plugin-edit-flow-custom-statuses-create-timestamp-problem
-	 * @see Core ticket: http://core.trac.wordpress.org/ticket/18362
-	 */
-	function check_timestamp_on_publish() {
-		global $edit_flow, $pagenow, $wpdb;
-
-		if ( $this->disable_custom_statuses_for_post_type() )
-			return;
-
-		// Handles the transition to 'publish' on edit.php
-		if ( isset( $edit_flow ) && $pagenow == 'edit.php' && isset( $_REQUEST['bulk_edit'] ) ) {
-			// For every post_id, set the post_status as 'pending' only when there's no timestamp set for $post_date_gmt
-			if ( $_REQUEST['_status'] == 'publish' ) {
-				$post_ids = array_map( 'intval', (array) $_REQUEST['post'] );
-				foreach ( $post_ids as $post_id ) {
-					$wpdb->update( $wpdb->posts, array( 'post_status' => 'pending' ), array( 'ID' => $post_id, 'post_date_gmt' => '0000-00-00 00:00:00' ) );
-					clean_post_cache( $post_id );
-				}
-			}
+			<?php
 		}
 
-		// Handles the transition to 'publish' on post.php
-		if ( isset( $edit_flow ) && $pagenow == 'post.php' && isset( $_POST['publish'] ) ) {
-			// Set the post_status as 'pending' only when there's no timestamp set for $post_date_gmt
-			if ( isset( $_POST['post_ID'] ) ) {
-				$post_id = (int) $_POST['post_ID'];
-				$ret = $wpdb->update( $wpdb->posts, array( 'post_status' => 'pending' ), array( 'ID' => $post_id, 'post_date_gmt' => '0000-00-00 00:00:00' ) );
-				clean_post_cache( $post_id );
-				foreach ( array('aa', 'mm', 'jj', 'hh', 'mn') as $timeunit ) {
-					if ( !empty( $_POST['hidden_' . $timeunit] ) && $_POST['hidden_' . $timeunit] != $_POST[$timeunit] ) {
-						$edit_date = '1';
-						break;
+		/**
+		 * This is a hack! hack! hack! until core is fixed/better supports custom statuses
+		 *
+		 * When publishing a post with a custom status, set the status to 'pending' temporarily
+		 * @see Works around this limitation: http://core.trac.wordpress.org/browser/tags/3.2.1/wp-includes/post.php#L2694
+		 * @see Original thread: http://wordpress.org/support/topic/plugin-edit-flow-custom-statuses-create-timestamp-problem
+		 * @see Core ticket: http://core.trac.wordpress.org/ticket/18362
+		 */
+		public function check_timestamp_on_publish() {
+			global $edit_flow, $pagenow, $wpdb;
+
+			if ( $this->disable_custom_statuses_for_post_type() ) {
+				return;
+			}
+
+			// Handles the transition to 'publish' on edit.php
+			if ( isset( $edit_flow ) && 'edit.php' === $pagenow && isset( $_REQUEST['bulk_edit'] ) ) {
+				// For every post_id, set the post_status as 'pending' only when there's no timestamp set for $post_date_gmt
+				if ( isset( $_REQUEST['post'] ) && isset( $_REQUEST['_status'] ) && 'publish' == $_REQUEST['_status'] ) {
+					$post_ids = array_map( 'intval', (array) $_REQUEST['post'] );
+					foreach ( $post_ids as $post_id ) {
+						$wpdb->update( $wpdb->posts, array( 'post_status' => 'pending' ), array(
+							'ID' => $post_id,
+							'post_date_gmt' => '0000-00-00 00:00:00',
+						) );
+						clean_post_cache( $post_id );
 					}
 				}
-				if ( $ret && empty( $edit_date ) ) {
-					add_filter( 'pre_post_date', array( $this, 'helper_timestamp_hack' ) );
-					add_filter( 'pre_post_date_gmt', array( $this, 'helper_timestamp_hack' ) );
+			}
+
+			// Handles the transition to 'publish' on post.php
+			if ( isset( $edit_flow ) && 'post.php' == $pagenow && isset( $_POST['publish'] ) ) {
+				// Set the post_status as 'pending' only when there's no timestamp set for $post_date_gmt
+				if ( isset( $_POST['post_ID'] ) ) {
+					$post_id = (int) $_POST['post_ID'];
+					$ret = $wpdb->update( $wpdb->posts, array( 'post_status' => 'pending' ), array(
+						'ID' => $post_id,
+						'post_date_gmt' => '0000-00-00 00:00:00',
+					) );
+					clean_post_cache( $post_id );
+					foreach ( array( 'aa', 'mm', 'jj', 'hh', 'mn' ) as $timeunit ) {
+						if ( isset( $_POST[ $timeunit ] ) && ! empty( $_POST[ 'hidden_' . $timeunit ] ) && $_POST[ 'hidden_' . $timeunit ] != $_POST[ $timeunit ] ) {
+							$edit_date = '1';
+							break;
+						}
+					}
+					if ( $ret && empty( $edit_date ) ) {
+						add_filter( 'pre_post_date', array( $this, 'helper_timestamp_hack' ) );
+						add_filter( 'pre_post_date_gmt', array( $this, 'helper_timestamp_hack' ) );
+					}
 				}
 			}
 		}
+		//phpcs:enable:WordPress.Security.NonceVerification.Missing
 
-	}
+		/**
+		 * PHP < 5.3.x doesn't support anonymous functions
+		 * This helper is only used for the check_timestamp_on_publish method above
+		 *
+		 * @since 0.7.3
+		 */
+		public function helper_timestamp_hack() {
+			return ( 'pre_post_date' == current_filter() ) ? current_time( 'mysql' ) : '';
+		}
 
-	/**
-	 * PHP < 5.3.x doesn't support anonymous functions
-	 * This helper is only used for the check_timestamp_on_publish method above
-	 *
-	 * @since 0.7.3
-	 */
-	function helper_timestamp_hack() {
-		return ( 'pre_post_date' == current_filter() ) ? current_time('mysql') : '';
-	}
+		/**
+		 * This is a hack! hack! hack! until core is fixed/better supports custom statuses
+		 *
+		 * @since 0.6.5
+		 *
+		 * Normalize post_date_gmt if it isn't set to the past or the future
+		 * @see Works around this limitation: https://core.trac.wordpress.org/browser/tags/4.5.1/src/wp-includes/post.php#L3182
+		 * @see Original thread: http://wordpress.org/support/topic/plugin-edit-flow-custom-statuses-create-timestamp-problem
+		 * @see Core ticket: http://core.trac.wordpress.org/ticket/18362
+		 */
+		public function fix_custom_status_timestamp( $data, $postarr ) {
+			global $edit_flow;
+			// Don't run this if Edit Flow isn't active, or we're on some other page
+			if ( $this->disable_custom_statuses_for_post_type()
+			|| ! isset( $edit_flow ) ) {
+				return $data;
+			}
 
-	/**
-	 * This is a hack! hack! hack! until core is fixed/better supports custom statuses
-	 *
-	 * @since 0.6.5
-	 *
-	 * Normalize post_date_gmt if it isn't set to the past or the future
-	 * @see Works around this limitation: https://core.trac.wordpress.org/browser/tags/4.5.1/src/wp-includes/post.php#L3182
-	 * @see Original thread: http://wordpress.org/support/topic/plugin-edit-flow-custom-statuses-create-timestamp-problem
-	 * @see Core ticket: http://core.trac.wordpress.org/ticket/18362
-	 */
-	function fix_custom_status_timestamp( $data, $postarr ) {
-		global $edit_flow;
-		// Don't run this if Edit Flow isn't active, or we're on some other page
-		if ( $this->disable_custom_statuses_for_post_type()
-		|| !isset( $edit_flow ) ) {
+			$status_slugs = wp_list_pluck( $this->get_custom_statuses(), 'slug' );
+
+			//Post is scheduled or published? Ignoring.
+			if ( ! in_array( $postarr['post_status'], $status_slugs ) ) {
+				return $data;
+			}
+
+			//If empty, keep empty.
+			if ( empty( $postarr['post_date_gmt'] )
+			|| '0000-00-00 00:00:00' == $postarr['post_date_gmt'] ) {
+				$data['post_date_gmt'] = '0000-00-00 00:00:00';
+			}
+
 			return $data;
 		}
 
-		$status_slugs = wp_list_pluck( $this->get_custom_statuses(), 'slug' );
+		/**
+		 * A new hack! hack! hack! until core better supports custom statuses`
+		 *
+		 * @since 0.9.4
+		 *
+		 * If the post_name is set, set it, otherwise keep it empty
+		 *
+		 * @see https://github.com/Automattic/Edit-Flow/issues/523
+		 * @see https://github.com/Automattic/Edit-Flow/issues/633
+		 */
+		public function maybe_keep_post_name_empty( $data, $postarr ) {
+			$status_slugs = wp_list_pluck( $this->get_custom_statuses(), 'slug' );
 
-		//Post is scheduled or published? Ignoring.
-		if ( !in_array( $postarr['post_status'], $status_slugs ) ) {
-			return $data;
-		}
-
-		//If empty, keep empty.
-		if ( empty( $postarr['post_date_gmt'] )
-		|| '0000-00-00 00:00:00' == $postarr['post_date_gmt'] ) {
-			$data['post_date_gmt'] = '0000-00-00 00:00:00';
-		}
-
-		return $data;
-	}
-
-	/**
-	 * A new hack! hack! hack! until core better supports custom statuses`
-	 *
-	 * @since 0.9.4
-	 *
-	 * If the post_name is set, set it, otherwise keep it empty
-	 *
-	 * @see https://github.com/Automattic/Edit-Flow/issues/523
-	 * @see https://github.com/Automattic/Edit-Flow/issues/633
-	 */
-	public function maybe_keep_post_name_empty( $data, $postarr ) {
-		$status_slugs = wp_list_pluck( $this->get_custom_statuses(), 'slug' );
-
-		// Ignore if it's not a post status and post type we support
-		if ( ! in_array( $data['post_status'], $status_slugs )
+			// Ignore if it's not a post status and post type we support
+			if ( ! in_array( $data['post_status'], $status_slugs )
 			|| ! in_array( $data['post_type'], $this->get_post_types_for_module( $this->module ) ) ) {
 				return $data;
-		}
+			}
 
-		// If the post_name was intentionally set, set the post_name
-		if ( ! empty( $postarr['post_name'] ) ) {
-			$data['post_name'] = sanitize_title( $postarr['post_name'] );
+			// If the post_name was intentionally set, set the post_name
+			if ( ! empty( $postarr['post_name'] ) ) {
+				$data['post_name'] = sanitize_title( $postarr['post_name'] );
+				return $data;
+			}
+
+			// Otherwise, keep the post_name empty
+			$data['post_name'] = '';
+
 			return $data;
 		}
 
-		// Otherwise, keep the post_name empty
-		$data['post_name'] = '';
+		/**
+			 * A new hack! hack! hack! until core better supports custom statuses`
+			 *
+			 * @since 0.9.4
+			 *
+			 * `wp_unique_post_slug` is used to set the `post_name`. When a custom status is used, WordPress will try
+			 * really hard to set `post_name`, and we leverage `wp_unique_post_slug` to prevent it being set
+			 *
+			 * @see: https://github.com/WordPress/WordPress/blob/396647666faebb109d9cd4aada7bb0c7d0fb8aca/wp-includes/post.php#L3932
+			 */
+		public function fix_unique_post_slug( $override_slug, $slug, $post_ID, $post_status, $post_type, $post_parent ) {
+			$status_slugs = wp_list_pluck( $this->get_custom_statuses(), 'slug' );
 
-		return $data;
-	}
-
-/**
-	 * A new hack! hack! hack! until core better supports custom statuses`
-	 *
-	 * @since 0.9.4
-	 *
-	 * `wp_unique_post_slug` is used to set the `post_name`. When a custom status is used, WordPress will try
-	 * really hard to set `post_name`, and we leverage `wp_unique_post_slug` to prevent it being set
-	 *
-	 * @see: https://github.com/WordPress/WordPress/blob/396647666faebb109d9cd4aada7bb0c7d0fb8aca/wp-includes/post.php#L3932
-	 */
-	public function fix_unique_post_slug( $override_slug, $slug, $post_ID, $post_status, $post_type, $post_parent ) {
-		$status_slugs = wp_list_pluck( $this->get_custom_statuses(), 'slug' );
-
-		if ( ! in_array( $post_status, $status_slugs )
+			if ( ! in_array( $post_status, $status_slugs )
 			|| ! in_array( $post_type, $this->get_post_types_for_module( $this->module ) ) ) {
-			return null;
+				return null;
+			}
+
+			$post = get_post( $post_ID );
+
+			if ( empty( $post ) ) {
+				return null;
+			}
+
+			if ( $post->post_name ) {
+				return $slug;
+			}
+
+			return '';
 		}
 
-		$post = get_post( $post_ID );
 
-		if ( empty( $post ) ) {
-			return null;
-		}
+		/**
+		 * Another hack! hack! hack! until core better supports custom statuses
+		 *
+		 * @since 0.7.4
+		 *
+		 * The preview link for an unpublished post should always be ?p=
+		 */
+		public function fix_preview_link_part_one( $preview_link ) {
+			global $pagenow;
 
-		if ( $post->post_name ) {
-			return $slug;
-		}
+			$post = get_post( get_the_ID() );
 
-		return '';
-	}
-
-
-	/**
-	 * Another hack! hack! hack! until core better supports custom statuses
-	 *
-	 * @since 0.7.4
-	 *
-	 * The preview link for an unpublished post should always be ?p=
-	 */
-	public function fix_preview_link_part_one( $preview_link ) {
-		global $pagenow;
-
-		$post = get_post( get_the_ID() );
-
-		// Only modify if we're using a pre-publish status on a supported custom post type
-		$status_slugs = wp_list_pluck( $this->get_custom_statuses(), 'slug' );
-		if ( !$post
-			|| !is_admin()
+			// Only modify if we're using a pre-publish status on a supported custom post type
+			$status_slugs = wp_list_pluck( $this->get_custom_statuses(), 'slug' );
+			if ( ! $post
+			|| ! is_admin()
 			|| 'post.php' != $pagenow
-			|| !in_array( $post->post_status, $status_slugs )
-			|| !in_array( $post->post_type, $this->get_post_types_for_module( $this->module ) )
+			|| ! in_array( $post->post_status, $status_slugs )
+			|| ! in_array( $post->post_type, $this->get_post_types_for_module( $this->module ) )
 			|| strpos( $preview_link, 'preview_id' ) !== false
-			|| $post->filter == 'sample' )
-			return $preview_link;
+			|| 'sample' == $post->filter ) {
+				return $preview_link;
+			}
 
-		return $this->get_preview_link( $post );
-	}
-
-	/**
-	 * Another hack! hack! hack! until core better supports custom statuses
-	 *
-	 * @since 0.7.4
-	 *
-	 * The preview link for an unpublished post should always be ?p=
-	 * The code used to trigger a post preview doesn't also apply the 'preview_post_link' filter
-	 * So we can't do a targeted filter. Instead, we can even more hackily filter get_permalink
-	 * @see http://core.trac.wordpress.org/ticket/19378
-	 */
-	public function fix_preview_link_part_two( $permalink, $post, $sample ) {
-		global $pagenow;
-
-		if ( is_int( $post ) )
-			$post = get_post( $post );
-
-		//Should we be doing anything at all?
-		if( !in_array( $post->post_type, $this->get_post_types_for_module( $this->module ) ) )
-			return $permalink;
-
-		//Is this published?
-		if( in_array( $post->post_status, $this->published_statuses ) )
-			return $permalink;
-
-		//Are we overriding the permalink? Don't do anything
-		if( isset( $_POST['action'] ) && $_POST['action'] == 'sample-permalink' )
-			return $permalink;
-
-		//Are we previewing the post from the normal post screen?
-		if( ( $pagenow == 'post.php' || $pagenow == 'post-new.php' )
-			&& !isset( $_POST['wp-preview'] ) )
-			return $permalink;
-
-		//If it's a sample permalink, not a preview
-		if ( $sample ) {
-			return $permalink;
+			return $this->get_preview_link( $post );
 		}
 
-		return $this->get_preview_link( $post );
-	}
+		/**
+		 * Another hack! hack! hack! until core better supports custom statuses
+		 *
+		 * @since 0.7.4
+		 *
+		 * The preview link for an unpublished post should always be ?p=
+		 * The code used to trigger a post preview doesn't also apply the 'preview_post_link' filter
+		 * So we can't do a targeted filter. Instead, we can even more hackily filter get_permalink
+		 * @see http://core.trac.wordpress.org/ticket/19378
+		 */
+		public function fix_preview_link_part_two( $permalink, $post, $sample ) {
+			global $pagenow;
 
-	/**
-	 * Another hack! hack! hack! until core better supports custom statuses
-	 *
-	 * @since 0.9
-	 *
-	 * The preview link for a saved unpublished post with a custom status returns a 'preview_nonce'
-	 * in it and needs to be removed when previewing it to return a viewable preview link.
-	 * @see https://github.com/Automattic/Edit-Flow/issues/513
-	 */
-	public function fix_preview_link_part_three( $preview_link, $query_args ) {
-		if ( $autosave = wp_get_post_autosave( $query_args->ID, get_current_user_id() ) ) {
-		    foreach ( array_intersect( array_keys( _wp_post_revision_fields( $query_args ) ), array_keys( _wp_post_revision_fields( $autosave ) ) ) as $field ) {
-		        if ( normalize_whitespace( $query_args->$field ) != normalize_whitespace( $autosave->$field ) ) {
-		        	// Pass through, it's a personal preview.
-		            return $preview_link;
-		        }
-		   }
+			if ( is_int( $post ) ) {
+				$post = get_post( $post );
+			}
+
+			//Should we be doing anything at all?
+			if ( ! in_array( $post->post_type, $this->get_post_types_for_module( $this->module ) ) ) {
+				return $permalink;
+			}
+
+			//Is this published?
+			if ( in_array( $post->post_status, $this->published_statuses ) ) {
+				return $permalink;
+			}
+
+			//Are we overriding the permalink? Don't do anything
+			// phpcs:ignore:WordPress.Security.NonceVerification.Missing
+			if ( isset( $_POST['action'] ) && 'sample-permalink' == $_POST['action'] ) {
+				return $permalink;
+			}
+
+			//Are we previewing the post from the normal post screen?
+			if ( ( 'post.php' == $pagenow || 'post-new.php' == $pagenow )
+			// phpcs:ignore:WordPress.Security.NonceVerification.Missing
+			&& ! isset( $_POST['wp-preview'] ) ) {
+				return $permalink;
+			}
+
+			//If it's a sample permalink, not a preview
+			if ( $sample ) {
+				return $permalink;
+			}
+
+			return $this->get_preview_link( $post );
 		}
-		return remove_query_arg( array( 'preview_nonce' ), $preview_link );
-	}
 
-	/**
-	 * Fix get_sample_permalink. Previosuly the 'editable_slug' filter was leveraged
-	 * to correct the sample permalink a user could edit on post.php. Since 4.4.40
-	 * the `get_sample_permalink` filter was added which allows greater flexibility in
-	 * manipulating the slug. Critical for cases like editing the sample permalink on
-	 * hierarchical post types.
-	 * @since 0.8.2
-	 *
-	 * @param string  $permalink Sample permalink
-	 * @param int 	  $post_id 	 Post ID
-	 * @param string  $title 	 Post title
-	 * @param string  $name 	 Post name (slug)
-	 * @param WP_Post $post 	 Post object
-	 * @return string $link Direct link to complete the action
-	 */
-	public function fix_get_sample_permalink( $permalink, $post_id, $title, $name, $post ) {
+		/**
+		 * Another hack! hack! hack! until core better supports custom statuses
+		 *
+		 * @since 0.9
+		 *
+		 * The preview link for a saved unpublished post with a custom status returns a 'preview_nonce'
+		 * in it and needs to be removed when previewing it to return a viewable preview link.
+		 * @see https://github.com/Automattic/Edit-Flow/issues/513
+		 */
+		public function fix_preview_link_part_three( $preview_link, $query_args ) {
+			$autosave = wp_get_post_autosave( $query_args->ID, get_current_user_id() );
+			if ( $autosave ) {
+				foreach ( array_intersect( array_keys( _wp_post_revision_fields( $query_args ) ), array_keys( _wp_post_revision_fields( $autosave ) ) ) as $field ) {
+					if ( normalize_whitespace( $query_args->$field ) != normalize_whitespace( $autosave->$field ) ) {
+						// Pass through, it's a personal preview.
+						return $preview_link;
+					}
+				}
+			}
+			return remove_query_arg( array( 'preview_nonce' ), $preview_link );
+		}
 
-		$status_slugs = wp_list_pluck( $this->get_custom_statuses(), 'slug' );
+		/**
+		 * Fix get_sample_permalink. Previosuly the 'editable_slug' filter was leveraged
+		 * to correct the sample permalink a user could edit on post.php. Since 4.4.40
+		 * the `get_sample_permalink` filter was added which allows greater flexibility in
+		 * manipulating the slug. Critical for cases like editing the sample permalink on
+		 * hierarchical post types.
+		 * @since 0.8.2
+		 *
+		 * @param string  $permalink Sample permalink
+		 * @param int     $post_id   Post ID
+		 * @param string  $title     Post title
+		 * @param string  $name      Post name (slug)
+		 * @param WP_Post $post      Post object
+		 * @return string $link Direct link to complete the action
+		 */
+		public function fix_get_sample_permalink( $permalink, $post_id, $title, $name, $post ) {
 
-		if ( ! in_array( $post->post_status, $status_slugs )
+			$status_slugs = wp_list_pluck( $this->get_custom_statuses(), 'slug' );
+
+			if ( ! in_array( $post->post_status, $status_slugs )
 			|| ! in_array( $post->post_type, $this->get_post_types_for_module( $this->module ) ) ) {
+				return $permalink;
+			}
+
+			remove_filter( 'get_sample_permalink', array( $this, 'fix_get_sample_permalink' ), 10, 5 );
+
+			$new_name  = ! is_null( $name ) ? $name : $post->post_name;
+			$new_title = ! is_null( $title ) ? $title : $post->post_title;
+
+			$post = get_post( $post_id );
+			$status_before = $post->post_status;
+			$post->post_status = 'draft';
+
+			$permalink = get_sample_permalink( $post, $title, sanitize_title( $new_name ? $new_name : $new_title, $post->ID ) );
+
+			$post->post_status = $status_before;
+
+			add_filter( 'get_sample_permalink', array( $this, 'fix_get_sample_permalink' ), 10, 5 );
+
 			return $permalink;
 		}
 
-		remove_filter( 'get_sample_permalink', array( $this, 'fix_get_sample_permalink' ), 10, 5 );
+		/**
+		 * Hack to work around post status check in get_sample_permalink_html
+		 *
+		 *
+		 * The get_sample_permalink_html checks the status of the post and if it's
+		 * a draft generates a certain permalink structure.
+		 * We need to do the same work it's doing for custom statuses in order
+		 * to support this link
+		 * @see https://core.trac.wordpress.org/browser/tags/4.5.2/src/wp-admin/includes/post.php#L1296
+		 *
+		 * @since 0.8.2
+		 *
+		 * @param string  $return    Sample permalink HTML markup.
+		 * @param int     $post_id   Post ID.
+		 * @param string  $new_title New sample permalink title.
+		 * @param string  $new_slug  New sample permalink slug.
+		 * @param WP_Post $post      Post object.
+		 */
+		public function fix_get_sample_permalink_html( $permalink, $post_id, $new_title, $new_slug, $post ) {
+			$status_slugs = wp_list_pluck( $this->get_custom_statuses(), 'slug' );
 
-		$new_name  = ! is_null( $name ) ? $name : $post->post_name;
-		$new_title = ! is_null( $title ) ? $title : $post->post_title;
-
-		$post = get_post( $post_id );
-		$status_before = $post->post_status;
-		$post->post_status = 'draft';
-
-		$permalink = get_sample_permalink( $post, $title, sanitize_title( $new_name ? $new_name : $new_title, $post->ID ) );
-
-		$post->post_status = $status_before;
-
-		add_filter( 'get_sample_permalink', array( $this, 'fix_get_sample_permalink' ), 10, 5 );
-
-		return $permalink;
-	}
-
-	/**
-	 * Hack to work around post status check in get_sample_permalink_html
-	 *
-	 *
-	 * The get_sample_permalink_html checks the status of the post and if it's
-	 * a draft generates a certain permalink structure.
-	 * We need to do the same work it's doing for custom statuses in order
-	 * to support this link
-	 * @see https://core.trac.wordpress.org/browser/tags/4.5.2/src/wp-admin/includes/post.php#L1296
-	 *
-	 * @since 0.8.2
-	 *
-	 * @param string  $return    Sample permalink HTML markup.
-	 * @param int     $post_id   Post ID.
-	 * @param string  $new_title New sample permalink title.
-	 * @param string  $new_slug  New sample permalink slug.
-	 * @param WP_Post $post      Post object.
-	 */
-	public function fix_get_sample_permalink_html( $permalink, $post_id, $new_title, $new_slug, $post ) {
-		$status_slugs = wp_list_pluck( $this->get_custom_statuses(), 'slug' );
-
-		if ( ! in_array( $post->post_status, $status_slugs )
+			if ( ! in_array( $post->post_status, $status_slugs )
 			|| ! in_array( $post->post_type, $this->get_post_types_for_module( $this->module ) ) ) {
-			return $permalink;
+				return $permalink;
+			}
+
+			remove_filter( 'get_sample_permalink_html', array( $this, 'fix_get_sample_permalink_html' ), 10, 5 );
+
+			$post->post_status = 'draft';
+			$sample_permalink_html = get_sample_permalink_html( $post, $new_title, $new_slug );
+
+			add_filter( 'get_sample_permalink_html', array( $this, 'fix_get_sample_permalink_html' ), 10, 5 );
+
+			return $sample_permalink_html;
 		}
 
-		remove_filter( 'get_sample_permalink_html', array( $this, 'fix_get_sample_permalink_html' ), 10, 5 );
 
-		$post->post_status = 'draft';
-		$sample_permalink_html = get_sample_permalink_html( $post, $new_title, $new_slug );
+		/**
+		 * Fixes a bug where post-pagination doesn't work when previewing a post with a custom status
+		 * @link https://github.com/Automattic/Edit-Flow/issues/192
+		 *
+		 * This filter only modifies output if `is_preview()` is true
+		 *
+		 * Used by `wp_link_pages_link` filter
+		 *
+		 * @param $link
+		 * @param $i
+		 *
+		 * @return string
+		 */
+		public function modify_preview_link_pagination_url( $link, $i ) {
 
-		add_filter( 'get_sample_permalink_html', array( $this, 'fix_get_sample_permalink_html' ), 10, 5 );
+			// Use the original $link when not in preview mode
+			if ( ! is_preview() ) {
+				return $link;
+			}
 
-		return $sample_permalink_html;
-	}
+			// Get an array of valid custom status slugs
+			$custom_statuses = wp_list_pluck( $this->get_custom_statuses(), 'slug' );
 
-
-	/**
-	 * Fixes a bug where post-pagination doesn't work when previewing a post with a custom status
-	 * @link https://github.com/Automattic/Edit-Flow/issues/192
-	 *
-	 * This filter only modifies output if `is_preview()` is true
-	 *
-	 * Used by `wp_link_pages_link` filter
-	 *
-	 * @param $link
-	 * @param $i
-	 *
-	 * @return string
-	 */
-	function modify_preview_link_pagination_url( $link, $i ) {
-
-		// Use the original $link when not in preview mode
-		if( ! is_preview() ) {
-			return $link;
-		}
-
-		// Get an array of valid custom status slugs
-		$custom_statuses = wp_list_pluck( $this->get_custom_statuses(), 'slug');
-
-		// Apply original link filters from core `wp_link_pages()`
-		$r = apply_filters( 'wp_link_pages_args', array(
+			// Apply original link filters from core `wp_link_pages()`
+			$r = apply_filters( 'wp_link_pages_args', array(
 				'link_before' => '',
 				'link_after'  => '',
 				'pagelink'    => '%',
-			)
-		);
+			));
 
-		// _wp_link_page() && _ef_wp_link_page() produce an opening link tag ( <a href=".."> )
-		// This is necessary to replicate core behavior:
-		$link = $r['link_before'] . str_replace( '%', $i, $r['pagelink'] ) . $r['link_after'];
-		$link = _ef_wp_link_page( $i, $custom_statuses ) . $link . '</a>';
+			// _wp_link_page() && _ef_wp_link_page() produce an opening link tag ( <a href=".."> )
+			// This is necessary to replicate core behavior:
+			$link = $r['link_before'] . str_replace( '%', $i, $r['pagelink'] ) . $r['link_after'];
+			$link = _ef_wp_link_page( $i, $custom_statuses ) . $link . '</a>';
 
 
-		return $link;
-	}
+			return $link;
+		}
 
-	/**
-	 * Get the proper preview link for a post
-	 *
-	 * @since 0.8
-	 */
-	private function get_preview_link( $post ) {
+		/**
+		 * Get the proper preview link for a post
+		 *
+		 * @since 0.8
+		 */
+		private function get_preview_link( $post ) {
 
-		if ( 'page' == $post->post_type ) {
-			$args = array(
+			if ( 'page' == $post->post_type ) {
+				$args = array(
 					'page_id'    => $post->ID,
 				);
-		} else if ( 'post' == $post->post_type ) {
-			$args = array(
+			} else if ( 'post' == $post->post_type ) {
+				$args = array(
 					'p'          => $post->ID,
-					'preview'	 => 'true'
+					'preview'    => 'true',
 				);
-		} else {
-			$args = array(
+			} else {
+				$args = array(
 					'p'          => $post->ID,
 					'post_type'  => $post->post_type,
 				);
+			}
+
+			$args['preview_id'] = $post->ID;
+			return add_query_arg( $args, home_url( '/' ) );
 		}
 
-		$args['preview_id'] = $post->ID;
-		return add_query_arg( $args, home_url( '/' ) );
-	}
+		/**
+		 * Another hack! hack! hack! until core better supports custom statuses
+		 *
+		 * @since 0.7.4
+		 *
+		 * The preview link for an unpublished post should always be ?p=, even in the list table
+		 * @see http://core.trac.wordpress.org/ticket/19378
+		 */
+		public function fix_post_row_actions( $actions, $post ) {
+			global $pagenow;
 
-	/**
-	 * Another hack! hack! hack! until core better supports custom statuses
-	 *
-	 * @since 0.7.4
-	 *
-	 * The preview link for an unpublished post should always be ?p=, even in the list table
-	 * @see http://core.trac.wordpress.org/ticket/19378
-	 */
-	public function fix_post_row_actions( $actions, $post ) {
-		global $pagenow;
-
-		// Only modify if we're using a pre-publish status on a supported custom post type
-		$status_slugs = wp_list_pluck( $this->get_custom_statuses(), 'slug' );
-		if ( 'edit.php' != $pagenow
+			// Only modify if we're using a pre-publish status on a supported custom post type
+			$status_slugs = wp_list_pluck( $this->get_custom_statuses(), 'slug' );
+			if ( 'edit.php' != $pagenow
 			|| ! in_array( $post->post_status, $status_slugs )
-			|| ! in_array( $post->post_type, $this->get_post_types_for_module( $this->module ) ) )
-			return $actions;
+			|| ! in_array( $post->post_type, $this->get_post_types_for_module( $this->module ) ) ) {
+				return $actions;
+			}
 
-		// 'view' is only set if the user has permission to post
-		if ( empty( $actions['view'] ) )
-			return $actions;
+			// 'view' is only set if the user has permission to post
+			if ( empty( $actions['view'] ) ) {
+				return $actions;
+			}
 
-		if ( 'page' == $post->post_type ) {
-			$args = array(
+			if ( 'page' == $post->post_type ) {
+				$args = array(
 					'page_id'    => $post->ID,
 				);
-		} else if ( 'post' == $post->post_type ) {
-			$args = array(
+			} else if ( 'post' == $post->post_type ) {
+				$args = array(
 					'p'          => $post->ID,
 				);
-		} else {
-			$args = array(
+			} else {
+				$args = array(
 					'p'          => $post->ID,
 					'post_type'  => $post->post_type,
 				);
+			}
+			$args['preview'] = 'true';
+			$preview_link = add_query_arg( $args, home_url( '/' ) );
+
+			/* translators: %s: post title */
+			$actions['view'] = '<a href="' . esc_url( $preview_link ) . '" title="' . esc_attr( sprintf( __( 'Preview &#8220;%s&#8221;' ), $post->post_title ) ) . '" rel="permalink">' . __( 'Preview' ) . '</a>';
+			return $actions;
 		}
-		$args['preview'] = 'true';
-		$preview_link = add_query_arg( $args, home_url( '/' ) );
-
-		$actions['view'] = '<a href="' . esc_url( $preview_link ) . '" title="' . esc_attr( sprintf( __( 'Preview &#8220;%s&#8221;' ), $post->post_title ) ) . '" rel="permalink">' . __( 'Preview' ) . '</a>';
-		return $actions;
 	}
-}
 
 }
+
+
+ // phpcs:disable Generic.Files.OneObjectStructurePerFile.MultipleFound
 
 /**
  * Custom Statuses uses WordPress' List Table API for generating the custom status management table
  *
  * @since 0.7
  */
-class EF_Custom_Status_List_Table extends WP_List_Table
-{
+class EF_Custom_Status_List_Table extends WP_List_Table {
 
-	var $callback_args;
-	var $default_status;
+	protected $callback_args;
+	protected $default_status;
 
 	/**
 	 * Construct the extended class
 	 */
-	function __construct() {
+	public function __construct() {
 
 		parent::__construct( array(
 			'plural' => 'custom statuses',
 			'singular' => 'custom status',
-			'ajax' => true
+			'ajax' => true,
 		) );
-
 	}
 
 	/**
@@ -1743,7 +1848,7 @@ class EF_Custom_Status_List_Table extends WP_List_Table
 	 *
 	 * @since 0.7
 	 */
-	function prepare_items() {
+	public function prepare_items() {
 		global $edit_flow;
 
 		$columns = $this->get_columns();
@@ -1751,7 +1856,7 @@ class EF_Custom_Status_List_Table extends WP_List_Table
 			'position',
 		);
 		$sortable = array();
-		$this->_column_headers = array($columns, $hidden, $sortable);
+		$this->_column_headers = array( $columns, $hidden, $sortable );
 
 		$this->items = $edit_flow->custom_status->get_custom_statuses();
 		$total_items = count( $this->items );
@@ -1769,7 +1874,7 @@ class EF_Custom_Status_List_Table extends WP_List_Table
 	 *
 	 * @since 0.7
 	 */
-	function no_items() {
+	public function no_items() {
 		_e( 'No custom statuses found.', 'edit-flow' );
 	}
 
@@ -1781,20 +1886,22 @@ class EF_Custom_Status_List_Table extends WP_List_Table
 	 *
 	 * @return array $columns Columns to be registered with the List Table
 	 */
-	function get_columns() {
+	public function get_columns() {
 		global $edit_flow;
 
 		$columns = array(
-			'position'			=> __( 'Position', 'edit-flow' ),
-			'name'			    => __( 'Name', 'edit-flow' ),
-			'description' 		=> __( 'Description', 'edit-flow' ),
+			'position'          => __( 'Position', 'edit-flow' ),
+			'name'              => __( 'Name', 'edit-flow' ),
+			'description'       => __( 'Description', 'edit-flow' ),
 		);
 
 		$post_types = get_post_types( '', 'objects' );
 		$supported_post_types = $edit_flow->helpers->get_post_types_for_module( $edit_flow->custom_status->module );
-		foreach ( $post_types as $post_type )
-			if ( in_array( $post_type->name, $supported_post_types ) )
-				$columns[$post_type->name] = $post_type->label;
+		foreach ( $post_types as $post_type ) {
+			if ( in_array( $post_type->name, $supported_post_types ) ) {
+				$columns[ $post_type->name ] = $post_type->label;
+			}
+		}
 
 		return $columns;
 	}
@@ -1809,7 +1916,7 @@ class EF_Custom_Status_List_Table extends WP_List_Table
 	 * @param string $column_name Name of the column as registered in $this->prepare_items()
 	 * @return string $output What will be rendered
 	 */
-	function column_default( $item, $column_name ) {
+	public function column_default( $item, $column_name ) {
 		global $edit_flow;
 
 		// Handle custom post counts for different post types
@@ -1822,16 +1929,16 @@ class EF_Custom_Status_List_Table extends WP_List_Table
 				$posts = wp_count_posts( $column_name );
 				$post_status = $item->slug;
 				// To avoid error notices when changing the name of non-standard statuses
-				if ( isset( $posts->$post_status ) )
+				if ( isset( $posts->$post_status ) ) {
 					$post_count = $posts->$post_status;
-				else
+				} else {
 					$post_count = 0;
+				}
 				//wp_cache_set( "ef_custom_status_count_$column_name", $post_count );
 			}
 			$output = sprintf( '<a title="See all %1$ss saved as \'%2$s\'" href="%3$s">%4$s</a>', $column_name, $item->name, $edit_flow->helpers->filter_posts_link( $item->slug, $column_name ), $post_count );
 			return $output;
 		}
-
 	}
 
 	/**
@@ -1842,7 +1949,7 @@ class EF_Custom_Status_List_Table extends WP_List_Table
 	 * @param object $item Custom status as an object
 	 * @return string $output What will be rendered
 	 */
-	function column_position( $item ) {
+	public function column_position( $item ) {
 		return esc_html( $item->position );
 	}
 
@@ -1854,28 +1961,39 @@ class EF_Custom_Status_List_Table extends WP_List_Table
 	 * @param object $item Custom status as an object
 	 * @return string $output What will be rendered
 	 */
-	function column_name( $item ) {
+	public function column_name( $item ) {
 		global $edit_flow;
 
-		$item_edit_link = esc_url( $edit_flow->custom_status->get_link( array( 'action' => 'edit-status', 'term-id' => $item->term_id ) ) );
+		$item_edit_link = esc_url( $edit_flow->custom_status->get_link( array(
+			'action' => 'edit-status',
+			'term-id' => $item->term_id,
+		) ) );
 
 		$output = '<strong><a href="' . $item_edit_link . '">' . esc_html( $item->name ) . '</a>';
-		if ( $item->slug == $this->default_status )
+		if ( $item->slug == $this->default_status ) {
 			$output .= ' - ' . __( 'Default', 'edit-flow' );
+		}
 		$output .= '</strong>';
 
 		// Don't allow for any of these status actions when adding a new custom status
-		if ( isset( $_GET['action'] ) && $_GET['action'] == 'add' )
+		if ( isset( $_GET['action'] ) && 'add' == $_GET['action'] ) {
 			return $output;
+		}
 
 		$actions = array();
-		$actions['edit'] = "<a href='$item_edit_link'>" . __( 'Edit', 'edit-flow' ) . "</a>";
+		$actions['edit'] = "<a href='$item_edit_link'>" . __( 'Edit', 'edit-flow' ) . '</a>';
 		$actions['inline hide-if-no-js'] = '<a href="#" class="editinline">' . __( 'Quick&nbsp;Edit' ) . '</a>';
-		$actions['make_default'] = sprintf( '<a href="%1$s">' . __( 'Make&nbsp;Default', 'edit-flow' ) . '</a>', $edit_flow->custom_status->get_link( array( 'action' => 'make-default', 'term-id' => $item->term_id ) ) );
+		$actions['make_default'] = sprintf( '<a href="%1$s">' . __( 'Make&nbsp;Default', 'edit-flow' ) . '</a>', $edit_flow->custom_status->get_link( array(
+			'action' => 'make-default',
+			'term-id' => $item->term_id,
+		) ) );
 
 		// Prevent deleting draft status
-		if( 'draft' !== $item->slug && $item->slug !== $this->default_status  ) {
-			$actions['delete delete-status'] = sprintf( '<a href="%1$s">' . __( 'Delete', 'edit-flow' ) . '</a>', $edit_flow->custom_status->get_link( array( 'action' => 'delete-status', 'term-id' => $item->term_id ) ) );
+		if ( 'draft' !== $item->slug && $item->slug !== $this->default_status ) {
+			$actions['delete delete-status'] = sprintf( '<a href="%1$s">' . __( 'Delete', 'edit-flow' ) . '</a>', $edit_flow->custom_status->get_link( array(
+				'action' => 'delete-status',
+				'term-id' => $item->term_id,
+			) ) );
 		}
 
 		$output .= $this->row_actions( $actions, false );
@@ -1885,7 +2003,6 @@ class EF_Custom_Status_List_Table extends WP_List_Table
 		$output .= '</div>';
 
 		return $output;
-
 	}
 
 	/**
@@ -1896,7 +2013,7 @@ class EF_Custom_Status_List_Table extends WP_List_Table
 	 * @param object $item Custom status as an object
 	 * @return string $output What will be rendered
 	 */
-	function column_description( $item ) {
+	public function column_description( $item ) {
 		return esc_html( $item->description );
 	}
 
@@ -1905,13 +2022,13 @@ class EF_Custom_Status_List_Table extends WP_List_Table
 	 *
 	 * @since 0.7
 	 */
-	function single_row( $item ) {
+	public function single_row( $item ) {
 		static $alternate_class = '';
-		$alternate_class = ( $alternate_class == '' ? ' alternate' : '' );
+		$alternate_class = ( '' == $alternate_class ? ' alternate' : '' );
 		$row_class = ' class="term-static' . $alternate_class . '"';
 
-		echo '<tr id="term-' . $item->term_id . '"' . $row_class . '>';
-		echo $this->single_row_columns( $item );
+		echo wp_kses_post( '<tr id="term-' . $item->term_id . '"' . $row_class . '>' );
+		echo wp_kses_post( $this->single_row_columns( $item ) );
 		echo '</tr>';
 	}
 
@@ -1920,11 +2037,11 @@ class EF_Custom_Status_List_Table extends WP_List_Table
 	 *
 	 * @since 0.7
 	 */
-	function inline_edit() {
+	public function inline_edit() {
 		global $edit_flow;
-?>
+		?>
 	<form method="get" action=""><table style="display: none"><tbody id="inlineedit">
-		<tr id="inline-edit" class="inline-edit-row" style="display: none"><td colspan="<?php echo $this->get_column_count(); ?>" class="colspanchange">
+		<tr id="inline-edit" class="inline-edit-row" style="display: none"><td colspan="<?php echo esc_attr( $this->get_column_count() ); ?>" class="colspanchange">
 			<fieldset><div class="inline-edit-col">
 				<h4><?php _e( 'Quick Edit' ); ?></h4>
 				<label>
@@ -1939,7 +2056,7 @@ class EF_Custom_Status_List_Table extends WP_List_Table
 		<p class="inline-edit-save submit">
 			<a accesskey="c" href="#inline-edit" title="<?php _e( 'Cancel' ); ?>" class="cancel button-secondary alignleft"><?php _e( 'Cancel' ); ?></a>
 			<?php $update_text = __( 'Update Status', 'edit-flow' ); ?>
-			<a accesskey="s" href="#inline-edit" title="<?php echo esc_attr( $update_text ); ?>" class="save button-primary alignright"><?php echo $update_text; ?></a>
+			<a accesskey="s" href="#inline-edit" title="<?php echo esc_attr( $update_text ); ?>" class="save button-primary alignright"><?php echo esc_html( $update_text ); ?></a>
 			<img class="waiting" style="display:none;" src="<?php echo esc_url( admin_url( 'images/wpspin_light.gif' ) ); ?>" alt="" />
 			<span class="error" style="display:none;"></span>
 			<?php wp_nonce_field( 'custom-status-inline-edit-nonce', 'inline_edit', false ); ?>
@@ -1947,7 +2064,6 @@ class EF_Custom_Status_List_Table extends WP_List_Table
 		</p>
 		</td></tr>
 		</tbody></table></form>
-	<?php
+		<?php
 	}
-
 }

--- a/modules/custom-status/custom-status.php
+++ b/modules/custom-status/custom-status.php
@@ -1334,22 +1334,12 @@ if ( ! class_exists( 'EF_Custom_Status' ) ) {
 					<form class="add:the-list:" action="<?php echo esc_url( $this->get_link() ); ?>" method="post" id="addstatus" name="addstatus">
 					<div class="form-field form-required">
 						<label for="status_name"><?php _e( 'Name', 'edit-flow' ); ?></label>
-						<input type="text" aria-required="true" size="20" maxlength="20" id="status_name" name="status_name" value="
-						<?php
-						if ( ! empty( $_POST['status_name'] ) ) {
-							echo esc_attr( $_POST['status_name'] );}
-						?>
-						" />
+						<input type="text" aria-required="true" size="20" maxlength="20" id="status_name" name="status_name" value="<?php /* phpcs:ignore Generic.ControlStructures.InlineControlStructure.NotAllowed */ if ( ! empty( $_POST['status_name'] ) ) echo esc_attr( $_POST['status_name'] ); ?>" />
 						<?php $edit_flow->settings->helper_print_error_or_description( 'name', __( 'The name is used to identify the status. (Max: 20 characters)', 'edit-flow' ) ); ?>
 					</div>
 					<div class="form-field">
 						<label for="status_description"><?php _e( 'Description', 'edit-flow' ); ?></label>
-						<textarea cols="40" rows="5" id="status_description" name="status_description">
-						<?php
-						if ( ! empty( $_POST['status_description'] ) ) {
-							echo esc_textarea( $_POST['status_description'] );}
-						?>
-						</textarea>
+						<textarea cols="40" rows="5" id="status_description" name="status_description"><?php /* phpcs:ignore Generic.ControlStructures.InlineControlStructure.NotAllowed */ if ( ! empty( $_POST['status_description'] ) ) echo esc_textarea( $_POST['status_description'] ); ?></textarea>
 						<?php $edit_flow->settings->helper_print_error_or_description( 'description', __( 'The description is primarily for administrative use, to give you some context on what the custom status is to be used for.', 'edit-flow' ) ); ?>
 					</div>
 					<?php wp_nonce_field( 'custom-status-add-nonce' ); ?>

--- a/modules/dashboard/dashboard.php
+++ b/modules/dashboard/dashboard.php
@@ -11,354 +11,362 @@
  * - Update the Posts I'm Following widget to use new activity class
  */
 
-if ( !class_exists('EF_Dashboard') ) {
+if ( ! class_exists( 'EF_Dashboard' ) ) {
 
-class EF_Dashboard extends EF_Module {
+	class EF_Dashboard extends EF_Module {
 
-	public $widgets;
-	
-	/**
-	 * Load the EF_Dashboard class as an Edit Flow module
-	 */
-	function __construct() {
-		
-		// Register the module with Edit Flow
-		$this->module_url = $this->get_module_url( __FILE__ );
-		$args = array(
-			'title' => __( 'Dashboard Widgets', 'edit-flow' ),
-			'short_description' => __( 'Track your content from the WordPress dashboard.', 'edit-flow' ),
-			'extended_description' => __( 'Enable dashboard widgets to quickly get an overview of what state your content is in.', 'edit-flow' ),
-			'module_url' => $this->module_url,
-			'img_url' => $this->module_url . 'lib/dashboard_s128.png',
-			'slug' => 'dashboard',
-			'post_type_support' => 'ef_dashboard',
-			'default_options' => array(
-				'enabled' => 'on',
-				'post_status_widget' => 'on',
-				'my_posts_widget' => 'on',
-				'notepad_widget' => 'on',
-			),
-			'configure_page_cb' => 'print_configure_view',
-			'configure_link_text' => __( 'Widget Options', 'edit-flow' ),		
-		);
-		$this->module = EditFlow()->register_module( 'dashboard', $args );
-	}
-	
-	/**
-	 * Initialize all of the class' functionality if its enabled
-	 */
-	function init() {
+		public $widgets;
 
-		$this->widgets = new stdClass;
+		/**
+		 * Load the EF_Dashboard class as an Edit Flow module
+		 */
+		public function __construct() {
 
-		if ( 'on' == $this->module->options->notepad_widget ) {
-			require_once dirname( __FILE__ ) . '/widgets/dashboard-notepad.php';
-			$this->widgets->notepad_widget = new EF_Dashboard_Notepad_Widget;
-			$this->widgets->notepad_widget->init();
+			// Register the module with Edit Flow
+			$this->module_url = $this->get_module_url( __FILE__ );
+			$args = array(
+				'title' => __( 'Dashboard Widgets', 'edit-flow' ),
+				'short_description' => __( 'Track your content from the WordPress dashboard.', 'edit-flow' ),
+				'extended_description' => __( 'Enable dashboard widgets to quickly get an overview of what state your content is in.', 'edit-flow' ),
+				'module_url' => $this->module_url,
+				'img_url' => $this->module_url . 'lib/dashboard_s128.png',
+				'slug' => 'dashboard',
+				'post_type_support' => 'ef_dashboard',
+				'default_options' => array(
+					'enabled' => 'on',
+					'post_status_widget' => 'on',
+					'my_posts_widget' => 'on',
+					'notepad_widget' => 'on',
+				),
+				'configure_page_cb' => 'print_configure_view',
+				'configure_link_text' => __( 'Widget Options', 'edit-flow' ),
+			);
+			$this->module = EditFlow()->register_module( 'dashboard', $args );
 		}
-		
-		// Add the widgets to the dashboard
-		add_action( 'wp_dashboard_setup', array( $this, 'add_dashboard_widgets') );
-		
-		// Register our settings
-		add_action( 'admin_init', array( $this, 'register_settings' ) );
-	}
 
-	/**
-	 * Upgrade our data in case we need to
-	 *
-	 * @since 0.7
-	 */
-	function upgrade( $previous_version ) {
-		global $edit_flow;
+		/**
+		 * Initialize all of the class' functionality if its enabled
+		 */
+		public function init() {
 
-		// Upgrade path to v0.7
-		if ( version_compare( $previous_version, '0.7' , '<' ) ) {
-			// Migrate whether dashboard widgets were enabled or not
-			if ( $enabled = get_option( 'edit_flow_dashboard_widgets_enabled' ) )
-				$enabled = 'on';
-			else
-				$enabled = 'off';
-			$edit_flow->update_module_option( $this->module->name, 'enabled', $enabled );
-			delete_option( 'edit_flow_dashboard_widgets_enabled' );
-			// Migrate whether the post status widget was on
-			if ( $post_status_widget = get_option( 'edit_flow_post_status_widget_enabled' ) )
-				$post_status_widget = 'on';
-			else
-				$post_status_widget = 'off';
-			$edit_flow->update_module_option( $this->module->name, 'post_status_widget', $post_status_widget );
-			delete_option( 'edit_flow_post_status_widget_enabled' );
-			// Migrate whether the my posts widget was on
-			if ( $my_posts_widget = get_option( 'edit_flow_myposts_widget_enabled' ) )
-				$my_posts_widget = 'on';
-			else
-				$my_posts_widget = 'off';
-			$edit_flow->update_module_option( $this->module->name, 'post_status_widget', $my_posts_widget );
-			delete_option( 'edit_flow_myposts_widget_enabled' );
-			// Delete legacy option
-			delete_option( 'edit_flow_quickpitch_widget_enabled' );
+			$this->widgets = new stdClass();
 
-			// Technically we've run this code before so we don't want to auto-install new data
-			$edit_flow->update_module_option( $this->module->name, 'loaded_once', true );
+			if ( 'on' == $this->module->options->notepad_widget ) {
+				require_once __DIR__ . '/widgets/dashboard-notepad.php';
+				$this->widgets->notepad_widget = new EF_Dashboard_Notepad_Widget();
+				$this->widgets->notepad_widget->init();
+			}
+
+			// Add the widgets to the dashboard
+			add_action( 'wp_dashboard_setup', array( $this, 'add_dashboard_widgets' ) );
+
+			// Register our settings
+			add_action( 'admin_init', array( $this, 'register_settings' ) );
 		}
-		
-	}
-	
-	/**
-	 * Add Edit Flow dashboard widgets to the WordPress admin dashboard
-	 */
-	function add_dashboard_widgets() {
-		
-		// Only show dashboard widgets for Contributor or higher
-		if ( !current_user_can('edit_posts') ) 
-			return;
-		
-		wp_enqueue_style( 'edit-flow-dashboard-css', $this->module_url . 'lib/dashboard.css', false, EDIT_FLOW_VERSION, 'all' );			
-			
-		// Set up Post Status widget but, first, check to see if it's enabled
-		if ( $this->module->options->post_status_widget == 'on' ) {
 
-			$status_widget_post_types = apply_filters( 'ef_dashboard_psw_post_types', $this->get_all_post_types() );
+		/**
+		 * Upgrade our data in case we need to
+		 *
+		 * @since 0.7
+		 */
+		public function upgrade( $previous_version ) {
+			global $edit_flow;
 
-			foreach ( $status_widget_post_types as $post_type => $label ) {
-				$this->add_dashboard_status_widget( $post_type );
+			// Upgrade path to v0.7
+			if ( version_compare( $previous_version, '0.7', '<' ) ) {
+				// Migrate whether dashboard widgets were enabled or not
+				if ( $enabled = get_option( 'edit_flow_dashboard_widgets_enabled' ) ) {
+					$enabled = 'on';
+				} else {
+					$enabled = 'off';
+				}
+				$edit_flow->update_module_option( $this->module->name, 'enabled', $enabled );
+				delete_option( 'edit_flow_dashboard_widgets_enabled' );
+				// Migrate whether the post status widget was on
+				if ( $post_status_widget = get_option( 'edit_flow_post_status_widget_enabled' ) ) {
+					$post_status_widget = 'on';
+				} else {
+					$post_status_widget = 'off';
+				}
+				$edit_flow->update_module_option( $this->module->name, 'post_status_widget', $post_status_widget );
+				delete_option( 'edit_flow_post_status_widget_enabled' );
+				// Migrate whether the my posts widget was on
+				if ( $my_posts_widget = get_option( 'edit_flow_myposts_widget_enabled' ) ) {
+					$my_posts_widget = 'on';
+				} else {
+					$my_posts_widget = 'off';
+				}
+				$edit_flow->update_module_option( $this->module->name, 'post_status_widget', $my_posts_widget );
+				delete_option( 'edit_flow_myposts_widget_enabled' );
+				// Delete legacy option
+				delete_option( 'edit_flow_quickpitch_widget_enabled' );
+
+				// Technically we've run this code before so we don't want to auto-install new data
+				$edit_flow->update_module_option( $this->module->name, 'loaded_once', true );
 			}
 		}
 
-		// Set up the Notepad widget if it's enabled
-		if ( 'on' == $this->module->options->notepad_widget )
-			wp_add_dashboard_widget( 'notepad_widget', __( 'Notepad', 'edit-flow' ), array( $this->widgets->notepad_widget, 'notepad_widget' ) );
-			
-		// Add the MyPosts widget, if enabled
-		if ( $this->module->options->my_posts_widget == 'on' && $this->module_enabled( 'notifications' ) )
-			wp_add_dashboard_widget( 'myposts_widget', __( 'Posts I\'m Following', 'edit-flow' ), array( $this, 'myposts_widget' ) );
+		/**
+		 * Add Edit Flow dashboard widgets to the WordPress admin dashboard
+		 */
+		public function add_dashboard_widgets() {
 
-	}
+			// Only show dashboard widgets for Contributor or higher
+			if ( ! current_user_can( 'edit_posts' ) ) {
+				return;
+			}
 
-	/**
-	 * Dynamically add a "Unpublished Content" post status widget for any post type
-	 *
-	 * @param $post_type_slug
-	 */
-	public function add_dashboard_status_widget( $post_type_slug ) {
+			wp_enqueue_style( 'edit-flow-dashboard-css', $this->module_url . 'lib/dashboard.css', false, EDIT_FLOW_VERSION, 'all' );
 
-		$post_type_labels = get_post_type_labels( get_post_type_object( $post_type_slug ) );
+			// Set up Post Status widget but, first, check to see if it's enabled
+			if ( 'on' == $this->module->options->post_status_widget ) {
 
-		if ( $post_type_slug !== 'post' ) {
-			$widget_id    = 'post_status_widget_' . $post_type_slug;
-			$widget_title = sprintf( esc_html__( 'Unpublished Content: %s', 'edit-flow' ), $post_type_labels->name );
-		} else {
-			$widget_id    = 'post_status_widget';
-			$widget_title = __( 'Unpublished Content', 'edit-flow' );
+				$status_widget_post_types = apply_filters( 'ef_dashboard_psw_post_types', $this->get_all_post_types() );
+
+				foreach ( $status_widget_post_types as $post_type => $label ) {
+					$this->add_dashboard_status_widget( $post_type );
+				}
+			}
+
+			// Set up the Notepad widget if it's enabled
+			if ( 'on' == $this->module->options->notepad_widget ) {
+				wp_add_dashboard_widget( 'notepad_widget', __( 'Notepad', 'edit-flow' ), array( $this->widgets->notepad_widget, 'notepad_widget' ) );
+			}
+
+			// Add the MyPosts widget, if enabled
+			if ( 'on' == $this->module->options->my_posts_widget && $this->module_enabled( 'notifications' ) ) {
+				wp_add_dashboard_widget( 'myposts_widget', __( 'Posts I\'m Following', 'edit-flow' ), array( $this, 'myposts_widget' ) );
+			}
 		}
 
-		$widget_title = apply_filters( 'ef_dashboard_psw_title', $widget_title, $post_type_slug );
-		$args         = array(
-			'post_type' => $post_type_slug,
-			'labels'    => $post_type_labels,
-		);
+		/**
+		 * Dynamically add a "Unpublished Content" post status widget for any post type
+		 *
+		 * @param $post_type_slug
+		 */
+		public function add_dashboard_status_widget( $post_type_slug ) {
 
-		wp_add_dashboard_widget( $widget_id, $widget_title, array( $this, 'post_status_widget' ), NULL, $args );
-	}
-	
-	/**
-	 * Creates Post Status widget
-	 * Display an at-a-glance view of post counts for all (post|custom) statuses in the system
-	 */
-	function post_status_widget( $unused, $args ) {
+			$post_type_labels = get_post_type_labels( get_post_type_object( $post_type_slug ) );
 
-		$labels    = $args['args']['labels'];
-		$post_type = $args['args']['post_type'];
+			if ( 'post' !== $post_type_slug ) {
+				$widget_id    = 'post_status_widget_' . $post_type_slug;
+				// translators: %s is the post type name
+				$widget_title = sprintf( esc_html__( 'Unpublished Content: %s', 'edit-flow' ), $post_type_labels->name );
+			} else {
+				$widget_id    = 'post_status_widget';
+				$widget_title = __( 'Unpublished Content', 'edit-flow' );
+			}
 
-		$statuses = $this->get_post_statuses();
-		$statuses[] = (object)array(
+			$widget_title = apply_filters( 'ef_dashboard_psw_title', $widget_title, $post_type_slug );
+			$args         = array(
+				'post_type' => $post_type_slug,
+				'labels'    => $post_type_labels,
+			);
+
+			wp_add_dashboard_widget( $widget_id, $widget_title, array( $this, 'post_status_widget' ), null, $args );
+		}
+
+		/**
+		 * Creates Post Status widget
+		 * Display an at-a-glance view of post counts for all (post|custom) statuses in the system
+		 */
+		public function post_status_widget( $unused, $args ) {
+
+			$labels    = $args['args']['labels'];
+			$post_type = $args['args']['post_type'];
+
+			$statuses = $this->get_post_statuses();
+			$statuses[] = (object) array(
 				'name' => __( 'Scheduled', 'edit-flow' ),
 				'description' => '',
 				'slug' => 'future',
 			);
-		$statuses = apply_filters( 'ef_dashboard_post_status_widget_statuses', $statuses );
-		// If custom statuses are enabled, we'll output a link to edit the terms just below the post counts
-		if ( $this->module_enabled( 'custom_status' ) )
-			$edit_custom_status_url = add_query_arg( 'page', 'ef-custom-status-settings', get_admin_url( null, 'admin.php' ) );
-		
-		?>
-		<p class="sub ef-psw-title"><?php printf( esc_html__('%s at a Glance', 'edit-flow'), $labels->name ) ?></p>
-		
+			$statuses = apply_filters( 'ef_dashboard_post_status_widget_statuses', $statuses );
+			// If custom statuses are enabled, we'll output a link to edit the terms just below the post counts
+			if ( $this->module_enabled( 'custom_status' ) ) {
+				$edit_custom_status_url = add_query_arg( 'page', 'ef-custom-status-settings', get_admin_url( null, 'admin.php' ) );
+			}
+
+			?>
+		<p class="sub ef-psw-title"><?php /* translators: %s is the type of content  */ printf( esc_html__( '%s at a Glance', 'edit-flow' ), esc_html( $labels->name ) ); ?></p>
+
 		<div class="table ef-psw-content">
 			<table>
 				<tbody>
 					<?php $post_count = wp_count_posts( $post_type ); ?>
-					<?php foreach($statuses as $status) : ?>
+					<?php foreach ( $statuses as $status ) : ?>
 						<?php $filter_link = $this->filter_posts_link( $status->slug, $post_type ); ?>
 						<tr>
 							<td class="b">
 								<a href="<?php echo esc_url( $filter_link ); ?>">
 									<?php
 									$slug = $status->slug;
-									echo esc_html( $post_count->$slug ); ?>
+									echo esc_html( $post_count->$slug );
+									?>
 								</a>
 							</td>
 							<td>
 								<a href="<?php echo esc_url( $filter_link ); ?>"><?php echo esc_html( $status->name ); ?></a>
 							</td>
 						</tr>
-							
+
 					<?php endforeach; ?>
 				</tbody>
 			</table>
-			<?php if ( isset( $edit_custom_status_url ) ) : ?>
+				<?php if ( isset( $edit_custom_status_url ) ) : ?>
 				<span class="small"><a href="<?php echo esc_url( $edit_custom_status_url ); ?>"><?php _e( 'Edit Custom Statuses', 'edit-flow' ); ?></a></span>
 			<?php endif; ?>
 		</div>
-		<?php
-	}
-	
-	/**
-	 * Creates My Posts widget
-	 * Shows a list of the "posts you're following" sorted by most recent activity.
-	 */ 
-	function myposts_widget() {
-		global $edit_flow;
+			<?php
+		}
 
-		$myposts = $edit_flow->notifications->get_user_following_posts();
-		
-		?>
+		/**
+		 * Creates My Posts widget
+		 * Shows a list of the "posts you're following" sorted by most recent activity.
+		 */
+		public function myposts_widget() {
+			global $edit_flow;
+
+			$myposts = $edit_flow->notifications->get_user_following_posts();
+
+			?>
 		<div class="ef-myposts">
-			<?php if( !empty($myposts) ) : ?>
-				
-				<?php foreach( $myposts as $post ) : ?>
+			<?php if ( ! empty( $myposts ) ) : ?>
+
+				<?php foreach ( $myposts as $post ) : ?>
 					<?php
-					$url = esc_url(get_edit_post_link( $post->ID ));
-					$title = esc_html($post->post_title);
+					$url = esc_url( get_edit_post_link( $post->ID ) );
+					$title = esc_html( $post->post_title );
 					?>
 					<li>
-						<h4><a href="<?php echo $url ?>" title="<?php _e('Edit this post', 'edit-flow') ?>"><?php echo $title; ?></a></h4>
-						<span class="ef-myposts-timestamp"><?php _e('This post was last updated on', 'edit-flow') ?> <?php echo get_the_time('F j, Y \\a\\t g:i a', $post) ?></span>
-					</li>	
+						<h4><a href="<?php echo esc_url( $url ); ?>" title="<?php _e( 'Edit this post', 'edit-flow' ); ?>"><?php echo esc_html( $title ); ?></a></h4>
+						<span class="ef-myposts-timestamp"><?php _e( 'This post was last updated on', 'edit-flow' ); ?> <?php echo esc_html( get_the_time( 'F j, Y \\a\\t g:i a', $post ) ); ?></span>
+					</li>
 				<?php endforeach; ?>
 			<?php else : ?>
-				<p><?php _e('Sorry! You\'re not subscribed to any posts!', 'edit-flow') ?></p>
+				<p><?php _e( 'Sorry! You\'re not subscribed to any posts!', 'edit-flow' ); ?></p>
 			<?php endif; ?>
 		</div>
-		<?php
-	}
-	
-	/**
-	 * Register settings for notifications so we can partially use the Settings API
-	 * (We use the Settings API for form generation, but not saving)
-	 * 
-	 * @since 0.7
-	 */
-	function register_settings() {
-		
+			<?php
+		}
+
+		/**
+		 * Register settings for notifications so we can partially use the Settings API
+		 * (We use the Settings API for form generation, but not saving)
+		 *
+		 * @since 0.7
+		 */
+		public function register_settings() {
+
 			add_settings_section( $this->module->options_group_name . '_general', false, '__return_false', $this->module->options_group_name );
 			add_settings_field( 'post_status_widget', __( 'Post Status Widget', 'edit-flow' ), array( $this, 'settings_post_status_widget_option' ), $this->module->options_group_name, $this->module->options_group_name . '_general' );
-			add_settings_field( 'my_posts_widget',__( 'Posts I\'m Following', 'edit-flow' ), array( $this, 'settings_my_posts_widget_option' ), $this->module->options_group_name, $this->module->options_group_name . '_general' );
-			add_settings_field( 'notepad_widget',__( 'Notepad', 'edit-flow' ), array( $this, 'settings_notepad_widget_option' ), $this->module->options_group_name, $this->module->options_group_name . '_general' );
+			add_settings_field( 'my_posts_widget', __( 'Posts I\'m Following', 'edit-flow' ), array( $this, 'settings_my_posts_widget_option' ), $this->module->options_group_name, $this->module->options_group_name . '_general' );
+			add_settings_field( 'notepad_widget', __( 'Notepad', 'edit-flow' ), array( $this, 'settings_notepad_widget_option' ), $this->module->options_group_name, $this->module->options_group_name . '_general' );
+		}
 
-	}
-	
-	/**
-	 * Enable or disable the Post Status Widget for the WP dashboard
-	 *
-	 * @since 0.7
-	 */
-	function settings_post_status_widget_option() {
-		$options = array(
-			'off' => __( 'Disabled', 'edit-flow' ),			
-			'on' => __( 'Enabled', 'edit-flow' ),
-		);
-		echo '<select id="post_status_widget" name="' . $this->module->options_group_name . '[post_status_widget]">';
-		foreach ( $options as $value => $label ) {
-			echo '<option value="' . esc_attr( $value ) . '"';
-			echo selected( $this->module->options->post_status_widget, $value );			
-			echo '>' . esc_html( $label ) . '</option>';
+		/**
+		 * Enable or disable the Post Status Widget for the WP dashboard
+		 *
+		 * @since 0.7
+		 */
+		public function settings_post_status_widget_option() {
+			$options = array(
+				'off' => __( 'Disabled', 'edit-flow' ),
+				'on' => __( 'Enabled', 'edit-flow' ),
+			);
+			echo '<select id="post_status_widget" name="' . esc_attr( $this->module->options_group_name ) . '[post_status_widget]">';
+			foreach ( $options as $value => $label ) {
+				echo '<option value="' . esc_attr( $value ) . '"';
+				echo selected( $this->module->options->post_status_widget, $value );
+				echo '>' . esc_html( $label ) . '</option>';
+			}
+			echo '</select>';
 		}
-		echo '</select>';
-	}
-	
-	/**
-	 * Enable or disable the Posts I'm Following Widget for the WP dashboard
-	 *
-	 * @since 0.7
-	 */
-	function settings_my_posts_widget_option() {
-		global $edit_flow;
-		$options = array(
-			'off' => __( 'Disabled', 'edit-flow' ),			
-			'on' => __( 'Enabled', 'edit-flow' ),
-		);
-		echo '<select id="my_posts_widget" name="' . $this->module->options_group_name . '[my_posts_widget]"';
-		// Notifications module has to be enabled for the My Posts widget to work
-		if ( !$this->module_enabled('notifications') ) {
-			echo ' disabled="disabled"';
-			$this->module->options->my_posts_widget = 'off';
-		}
-		echo '>';
-		foreach ( $options as $value => $label ) {
-			echo '<option value="' . esc_attr( $value ) . '"';
-			echo selected( $this->module->options->my_posts_widget, $value );
-			echo '>' . esc_html( $label ) . '</option>';
-		}
-		echo '</select>';
-		if ( !$this->module_enabled('notifications') ) {
-			echo '&nbsp;&nbsp;&nbsp;<span class="description">' . __( 'The notifications module will need to be enabled for this widget to display.', 'edit-flow' );
-		}
-	}
 
-	/**
-	 * Enable or disable the Notepad widget for the dashboard
-	 *
-	 * @since 0.8
-	 */
-	function settings_notepad_widget_option() {
-		$options = array(
-			'off' => __( 'Disabled', 'edit-flow' ),			
-			'on' => __( 'Enabled', 'edit-flow' ),
-		);
-		echo '<select id="notepad_widget" name="' . $this->module->options_group_name . '[notepad_widget]">';
-		foreach ( $options as $value => $label ) {
-			echo '<option value="' . esc_attr( $value ) . '"';
-			echo selected( $this->module->options->notepad_widget, $value );			
-			echo '>' . esc_html( $label ) . '</option>';
+		/**
+		 * Enable or disable the Posts I'm Following Widget for the WP dashboard
+		 *
+		 * @since 0.7
+		 */
+		public function settings_my_posts_widget_option() {
+			global $edit_flow;
+			$options = array(
+				'off' => __( 'Disabled', 'edit-flow' ),
+				'on' => __( 'Enabled', 'edit-flow' ),
+			);
+			echo '<select id="my_posts_widget" name="' . esc_attr( $this->module->options_group_name ) . '[my_posts_widget]"';
+			// Notifications module has to be enabled for the My Posts widget to work
+			if ( ! $this->module_enabled( 'notifications' ) ) {
+				echo ' disabled="disabled"';
+				$this->module->options->my_posts_widget = 'off';
+			}
+			echo '>';
+			foreach ( $options as $value => $label ) {
+				echo '<option value="' . esc_attr( $value ) . '"';
+				echo selected( $this->module->options->my_posts_widget, $value );
+				echo '>' . esc_html( $label ) . '</option>';
+			}
+			echo '</select>';
+			if ( ! $this->module_enabled( 'notifications' ) ) {
+				echo '&nbsp;&nbsp;&nbsp;<span class="description">' . esc_html__( 'The notifications module will need to be enabled for this widget to display.', 'edit-flow' );
+			}
 		}
-		echo '</select>';
-	}
-	
-	/**
-	 * Validate the field submitted by the user
-	 *
-	 * @since 0.7
-	 */
-	function settings_validate( $new_options ) {
-		
-		// Follow whitelist validation for modules
-		if ( array_key_exists( 'post_status_widget', $new_options ) && $new_options['post_status_widget'] != 'on' )
-			$new_options['post_status_widget'] = 'off';
-			
-		if ( array_key_exists( 'my_posts_widget', $new_options ) && $new_options['my_posts_widget'] != 'on' )
-			$new_options['my_posts_widget'] = 'off';
-		
-		return $new_options;
-	}	
-	
-	/**
-	 * Settings page for the dashboard
-	 *
-	 * @since 0.7
-	 */
-	function print_configure_view() {
-		?>
+
+		/**
+		 * Enable or disable the Notepad widget for the dashboard
+		 *
+		 * @since 0.8
+		 */
+		public function settings_notepad_widget_option() {
+			$options = array(
+				'off' => __( 'Disabled', 'edit-flow' ),
+				'on' => __( 'Enabled', 'edit-flow' ),
+			);
+			echo '<select id="notepad_widget" name="' . esc_attr( $this->module->options_group_name ) . '[notepad_widget]">';
+			foreach ( $options as $value => $label ) {
+				echo '<option value="' . esc_attr( $value ) . '"';
+				echo selected( $this->module->options->notepad_widget, $value );
+				echo '>' . esc_html( $label ) . '</option>';
+			}
+			echo '</select>';
+		}
+
+		/**
+		 * Validate the field submitted by the user
+		 *
+		 * @since 0.7
+		 */
+		public function settings_validate( $new_options ) {
+
+			// Follow whitelist validation for modules
+			if ( array_key_exists( 'post_status_widget', $new_options ) && 'on' != $new_options['post_status_widget'] ) {
+				$new_options['post_status_widget'] = 'off';
+			}
+
+			if ( array_key_exists( 'my_posts_widget', $new_options ) && 'on' != $new_options['my_posts_widget'] ) {
+				$new_options['my_posts_widget'] = 'off';
+			}
+
+			return $new_options;
+		}
+
+		/**
+		 * Settings page for the dashboard
+		 *
+		 * @since 0.7
+		 */
+		public function print_configure_view() {
+			?>
 		<form class="basic-settings" action="<?php echo esc_url( menu_page_url( $this->module->settings_slug, false ) ); ?>" method="post">
 			<?php settings_fields( $this->module->options_group_name ); ?>
-			<?php do_settings_sections( $this->module->options_group_name ); ?>	
-			<?php				
+			<?php do_settings_sections( $this->module->options_group_name ); ?>
+			<?php
 				echo '<input id="edit_flow_module_name" name="edit_flow_module_name" type="hidden" value="' . esc_attr( $this->module->name ) . '" />';
 			?>
-			<p class="submit"><?php submit_button( null, 'primary', 'submit', false ); ?><a class="cancel-settings-link" href="<?php echo EDIT_FLOW_SETTINGS_PAGE; ?>"><?php _e( 'Back to Edit Flow', 'edit-flow' ); ?></a></p>
+			<p class="submit"><?php submit_button( null, 'primary', 'submit', false ); ?><a class="cancel-settings-link" href="<?php echo esc_url( EDIT_FLOW_SETTINGS_PAGE ); ?>"><?php _e( 'Back to Edit Flow', 'edit-flow' ); ?></a></p>
 		</form>
-		<?php
+			<?php
+		}
 	}
-}
 
 } // END - !class_exists('EF_Dashboard')

--- a/modules/dashboard/dashboard.php
+++ b/modules/dashboard/dashboard.php
@@ -239,12 +239,12 @@ if ( ! class_exists( 'EF_Dashboard' ) ) {
 					$title = esc_html( $post->post_title );
 					?>
 					<li>
-						<h4><a href="<?php echo esc_url( $url ); ?>" title="<?php _e( 'Edit this post', 'edit-flow' ); ?>"><?php echo esc_html( $title ); ?></a></h4>
-						<span class="ef-myposts-timestamp"><?php _e( 'This post was last updated on', 'edit-flow' ); ?> <?php echo esc_html( get_the_time( 'F j, Y \\a\\t g:i a', $post ) ); ?></span>
+						<h4><a href="<?php echo esc_url( $url ); ?>" title="<?php esc_attr_e( 'Edit this post', 'edit-flow' ); ?>"><?php echo esc_html( $title ); ?></a></h4>
+						<span class="ef-myposts-timestamp"><?php esc_html_e( 'This post was last updated on', 'edit-flow' ); ?> <?php echo esc_html( get_the_time( 'F j, Y \\a\\t g:i a', $post ) ); ?></span>
 					</li>
 				<?php endforeach; ?>
 			<?php else : ?>
-				<p><?php _e( 'Sorry! You\'re not subscribed to any posts!', 'edit-flow' ); ?></p>
+				<p><?php esc_html_e( 'Sorry! You\'re not subscribed to any posts!', 'edit-flow' ); ?></p>
 			<?php endif; ?>
 		</div>
 			<?php

--- a/modules/dashboard/widgets/dashboard-notepad.php
+++ b/modules/dashboard/widgets/dashboard-notepad.php
@@ -5,21 +5,21 @@
 
 class EF_Dashboard_Notepad_Widget {
 
+	// phpcs:ignore Generic.NamingConventions.UpperCaseConstantName.ClassConstantNotUpperCase
 	const notepad_post_type = 'dashboard-note';
 
 	public $edit_cap = 'edit_others_posts';
 
-	function __construct() {
+	public function __construct() {
 		// Silence is golden
 	}
 
 	public function init() {
 
 		register_post_type( self::notepad_post_type, array(
-				'rewrite' => false,
-				'label' => __( 'Dashboard Note', 'edit-flow' )
-			)
-		);
+			'rewrite' => false,
+			'label' => __( 'Dashboard Note', 'edit-flow' ),
+		));
 
 		$this->edit_cap = apply_filters( 'ef_dashboard_notepad_edit_cap', $this->edit_cap );
 
@@ -41,7 +41,7 @@ class EF_Dashboard_Notepad_Widget {
 		check_admin_referer( 'dashboard-notepad' );
 
 		if ( ! current_user_can( $this->edit_cap ) ) {
-			wp_die( EditFlow()->dashboard->messages['invalid-permissions'] );
+			wp_die( esc_html( EditFlow()->dashboard->messages['invalid-permissions'] ) );
 		}
 
 		$note_data = array(
@@ -68,19 +68,22 @@ class EF_Dashboard_Notepad_Widget {
 	public function notepad_widget() {
 
 		$args = array(
-				'posts_per_page'   => 1,
-				'post_status'      => 'draft',
-				'post_type'        => self::notepad_post_type,
-			);
+			'posts_per_page'   => 1,
+			'post_status'      => 'draft',
+			'post_type'        => self::notepad_post_type,
+		);
+
 		$posts = get_posts( $args );
 		$current_note = ( ! empty( $posts[0]->post_content ) ) ? $posts[0]->post_content : '';
 		$current_id = ( ! empty( $posts[0]->ID ) ) ? $posts[0]->ID : 0;
 		$current_post = ( ! empty( $posts[0] ) ) ? $posts[0] : false;
 
-		if ( $current_post )
+		if ( $current_post ) {
+			// translators: %1$s is the author name, %2$s is the date the note was last updated
 			$last_updated = '<span id="dashboard-notepad-last-updated">' . sprintf( __( '%1$s last updated on %2$s', 'edit-flow' ), get_user_by( 'id', $current_post->post_author )->display_name, get_the_modified_time( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), $current_post ) ) . '</span>';
-		else
+		} else {
 			$last_updated = '';
+		}
 
 		if ( current_user_can( $this->edit_cap ) ) {
 			echo '<form method="post" id="dashboard-notepad">';
@@ -90,7 +93,7 @@ class EF_Dashboard_Notepad_Widget {
 			echo esc_textarea( trim( $current_note ) );
 			echo '</textarea>';
 			echo '<p class="submit">';
-			echo $last_updated;
+			echo wp_kses_post( $last_updated );
 			echo '<span id="dashboard-notepad-submit-buttons">';
 			submit_button( __( 'Update Note', 'edit-flow' ), 'primary', 'update-note', false );
 			echo '</span>';
@@ -102,9 +105,8 @@ class EF_Dashboard_Notepad_Widget {
 			echo '<textarea style="width:100%" rows="10" name="note" disabled="disabled">';
 			echo esc_textarea( trim( $current_note ) );
 			echo '</textarea>';
-			echo $last_updated;
+			echo wp_kses_post( $last_updated );
 			echo '</form>';
 		}
 	}
-
 }

--- a/modules/editorial-comments/editorial-comments.php
+++ b/modules/editorial-comments/editorial-comments.php
@@ -6,117 +6,118 @@
  * @author batmoo
  */
 
-if ( !class_exists( 'EF_Editorial_Comments' ) ) {
+if ( ! class_exists( 'EF_Editorial_Comments' ) ) {
 
-class EF_Editorial_Comments extends EF_Module
-{
-	// This is comment type used to differentiate editorial comments
-	const comment_type = 'editorial-comment';
+	class EF_Editorial_Comments extends EF_Module {
 
-	function __construct() {
+		// This is comment type used to differentiate editorial comments
+		// phpcs:ignore Generic.NamingConventions.UpperCaseConstantName.ClassConstantNotUpperCase
+		const comment_type = 'editorial-comment';
 
-		$this->module_url = $this->get_module_url( __FILE__ );
-		// Register the module with Edit Flow
-		$args = array(
-			'title' => __( 'Editorial Comments', 'edit-flow' ),
-			'short_description' => __( 'Share internal notes with your team.', 'edit-flow' ),
-			'extended_description' => __( 'Use editorial comments to hold a private discussion about a post. Communicate directly with your writers or editors about what works and what needs to be improved for each piece.', 'edit-flow' ),
-			'module_url' => $this->module_url,
-			'img_url' => $this->module_url . 'lib/editorial_comments_s128.png',
-			'slug' => 'editorial-comments',
-			'default_options' => array(
-				'enabled' => 'on',
-				'post_types' => array(
-					'post' => 'on',
-					'page' => 'on',
+		public function __construct() {
+
+			$this->module_url = $this->get_module_url( __FILE__ );
+			// Register the module with Edit Flow
+			$args = array(
+				'title' => __( 'Editorial Comments', 'edit-flow' ),
+				'short_description' => __( 'Share internal notes with your team.', 'edit-flow' ),
+				'extended_description' => __( 'Use editorial comments to hold a private discussion about a post. Communicate directly with your writers or editors about what works and what needs to be improved for each piece.', 'edit-flow' ),
+				'module_url' => $this->module_url,
+				'img_url' => $this->module_url . 'lib/editorial_comments_s128.png',
+				'slug' => 'editorial-comments',
+				'default_options' => array(
+					'enabled' => 'on',
+					'post_types' => array(
+						'post' => 'on',
+						'page' => 'on',
+					),
 				),
-			),
-			'configure_page_cb' => 'print_configure_view',
-			'configure_link_text' => __( 'Choose Post Types', 'edit-flow' ),
-			'autoload' => false,
-			'settings_help_tab' => array(
-				'id' => 'ef-editorial-comments-overview',
-				'title' => __('Overview', 'edit-flow'),
-				'content' => __('<p>Editorial comments help you cut down on email overload and keep the conversation close to where it matters: your content. Threaded commenting in the admin, similar to what you find at the end of a blog post, allows writers and editors to privately leave feedback and discuss what needs to be changed before publication.</p><p>Anyone with access to view the story in progress will also have the ability to comment on it. If you have notifications enabled, those following the post will receive an email every time a comment is left.</p>', 'edit-flow'),
+				'configure_page_cb' => 'print_configure_view',
+				'configure_link_text' => __( 'Choose Post Types', 'edit-flow' ),
+				'autoload' => false,
+				'settings_help_tab' => array(
+					'id' => 'ef-editorial-comments-overview',
+					'title' => __( 'Overview', 'edit-flow' ),
+					'content' => __( '<p>Editorial comments help you cut down on email overload and keep the conversation close to where it matters: your content. Threaded commenting in the admin, similar to what you find at the end of a blog post, allows writers and editors to privately leave feedback and discuss what needs to be changed before publication.</p><p>Anyone with access to view the story in progress will also have the ability to comment on it. If you have notifications enabled, those following the post will receive an email every time a comment is left.</p>', 'edit-flow' ),
 				),
-			'settings_help_sidebar' => __( '<p><strong>For more information:</strong></p><p><a href="http://editflow.org/features/editorial-comments/">Editorial Comments Documentation</a></p><p><a href="http://wordpress.org/tags/edit-flow?forum_id=10">Edit Flow Forum</a></p><p><a href="https://github.com/danielbachhuber/Edit-Flow">Edit Flow on Github</a></p>', 'edit-flow' ),
-		);
-		$this->module = EditFlow()->register_module( 'editorial_comments', $args );
-	}
-
-	/**
-	 * Initialize the rest of the stuff in the class if the module is active
-	 */
-	function init() {
-		add_action( 'add_meta_boxes', array ( $this, 'add_post_meta_box' ) );
-		add_action( 'admin_init', array( $this, 'register_settings' ) );
-		add_action( 'admin_enqueue_scripts', array( $this, 'add_admin_scripts' ) );
-		add_action( 'wp_ajax_editflow_ajax_insert_comment', array( $this, 'ajax_insert_comment' ) );
-	}
-
-	/**
-	 * Upgrade our data in case we need to
-	 *
-	 * @since 0.7
-	 */
-	function upgrade( $previous_version ) {
-		global $edit_flow;
-
-		// Upgrade path to v0.7
-		if ( version_compare( $previous_version, '0.7' , '<' ) ) {
-			// Technically we've run this code before so we don't want to auto-install new data
-			$edit_flow->update_module_option( $this->module->name, 'loaded_once', true );
+				'settings_help_sidebar' => __( '<p><strong>For more information:</strong></p><p><a href="http://editflow.org/features/editorial-comments/">Editorial Comments Documentation</a></p><p><a href="http://wordpress.org/tags/edit-flow?forum_id=10">Edit Flow Forum</a></p><p><a href="https://github.com/danielbachhuber/Edit-Flow">Edit Flow on Github</a></p>', 'edit-flow' ),
+			);
+			$this->module = EditFlow()->register_module( 'editorial_comments', $args );
 		}
 
-	}
+		/**
+		 * Initialize the rest of the stuff in the class if the module is active
+		 */
+		public function init() {
+			add_action( 'add_meta_boxes', array( $this, 'add_post_meta_box' ) );
+			add_action( 'admin_init', array( $this, 'register_settings' ) );
+			add_action( 'admin_enqueue_scripts', array( $this, 'add_admin_scripts' ) );
+			add_action( 'wp_ajax_editflow_ajax_insert_comment', array( $this, 'ajax_insert_comment' ) );
+		}
 
-	/**
-	 * Load any of the admin scripts we need but only on the pages we need them
-	 */
-	function add_admin_scripts( ) {
-		global $pagenow;
+		/**
+		 * Upgrade our data in case we need to
+		 *
+		 * @since 0.7
+		 */
+		public function upgrade( $previous_version ) {
+			global $edit_flow;
 
-		$post_type = $this->get_current_post_type();
-		$supported_post_types = $this->get_post_types_for_module( $this->module );
-		if ( !in_array( $post_type, $supported_post_types ) )
-			return;
+			// Upgrade path to v0.7
+			if ( version_compare( $previous_version, '0.7', '<' ) ) {
+				// Technically we've run this code before so we don't want to auto-install new data
+				$edit_flow->update_module_option( $this->module->name, 'loaded_once', true );
+			}
+		}
 
-		if ( !in_array( $pagenow, array( 'post.php', 'page.php', 'post-new.php', 'page-new.php' ) ) )
-			return;
+		/**
+		 * Load any of the admin scripts we need but only on the pages we need them
+		 */
+		public function add_admin_scripts() {
+			global $pagenow;
 
-		wp_enqueue_script( 'edit_flow-post_comment', $this->module_url . 'lib/editorial-comments.js', array( 'jquery', 'wp-ajax-response' ), EDIT_FLOW_VERSION, true );
-		wp_localize_script( 'edit_flow-post_comment', '__ef_localize_post_comment', array(
-			'and'           => esc_html__( 'and', 'edit-flow' ),
-			'none_notified' => esc_html__( 'No one will be notified.', 'edit-flow' ),
-		) );
+			$post_type = $this->get_current_post_type();
+			$supported_post_types = $this->get_post_types_for_module( $this->module );
+			if ( ! in_array( $post_type, $supported_post_types ) ) {
+				return;
+			}
 
-		wp_enqueue_style( 'edit-flow-editorial-comments-css', $this->module_url . 'lib/editorial-comments.css', false, EDIT_FLOW_VERSION, 'all' );
+			if ( ! in_array( $pagenow, array( 'post.php', 'page.php', 'post-new.php', 'page-new.php' ) ) ) {
+				return;
+			}
 
-		$thread_comments = (int) get_option('thread_comments');
-		?>
+			wp_enqueue_script( 'edit_flow-post_comment', $this->module_url . 'lib/editorial-comments.js', array( 'jquery', 'wp-ajax-response' ), EDIT_FLOW_VERSION, true );
+			wp_localize_script( 'edit_flow-post_comment', '__ef_localize_post_comment', array(
+				'and'           => esc_html__( 'and', 'edit-flow' ),
+				'none_notified' => esc_html__( 'No one will be notified.', 'edit-flow' ),
+			) );
+
+			wp_enqueue_style( 'edit-flow-editorial-comments-css', $this->module_url . 'lib/editorial-comments.css', false, EDIT_FLOW_VERSION, 'all' );
+
+			$thread_comments = (int) get_option( 'thread_comments' );
+			?>
 		<script type="text/javascript">
-			var ef_thread_comments = <?php echo ($thread_comments) ? $thread_comments : 0; ?>;
+			var ef_thread_comments = <?php echo esc_html( ( $thread_comments ) ? $thread_comments : 0 ); ?>;
 		</script>
-		<?php
+			<?php
+		}
 
-	}
+		/**
+		 * Add the editorial comments metabox to enabled post types
+		 *
+		 * @uses add_meta_box()
+		 */
+		public function add_post_meta_box() {
 
-	/**
-	 * Add the editorial comments metabox to enabled post types
-	 *
-	 * @uses add_meta_box()
-	 */
-	function add_post_meta_box() {
+			$supported_post_types = $this->get_post_types_for_module( $this->module );
+			foreach ( $supported_post_types as $post_type ) {
+				add_meta_box( 'edit-flow-editorial-comments', __( 'Editorial Comments', 'edit-flow' ), array( $this, 'editorial_comments_meta_box' ), $post_type, 'normal' );
+			}
+		}
 
-		$supported_post_types = $this->get_post_types_for_module( $this->module );
-		foreach ( $supported_post_types as $post_type )
-			add_meta_box('edit-flow-editorial-comments', __('Editorial Comments', 'edit-flow'), array($this, 'editorial_comments_meta_box'), $post_type, 'normal' );
-
-	}
-
-	function editorial_comments_meta_box( ) {
-		global $post, $post_ID;
-		?>
+		public function editorial_comments_meta_box() {
+			global $post, $post_ID;
+			?>
 		<div id="ef-comments_wrapper">
 			<a name="editorialcomments"></a>
 
@@ -131,7 +132,7 @@ class EF_Editorial_Comments extends EF_Module
 						'comment_type' => self::comment_type,
 						'orderby' => 'comment_date',
 						'order' => 'ASC',
-						'status' => self::comment_type
+						'status' => self::comment_type,
 					)
 				);
 				?>
@@ -143,8 +144,8 @@ class EF_Editorial_Comments extends EF_Module
 						wp_list_comments(
 							array(
 								'type' => self::comment_type,
-								'callback' => array($this, 'the_comment'),
-								'end-callback' => '__return_false'
+								'callback' => array( $this, 'the_comment' ),
+								'end-callback' => '__return_false',
 							),
 							$editorial_comments
 						);
@@ -153,26 +154,26 @@ class EF_Editorial_Comments extends EF_Module
 
 				<?php $this->the_comment_form(); ?>
 
-			<?php
-			else :
-			?>
+				<?php
+				else :
+					?>
 				<p><?php _e( 'You can add editorial comments to a post once you\'ve saved it for the first time.', 'edit-flow' ); ?></p>
-			<?php
-			endif;
-			?>
+					<?php
+				endif;
+				?>
 			<div class="clear"></div>
 		</div>
 		<div class="clear"></div>
-		<?php
-	}
+			<?php
+		}
 
-	/**
-	 * Displays the main commenting form
-	 */
-	function the_comment_form( ) {
-		global $post;
+		/**
+		 * Displays the main commenting form
+		 */
+		public function the_comment_form() {
+			global $post;
 
-		?>
+			?>
 		<a href="#" id="ef-comment_respond" onclick="editorialCommentReply.open();return false;" class="button-primary alignright hide-if-no-js" title=" <?php _e( 'Respond to this post', 'edit-flow' ); ?>"><span><?php _e( 'Respond to this post', 'edit-flow' ); ?></span></a>
 
 		<!-- Reply form, hidden until reply clicked by user -->
@@ -189,10 +190,10 @@ class EF_Editorial_Comments extends EF_Module
 
 			<p id="ef-replysubmit">
 				<a class="ef-replysave button-primary alignright" href="#comments-form">
-					<span id="ef-replybtn"><?php _e('Submit Response', 'edit-flow') ?></span>
+					<span id="ef-replybtn"><?php _e( 'Submit Response', 'edit-flow' ); ?></span>
 				</a>
 				<a class="ef-replycancel button-secondary alignright" href="#comments-form"><?php _e( 'Cancel', 'edit-flow' ); ?></a>
-				<img alt="Sending comment..." src="<?php echo admin_url('/images/wpspin_light.gif') ?>" class="alignright" style="display: none;" id="ef-comment_loading" />
+				<img alt="Sending comment..." src="<?php echo esc_url( admin_url( '/images/wpspin_light.gif' ) ); ?>" class="alignright" style="display: none;" id="ef-comment_loading" />
 				<br class="clear" style="margin-bottom:35px;" />
 				<span style="display: none;" class="error"></span>
 			</p>
@@ -200,250 +201,272 @@ class EF_Editorial_Comments extends EF_Module
 			<input type="hidden" value="" id="ef-comment_parent" name="ef-comment_parent" />
 			<input type="hidden" name="ef-post_id" id="ef-post_id" value="<?php echo esc_attr( $post->ID ); ?>" />
 
-			<?php wp_nonce_field('comment', 'ef_comment_nonce', false); ?>
+			<?php wp_nonce_field( 'comment', 'ef_comment_nonce', false ); ?>
 
 			<br class="clear" />
 		</div>
 
-		<?php
-	}
-
-	/**
-	 * Maybe display who was notified underneath an editorial comment.
-	 *
-	 * @param int $comment_id
-	 * @return void
-	 */
-	function maybe_output_comment_meta( $comment_id ) {
-		if ( ! $this->module_enabled( 'notifications' ) || ! apply_filters( 'ef_editorial_comments_show_notified_users', true ) ) {
-			return;
+			<?php
 		}
 
-		$notification = get_comment_meta( $comment_id, 'notification_list', true );
-
-		if ( empty( $notification ) ) {
-			$message = esc_html__( 'No users or groups were notified.', 'edit-flow' );
-		} else {
-			$message = '<strong>'. esc_html__( 'Notified', 'edit-flow' ) . ':</strong> ' . esc_html( $notification );
-		}
-
-		echo '<p class="ef-notification-meta">' . $message . '</p>';
-	}
-
-	/**
-	 * Displays a single comment
-	 */
-	function the_comment($comment, $args, $depth) {
-		global $current_user, $userdata;
-
-		// Get current user
-		wp_get_current_user() ;
-
-		$GLOBALS['comment'] = $comment;
-
-		$actions = array();
-
-		$actions_string = '';
-		// Comments can only be added by users that can edit the post
-		if ( current_user_can('edit_post', $comment->comment_post_ID) ) {
-			$actions['reply'] = '<a onclick="editorialCommentReply.open(\''.$comment->comment_ID.'\',\''.$comment->comment_post_ID.'\');return false;" class="vim-r hide-if-no-js" title="'.__( 'Reply to this comment', 'edit-flow' ).'" href="#">' . __( 'Reply', 'edit-flow' ) . '</a>';
-
-			$sep = ' ';
-			$i = 0;
-			foreach ( $actions as $action => $link ) {
-				++$i;
-				// Reply and quickedit need a hide-if-no-js span
-				if ( 'reply' == $action || 'quickedit' == $action )
-					$action .= ' hide-if-no-js';
-
-				$actions_string .= "<span class='$action'>$sep$link</span>";
+		/**
+		 * Maybe display who was notified underneath an editorial comment.
+		 *
+		 * @param int $comment_id
+		 * @return void
+		 */
+		public function maybe_output_comment_meta( $comment_id ) {
+			if ( ! $this->module_enabled( 'notifications' ) || ! apply_filters( 'ef_editorial_comments_show_notified_users', true ) ) {
+				return;
 			}
+
+			$notification = get_comment_meta( $comment_id, 'notification_list', true );
+
+			if ( empty( $notification ) ) {
+				$message = esc_html__( 'No users or groups were notified.', 'edit-flow' );
+			} else {
+				$message = '<strong>' . esc_html__( 'Notified', 'edit-flow' ) . ':</strong> ' . esc_html( $notification );
+			}
+
+			// It's already been escaped above.
+			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+			echo '<p class="ef-notification-meta">' . $message . '</p>';
 		}
 
-	?>
+		/**
+		 * Displays a single comment
+		 */
+		public function the_comment( $comment, $args, $depth ) {
+			global $current_user, $userdata;
 
-		<li id="comment-<?php echo esc_attr( $comment->comment_ID ); ?>" <?php comment_class( array( 'comment-item', wp_get_comment_status($comment->comment_ID) ) ); ?>>
+			// Get current user
+			wp_get_current_user();
+
+			// Without this, the comment will not appear.
+			// ToDo: Find an alternative so we don't override global variables
+			// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+			$GLOBALS['comment'] = $comment;
+
+			$actions = array();
+
+			$actions_string = '';
+			// Comments can only be added by users that can edit the post
+			if ( current_user_can( 'edit_post', $comment->comment_post_ID ) ) {
+				// The output for this has been individually escaped. Escaping the entire string will break comment reply functionality.
+				// ToDo: Use wp_kses with a custom set of allowed tags instead.
+				$actions['reply'] = '<a onclick="editorialCommentReply.open(\'' . esc_html( $comment->comment_ID ) . '\',\'' . esc_html( $comment->comment_post_ID ) . '\');return false;" class="vim-r hide-if-no-js" title="' . esc_attr( __( 'Reply to this comment', 'edit-flow' ) ) . '" href="#">' . esc_html__( 'Reply', 'edit-flow' ) . '</a>';
+
+				$sep = ' ';
+				$i = 0;
+				foreach ( $actions as $action => $link ) {
+					++$i;
+					// Reply and quickedit need a hide-if-no-js span
+					if ( 'reply' == $action || 'quickedit' == $action ) {
+						$action .= ' hide-if-no-js';
+					}
+
+					$actions_string .= "<span class='$action'>$sep$link</span>";
+				}
+			}
+
+			?>
+
+		<li id="comment-<?php echo esc_attr( $comment->comment_ID ); ?>" <?php comment_class( array( 'comment-item', wp_get_comment_status( $comment->comment_ID ) ) ); ?>>
 
 			<?php echo get_avatar( $comment->comment_author_email, 50 ); ?>
 
 			<div class="post-comment-wrap">
 				<h5 class="comment-meta">
-					<?php printf( __('<span class="comment-author">%1$s</span><span class="meta"> said on %2$s at %3$s</span>', 'edit-flow'),
-							comment_author_email_link( $comment->comment_author ),
-							get_comment_date( get_option( 'date_format' ) ),
-							get_comment_time() ); ?>
+					<?php
+					/* translators: 1: HTML email link to the author of the current comment, 2: the date of the comment, 3: the time of the comment */
+					printf( wp_kses_post( __( '<span class="comment-author">%1$s</span><span class="meta"> said on %2$s at %3$s</span>', 'edit-flow' ) ),
+						wp_kses_post( comment_author_email_link( $comment->comment_author ) ),
+						esc_attr( get_comment_date( get_option( 'date_format' ) ) ),
+					esc_attr( get_comment_time() ) );
+					?>
 				</h5>
 
 				<div class="comment-content"><?php comment_text(); ?></div>
-				<?php $this->maybe_output_comment_meta( $comment->comment_ID ); ?>
-				<p class="row-actions"><?php echo $actions_string; ?></p>
-
+					<?php $this->maybe_output_comment_meta( $comment->comment_ID ); ?>
+				<p class="row-actions"><?php /* phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped */ echo $actions_string; ?></p>
 			</div>
 		</li>
-		<?php
-	}
+			<?php
+		}
 
-	/**
-	 * Handles AJAX insert comment
-	 */
-	function ajax_insert_comment( ) {
-		global $current_user, $user_ID, $wpdb;
+		/**
+		 * Handles AJAX insert comment
+		 */
+		public function ajax_insert_comment() {
+			global $current_user, $user_ID, $wpdb;
 
-		// Verify nonce
-		if ( !wp_verify_nonce( $_POST['_nonce'], 'comment') )
-			die( __( "Nonce check failed. Please ensure you're supposed to be adding editorial comments.", 'edit-flow' ) );
-
-		// Get user info
-      	wp_get_current_user();
-
-      	// Set up comment data
-		$post_id = absint( $_POST['post_id'] );
-		$parent  = absint( $_POST['parent'] );
-
-      	// Only allow the comment if user can edit post
-      	// @TODO: allow contributers to add comments as well (?)
-		if ( ! current_user_can( 'edit_post', $post_id ) )
-			die( __('Sorry, you don\'t have the privileges to add editorial comments. Please talk to your Administrator.', 'edit-flow' ) );
-
-		// Verify that comment was actually entered
-		$comment_content = trim($_POST['content']);
-		if( !$comment_content )
-			die( __( "Please enter a comment.", 'edit-flow' ) );
-
-		// Check that we have a post_id and user logged in
-		if( $post_id && $current_user ) {
-
-			// set current time
-			$time = current_time('mysql', $gmt = 0);
-
-			// Set comment data
-			$data = array(
-			    'comment_post_ID' => (int) $post_id,
-			    'comment_author' => esc_sql($current_user->display_name),
-			    'comment_author_email' => esc_sql($current_user->user_email),
-			    'comment_author_url' => esc_sql($current_user->user_url),
-			    'comment_content' => wp_kses($comment_content, array('a' => array('href' => array(),'title' => array()),'b' => array(),'i' => array(),'strong' => array(),'em' => array(),'u' => array(),'del' => array(), 'blockquote' => array(), 'sub' => array(), 'sup' => array() )),
-			    'comment_type' => self::comment_type,
-			    'comment_parent' => (int) $parent,
-			    'user_id' => (int) $user_ID,
-			    'comment_author_IP' => esc_sql($_SERVER['REMOTE_ADDR']),
-			    'comment_agent' => esc_sql($_SERVER['HTTP_USER_AGENT']),
-			    'comment_date' => $time,
-			    'comment_date_gmt' => $time,
-				// Set to -1?
-			    'comment_approved' => self::comment_type,
-			);
-
-			$data = apply_filters( 'ef_pre_insert_editorial_comment', $data );
-
-			// Insert Comment
-			$comment_id = wp_insert_comment($data);
-			$comment = get_comment($comment_id);
-
-			// Save the list of notified users/usergroups.
-			if ( $this->module_enabled( 'notifications' ) && apply_filters( 'ef_editorial_comments_show_notified_users', true ) ) {
-				$notification = isset( $_POST['notification'] ) ? sanitize_text_field( $_POST['notification'] ) : '';
-
-				if ( ! empty( $notification ) && __( 'No one will be notified.', 'edit-flow' ) !== $notification ) {
-					add_comment_meta( $comment_id, 'notification_list', $notification );
-				}
+			// Verify nonce
+			if ( ! isset( $_POST['_nonce'] ) || ! wp_verify_nonce( $_POST['_nonce'], 'comment' ) ) {
+				die( esc_html__( "Nonce check failed. Please ensure you're supposed to be adding editorial comments.", 'edit-flow' ) );
 			}
 
-			// Register actions -- will be used to set up notifications and other modules can hook into this
-			if ( $comment_id )
-				do_action( 'ef_post_insert_editorial_comment', $comment );
+			// Get user info
+			wp_get_current_user();
 
-			// Prepare response
-			$response = new WP_Ajax_Response();
+			// Set up comment data
+			// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotValidated
+			$post_id = absint( $_POST['post_id'] );
+			// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotValidated
+			$parent  = absint( $_POST['parent'] );
 
-			ob_start();
+			// Only allow the comment if user can edit post
+			// @TODO: allow contributers to add comments as well (?)
+			if ( ! current_user_can( 'edit_post', $post_id ) ) {
+				die( esc_html__( 'Sorry, you don\'t have the privileges to add editorial comments. Please talk to your Administrator.', 'edit-flow' ) );
+			}
+
+			// Verify that comment was actually entered
+			$comment_content = isset( $_POST['content'] ) ? trim( $_POST['content'] ) : '';
+			if ( ! $comment_content ) {
+				die( esc_html__( 'Please enter a comment.', 'edit-flow' ) );
+			}
+
+			// Check that we have a post_id and user logged in
+			if ( $post_id && $current_user ) {
+
+				// set current time
+				$time = current_time( 'mysql', $gmt = 0 );
+
+				// Set comment data
+				$data = array(
+					'comment_post_ID' => (int) $post_id,
+					'comment_author' => esc_sql( $current_user->display_name ),
+					'comment_author_email' => esc_sql( $current_user->user_email ),
+					'comment_author_url' => esc_sql( $current_user->user_url ),
+					'comment_content' => wp_kses( $comment_content, array(
+						'a' => array(
+							'href' => array(),
+							'title' => array(),
+						),
+						'b' => array(),
+						'i' => array(),
+						'strong' => array(),
+						'em' => array(),
+						'u' => array(),
+						'del' => array(),
+						'blockquote' => array(),
+						'sub' => array(),
+						'sup' => array(),
+					) ),
+					'comment_type' => self::comment_type,
+					'comment_parent' => (int) $parent,
+					'user_id' => (int) $user_ID,
+					// This is just used for logging in the DB, and it's been escaped as well
+					// phpcs:ignore WordPressVIPMinimum.Variables.ServerVariables.UserControlledHeaders
+					'comment_author_IP' => isset( $_SERVER['REMOTE_ADDR'] ) ? esc_sql( $_SERVER['REMOTE_ADDR'] ) : '',
+					// This is just used for logging in the DB, and it's been escaped as well.
+					// phpcs:ignore WordPressVIPMinimum.Variables.ServerVariables.UserControlledHeaders
+					// phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___SERVER__HTTP_USER_AGENT__
+					'comment_agent' => isset( $_SERVER['HTTP_USER_AGENT'] ) ? esc_sql( $_SERVER['HTTP_USER_AGENT'] ) : '',
+					'comment_date' => $time,
+					'comment_date_gmt' => $time,
+					// Set to -1?
+					'comment_approved' => self::comment_type,
+				);
+
+				$data = apply_filters( 'ef_pre_insert_editorial_comment', $data );
+
+				// Insert Comment
+				$comment_id = wp_insert_comment( $data );
+				$comment = get_comment( $comment_id );
+
+				// Save the list of notified users/usergroups.
+				if ( $this->module_enabled( 'notifications' ) && apply_filters( 'ef_editorial_comments_show_notified_users', true ) ) {
+					$notification = isset( $_POST['notification'] ) ? sanitize_text_field( $_POST['notification'] ) : '';
+
+					if ( ! empty( $notification ) && __( 'No one will be notified.', 'edit-flow' ) !== $notification ) {
+						add_comment_meta( $comment_id, 'notification_list', $notification );
+					}
+				}
+
+				// Register actions -- will be used to set up notifications and other modules can hook into this
+				if ( $comment_id ) {
+					do_action( 'ef_post_insert_editorial_comment', $comment );
+				}
+
+				// Prepare response
+				$response = new WP_Ajax_Response();
+
+				ob_start();
 				$this->the_comment( $comment, '', '' );
 				$comment_list_item = ob_get_contents();
-			ob_end_clean();
+				ob_end_clean();
 
-			$response->add( array(
-				'what' => 'comment',
-				'id' => $comment_id,
-				'data' => $comment_list_item,
-				'action' => ($parent) ? 'reply' : 'new'
-			));
+				$response->add( array(
+					'what' => 'comment',
+					'id' => $comment_id,
+					'data' => $comment_list_item,
+					'action' => ( $parent ) ? 'reply' : 'new',
+				));
 
-			$response->send();
+				$response->send();
 
-		} else {
-			die( __('There was a problem of some sort. Try again or contact your administrator.', 'edit-flow') );
+			} else {
+				die( esc_html__( 'There was a problem of some sort. Try again or contact your administrator.', 'edit-flow' ) );
+			}
 		}
-	}
 
-	/**
-	 * Register settings for editorial comments so we can partially use the Settings API
-	 * (We use the Settings API for form generation, but not saving)
-	 *
-	 * @since 0.7
-	 */
-	function register_settings() {
+		/**
+		 * Register settings for editorial comments so we can partially use the Settings API
+		 * (We use the Settings API for form generation, but not saving)
+		 *
+		 * @since 0.7
+		 */
+		public function register_settings() {
 			add_settings_section( $this->module->options_group_name . '_general', false, '__return_false', $this->module->options_group_name );
 			add_settings_field( 'post_types', __( 'Enable for these post types:', 'edit-flow' ), array( $this, 'settings_post_types_option' ), $this->module->options_group_name, $this->module->options_group_name . '_general' );
-	}
+		}
 
-	/**
-	 * Chose the post types for editorial comments
-	 *
-	 * @since 0.7
-	 */
-	function settings_post_types_option() {
-		global $edit_flow;
-		$edit_flow->settings->helper_option_custom_post_type( $this->module );
-	}
+		/**
+		 * Chose the post types for editorial comments
+		 *
+		 * @since 0.7
+		 */
+		public function settings_post_types_option() {
+			global $edit_flow;
+			$edit_flow->settings->helper_option_custom_post_type( $this->module );
+		}
 
-	/**
-	 * Validate our user input as the settings are being saved
-	 *
-	 * @since 0.7
-	 */
-	function settings_validate( $new_options ) {
+		/**
+		 * Validate our user input as the settings are being saved
+		 *
+		 * @since 0.7
+		 */
+		public function settings_validate( $new_options ) {
 
-		// Whitelist validation for the post type options
-		if ( !isset( $new_options['post_types'] ) )
-			$new_options['post_types'] = array();
-		$new_options['post_types'] = $this->clean_post_type_options( $new_options['post_types'], $this->module->post_type_support );
+			// Whitelist validation for the post type options
+			if ( ! isset( $new_options['post_types'] ) ) {
+				$new_options['post_types'] = array();
+			}
+			$new_options['post_types'] = $this->clean_post_type_options( $new_options['post_types'], $this->module->post_type_support );
 
-		return $new_options;
+			return $new_options;
+		}
 
-	}
+		/**
+		 * Settings page for editorial comments
+		 *
+		 * @since 0.7
+		 */
+		public function print_configure_view() {
+			?>
 
-	/**
-	 * Settings page for editorial comments
-	 *
-	 * @since 0.7
-	 */
-	function print_configure_view() {
-		?>
-
-		<form class="basic-settings" action="<?php echo add_query_arg( 'page', $this->module->settings_slug, get_admin_url( null, 'admin.php' ) ); ?>" method="post">
+		<form class="basic-settings" action="<?php echo esc_url( add_query_arg( 'page', $this->module->settings_slug, get_admin_url( null, 'admin.php' ) ) ); ?>" method="post">
 			<?php settings_fields( $this->module->options_group_name ); ?>
 			<?php do_settings_sections( $this->module->options_group_name ); ?>
 			<?php
 				echo '<input id="edit_flow_module_name" name="edit_flow_module_name" type="hidden" value="' . esc_attr( $this->module->name ) . '" />';
 			?>
-			<p class="submit"><?php submit_button( null, 'primary', 'submit', false ); ?><a class="cancel-settings-link" href="<?php echo EDIT_FLOW_SETTINGS_PAGE; ?>"><?php _e( 'Back to Edit Flow', 'edit-flow' ); ?></a></p>
+			<p class="submit"><?php submit_button( null, 'primary', 'submit', false ); ?><a class="cancel-settings-link" href="<?php echo esc_url( EDIT_FLOW_SETTINGS_PAGE ); ?>"><?php _e( 'Back to Edit Flow', 'edit-flow' ); ?></a></p>
 
 		</form>
-		<?php
+			<?php
+		}
 	}
 
-}
-
-}
-
-/**
- * Deprecated. Used to retrieve a list of comments.
- * Was needed before https://core.trac.wordpress.org/ticket/10668 was available.
- *
- * @param mixed $args Optional. Array or string of options.
- * @return array List of comments.
- */
-function ef_get_comments_plus( $args = '' ) {
-	_deprecated_function( 'ef_get_comments_plus', '1.0', 'get_comments' );
-	return get_comments( $args );
 }

--- a/modules/editorial-comments/editorial-comments.php
+++ b/modules/editorial-comments/editorial-comments.php
@@ -97,7 +97,7 @@ if ( ! class_exists( 'EF_Editorial_Comments' ) ) {
 			$thread_comments = (int) get_option( 'thread_comments' );
 			?>
 		<script type="text/javascript">
-			var ef_thread_comments = <?php echo esc_html( ( $thread_comments ) ? $thread_comments : 0 ); ?>;
+			var ef_thread_comments = <?php echo $thread_comments ? intval( $thread_comments ) : 0; ?>;
 		</script>
 			<?php
 		}
@@ -190,7 +190,7 @@ if ( ! class_exists( 'EF_Editorial_Comments' ) ) {
 
 			<p id="ef-replysubmit">
 				<a class="ef-replysave button-primary alignright" href="#comments-form">
-					<span id="ef-replybtn"><?php _e( 'Submit Response', 'edit-flow' ); ?></span>
+					<span id="ef-replybtn"><?php esc_html_e( 'Submit Response', 'edit-flow' ); ?></span>
 				</a>
 				<a class="ef-replycancel button-secondary alignright" href="#comments-form"><?php _e( 'Cancel', 'edit-flow' ); ?></a>
 				<img alt="Sending comment..." src="<?php echo esc_url( admin_url( '/images/wpspin_light.gif' ) ); ?>" class="alignright" style="display: none;" id="ef-comment_loading" />
@@ -228,8 +228,7 @@ if ( ! class_exists( 'EF_Editorial_Comments' ) ) {
 				$message = '<strong>' . esc_html__( 'Notified', 'edit-flow' ) . ':</strong> ' . esc_html( $notification );
 			}
 
-			// It's already been escaped above.
-			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- It's already been escaped above
 			echo '<p class="ef-notification-meta">' . $message . '</p>';
 		}
 
@@ -242,9 +241,8 @@ if ( ! class_exists( 'EF_Editorial_Comments' ) ) {
 			// Get current user
 			wp_get_current_user();
 
-			// Without this, the comment will not appear.
 			// ToDo: Find an alternative so we don't override global variables
-			// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+			// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Without this, the comment will not appear.
 			$GLOBALS['comment'] = $comment;
 
 			$actions = array();

--- a/modules/editorial-metadata/editorial-metadata.php
+++ b/modules/editorial-metadata/editorial-metadata.php
@@ -293,7 +293,8 @@ if ( ! class_exists( 'EF_Editorial_Metadata' ) ) {
 					$css_rules = apply_filters( 'ef_editorial_metadata_manage_posts_css_rules', $css_rules );
 					echo "<style type=\"text/css\">\n";
 					foreach ( (array) $css_rules as $css_property => $rules ) {
-						echo wp_kses_post( $css_property . ' {' . implode( ' ', $rules ) . "}\n " );
+						// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- This is for the escaping of the CSS property and rules.
+						echo $css_property . ' {' . implode( ' ', $rules ) . "}\n ";
 					}
 					echo '</style>';
 				}
@@ -357,7 +358,7 @@ if ( ! class_exists( 'EF_Editorial_Metadata' ) ) {
 		public function display_meta_box( $post ) {
 			echo "<div id='" . esc_attr( self::metadata_taxonomy ) . "_meta_box'>";
 			// Add nonce for verification upon save
-			echo "<input type='hidden' name='" . esc_attr( self::metadata_taxonomy ) . "_nonce' value='" . esc_js( wp_create_nonce( 'ef-save-metabox' ) ) . "' />";
+			echo "<input type='hidden' name='" . esc_attr( self::metadata_taxonomy ) . "_nonce' value='" . esc_attr( wp_create_nonce( 'ef-save-metabox' ) ) . "' />";
 
 			if ( current_user_can( 'manage_options' ) ) {
 				// Make the metabox title include a link to edit the Editorial Metadata terms. Logic similar to how Core dashboard widgets work.
@@ -386,8 +387,7 @@ if ( ! class_exists( 'EF_Editorial_Metadata' ) ) {
 					} else {
 						$description_span = '';
 					}
-					// This is for the escaping of type.
-					// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+					// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- This is for the escaping of type.
 					echo "<div class='" . esc_attr( self::metadata_taxonomy ) . ' ' . esc_attr( self::metadata_taxonomy ) . "_$type'>";
 					switch ( $type ) {
 						case 'date':
@@ -425,8 +425,7 @@ if ( ! class_exists( 'EF_Editorial_Metadata' ) ) {
 							break;
 						case 'checkbox':
 							echo '<label for="' . esc_attr( $postmeta_key ) . '">' . esc_html( $term->name ) . wp_kses_post( $description_span ) . '</label>';
-							$checked = checked( $current_metadata, 1, false );
-							echo '<input id="' . esc_attr( $postmeta_key ) . '" name="' . esc_attr( $postmeta_key ) . '" type=checkbox value=1 "' . wp_kses_post( $checked ) . '" />';
+							echo '<input id="' . esc_attr( $postmeta_key ) . '" name="' . esc_attr( $postmeta_key ) . '" type=checkbox value=1 "' . checked( $current_metadata, 1, false ) . '" />';
 							break;
 						case 'user':
 							echo '<label for="' . esc_attr( $postmeta_key ) . '">' . esc_html( $term->name ) . wp_kses_post( $description_span ) . '</label>';
@@ -1347,8 +1346,8 @@ if ( ! class_exists( 'EF_Editorial_Metadata' ) ) {
 				die();
 			} else {
 				/* Translators: 1: the name of the term that could not be found */
-				$change_error = new WP_Error( 'invalid', wp_kses( sprintf( __( 'Could not update the term: <strong>%s</strong>', 'edit-flow' ), $metadata_name ), 'strong' ) );
-				die( esc_html( $change_error->get_error_message() ) );
+				$change_error = new WP_Error( 'invalid', sprintf( __( 'Could not update the term: <strong>%s</strong>', 'edit-flow' ), $metadata_name ) );
+				die( wp_kses( $change_error->get_error_message() ) );
 			}
 		}
 
@@ -1583,27 +1582,18 @@ if ( ! class_exists( 'EF_Editorial_Metadata' ) ) {
 			<div class="col-wrap">
 			<div class="form-wrap">
 			<h3 class="nav-tab-wrapper">
-				<a href="<?php echo esc_url( add_query_arg( array( 'page' => $this->module->settings_slug ), get_admin_url( null, 'admin.php' ) ) ); ?>" class="nav-tab
-									<?php
-									if ( ! isset( $_GET['action'] ) || 'change-options' != $_GET['action'] ) {
-										echo ' nav-tab-active';}
-									?>
-				"><?php _e( 'Add New', 'edit-flow' ); ?></a>
-				<a href="
-				<?php
-				echo esc_url( add_query_arg( array(
-					'page' => $this->module->settings_slug,
-					'action' => 'change-options',
-				), get_admin_url( null, 'admin.php' ) ) );
-				?>
-							" class="nav-tab
-							<?php
-							if ( isset( $_GET['action'] ) && 'change-options' == $_GET['action'] ) {
-														echo ' nav-tab-active';}
-							?>
-"><?php _e( 'Options', 'edit-flow' ); ?></a>
+					<?php $add_new_nav_class = ! isset( $_GET['action'] ) || 'change-options' != $_GET['action'] ? 'nav-tab-active' : ''; ?>
+					<a href="<?php echo esc_url( add_query_arg( array( 'page' => $this->module->settings_slug ), get_admin_url( null, 'admin.php' ) ) ); ?>" class="nav-tab <?php echo esc_attr( $add_new_nav_class ); ?>"><?php esc_html_e( 'Add New', 'edit-flow' ); ?></a>
+					<?php $options_nav_class = isset( $_GET['action'] ) && 'change-options' == $_GET['action'] ? 'nav-tab-active' : ''; ?>
+					<a href="
+					<?php
+					echo esc_url( add_query_arg( array(
+						'page' => $this->module->settings_slug,
+						'action' => 'change-options',
+					), get_admin_url( null, 'admin.php' ) ) );
+					?>
+								" class="nav-tab <?php echo esc_attr( $options_nav_class ); ?>"><?php esc_html_e( 'Options', 'edit-flow' ); ?></a>
 			</h3>
-
 			<?php if ( isset( $_GET['action'] ) && 'change-options' == $_GET['action'] ) : ?>
 				<?php /** Basic form built on WP Settings API for outputting Editorial Metadata options **/ ?>
 		<form class="basic-settings" action="
@@ -1624,17 +1614,17 @@ if ( ! class_exists( 'EF_Editorial_Metadata' ) ) {
 			<form class="add:the-list:" action="<?php echo esc_url( add_query_arg( array( 'page' => $this->module->settings_slug ), get_admin_url( null, 'admin.php' ) ) ); ?>" method="post" id="addmetadata" name="addmetadata">
 			<div class="form-field form-required">
 				<label for="metadata_name"><?php _e( 'Name', 'edit-flow' ); ?></label>
-				<input type="text" aria-required="true" size="20" maxlength="200" id="metadata_name" name="metadata_name" value="<?php /* phpcs:ignore Generic.ControlStructures.InlineControlStructure.NotAllowed */ if ( ! empty( $_POST['metadata_name'] ) ) echo esc_attr( $_POST['metadata_name'] ); ?>" />
+				<input type="text" aria-required="true" size="20" maxlength="200" id="metadata_name" name="metadata_name" value="<?php echo ( empty( $_POST['metadata_name'] ) ? '' : esc_attr( $_POST['metadata_name'] ) ); ?>" />
 				<?php $edit_flow->settings->helper_print_error_or_description( 'name', __( 'The name is for labeling the metadata field.', 'edit-flow' ) ); ?>
 			</div>
 			<div class="form-field form-required">
 				<label for="metadata_slug"><?php _e( 'Slug', 'edit-flow' ); ?></label>
-				<input type="text" aria-required="true" size="20" maxlength="200" id="metadata_slug" name="metadata_slug" value="<?php /* phpcs:ignore Generic.ControlStructures.InlineControlStructure.NotAllowed */ if ( ! empty( $_POST['metadata_slug'] ) ) echo esc_attr( $_POST['metadata_slug'] ); ?>" />
+				<input type="text" aria-required="true" size="20" maxlength="200" id="metadata_slug" name="metadata_slug" value="<?php echo ( empty( $_POST['metadata_slug'] ) ? '' : esc_attr( $_POST['metadata_slug'] ) ); ?>" />
 				<?php $edit_flow->settings->helper_print_error_or_description( 'slug', __( 'The "slug" is the URL-friendly version of the name. It is usually all lowercase and contains only letters, numbers, and hyphens.', 'edit-flow' ) ); ?>
 			</div>
 			<div class="form-field">
 				<label for="metadata_description"><?php _e( 'Description', 'edit-flow' ); ?></label>
-				<textarea cols="40" rows="5" id="metadata_description" name="metadata_description"><?php /* phpcs:ignore Generic.ControlStructures.InlineControlStructure.NotAllowed */ if ( ! empty( $_POST['metadata_description'] ) ) echo esc_textarea( $_POST['metadata_description'] ); ?></textarea>
+				<textarea cols="40" rows="5" id="metadata_description" name="metadata_description"><?php echo ( empty( $_POST['metadata_description'] ) ? '' : esc_attr( $_POST['metadata_description'] ) ); ?></textarea>
 				<?php $edit_flow->settings->helper_print_error_or_description( 'description', __( 'The description can be used to communicate with your team about what the metadata is for.', 'edit-flow' ) ); ?>
 			</div>
 			<div class="form-field form-required">

--- a/modules/editorial-metadata/editorial-metadata.php
+++ b/modules/editorial-metadata/editorial-metadata.php
@@ -14,311 +14,312 @@
  * 6) Clear the metadata for a single term in a post and watch the count go down!
  * 6) Delete a term and note the metadata disappears from posts
  * 7) Re-add the term (same slug) and the metadata returns!
- * 
+ *
  * Improvements to make:
  * @todo Abstract the permissions check for management to class level
  */
-if ( !class_exists('EF_Editorial_Metadata') ) {
+if ( ! class_exists( 'EF_Editorial_Metadata' ) ) {
 
-class EF_Editorial_Metadata extends EF_Module {
+	class EF_Editorial_Metadata extends EF_Module {
 
-	/**
-	 * The name of the taxonomy we're going to register for editorial metadata.
-	 */
-	const metadata_taxonomy = 'ef_editorial_meta';
-	const metadata_postmeta_key = "_ef_editorial_meta";
-	
-	var $module_name = 'editorial_metadata';
+		/**
+		 * The name of the taxonomy we're going to register for editorial metadata.
+		 */
+		// phpcs:ignore Generic.NamingConventions.UpperCaseConstantName.ClassConstantNotUpperCase
+		const metadata_taxonomy = 'ef_editorial_meta';
+		// phpcs:ignore Generic.NamingConventions.UpperCaseConstantName.ClassConstantNotUpperCase
+		const metadata_postmeta_key = '_ef_editorial_meta';
 
-	private $editorial_metadata_terms_cache = array();
-	
-	/**
-	 * Construct the EF_Editorial_Metadata class
-	 */
-	function __construct() {
-		
-		$this->module_url = $this->get_module_url( __FILE__ );
-		// Register the module with Edit Flow
-		$args = array(
-			'title' => __( 'Editorial Metadata', 'edit-flow' ),
-			'short_description' => __( 'Track details about your posts in progress.', 'edit-flow' ),
-			'extended_description' => __( 'Log details on every assignment using configurable editorial metadata. It’s completely customizable; create fields for everything from due date to location to contact information to role assignments.', 'edit-flow' ),
-			'module_url' => $this->module_url,
-			'img_url' => $this->module_url . 'lib/editorial_metadata_s128.png',
-			'slug' => 'editorial-metadata',
-			'default_options' => array(
-				'enabled' => 'on',
-				'post_types' => array(
-					'post' => 'on',
-					'page' => 'off',
+		public $module_name = 'editorial_metadata';
+
+		private $editorial_metadata_terms_cache = array();
+
+		/**
+		 * Construct the EF_Editorial_Metadata class
+		 */
+		public function __construct() {
+
+			$this->module_url = $this->get_module_url( __FILE__ );
+			// Register the module with Edit Flow
+			$args = array(
+				'title' => __( 'Editorial Metadata', 'edit-flow' ),
+				'short_description' => __( 'Track details about your posts in progress.', 'edit-flow' ),
+				'extended_description' => __( 'Log details on every assignment using configurable editorial metadata. It’s completely customizable; create fields for everything from due date to location to contact information to role assignments.', 'edit-flow' ),
+				'module_url' => $this->module_url,
+				'img_url' => $this->module_url . 'lib/editorial_metadata_s128.png',
+				'slug' => 'editorial-metadata',
+				'default_options' => array(
+					'enabled' => 'on',
+					'post_types' => array(
+						'post' => 'on',
+						'page' => 'off',
+					),
 				),
-			),
-			'messages' => array(
-				'term-added' => __( "Metadata term added.", 'edit-flow' ),
-				'term-updated' => __( "Metadata term updated.", 'edit-flow' ),
-				'term-missing' => __( "Metadata term doesn't exist.", 'edit-flow' ),
-				'term-deleted' => __( "Metadata term deleted.", 'edit-flow' ),
-				'term-position-updated' => __( "Term order updated.", 'edit-flow' ),
-				'term-visibility-changed' => __( "Term visibility changed.", 'edit-flow' ),
-			),
-			'configure_page_cb' => 'print_configure_view',
-			'settings_help_tab' => array(
-				'id' => 'ef-editorial-metadata-overview',
-				'title' => __('Overview', 'edit-flow'),
-				'content' => __('<p>Keep track of important details about your content with editorial metadata. This feature allows you to create as many date, text, number, etc. fields as you like, and then use them to store information like contact details, required word count, or the location of an interview.</p><p>Once you’ve set your fields up, editorial metadata integrates with both the calendar and the story budget. Make an editorial metadata item visible to have it appear to the rest of your team. Keep it hidden to restrict the information between the writer and their editor.</p>', 'edit-flow'),
+				'messages' => array(
+					'term-added' => __( 'Metadata term added.', 'edit-flow' ),
+					'term-updated' => __( 'Metadata term updated.', 'edit-flow' ),
+					'term-missing' => __( "Metadata term doesn't exist.", 'edit-flow' ),
+					'term-deleted' => __( 'Metadata term deleted.', 'edit-flow' ),
+					'term-position-updated' => __( 'Term order updated.', 'edit-flow' ),
+					'term-visibility-changed' => __( 'Term visibility changed.', 'edit-flow' ),
 				),
-			'settings_help_sidebar' => __( '<p><strong>For more information:</strong></p><p><a href="http://editflow.org/features/editorial-metadata/">Editorial Metadata Documentation</a></p><p><a href="http://wordpress.org/tags/edit-flow?forum_id=10">Edit Flow Forum</a></p><p><a href="https://github.com/danielbachhuber/Edit-Flow">Edit Flow on Github</a></p>', 'edit-flow' ),
-		);
-		EditFlow()->register_module( $this->module_name, $args );
-	}
-	
-	/**
-	 * Initialize the module. Conditionally loads if the module is enabled
-	 */
-	function init() {
-		
-		// Register the taxonomy we use for Editorial Metadata with WordPress core
-		$this->register_taxonomy();
-
-		// Anything that needs to happen in the admin
-		add_action( 'admin_init', array( $this, 'action_admin_init' ) );
-		
-		// Register our settings
-		add_action( 'admin_init', array( $this, 'register_settings' ) );		
-		
-		// Actions relevant to the configuration view (adding, editing, or sorting existing Editorial Metadata)
-		add_action( 'admin_init', array( $this, 'handle_add_editorial_metadata' ) );
-		add_action( 'admin_init', array( $this, 'handle_edit_editorial_metadata' ) );
-		add_action( 'admin_init', array( $this, 'handle_change_editorial_metadata_visibility' ) );	
-		add_action( 'admin_init', array( $this, 'handle_delete_editorial_metadata' ) );
-		add_action( 'wp_ajax_inline_save_term', array( $this, 'handle_ajax_inline_save_term' ) );
-		add_action( 'wp_ajax_update_term_positions', array( $this, 'handle_ajax_update_term_positions' ) );
-		
-		add_action( 'add_meta_boxes', array( $this, 'handle_post_metaboxes' ) );
-		add_action( 'save_post', array( $this, 'save_meta_box' ), 10, 2 );
-		
-		// Add Editorial Metadata columns to the Manage Posts view
-		$supported_post_types = $this->get_post_types_for_module( $this->module );
-		foreach( $supported_post_types as $post_type ) {
-			add_filter( "manage_{$post_type}_posts_columns", array( $this, 'filter_manage_posts_columns' ) );
-			add_action( "manage_{$post_type}_posts_custom_column", array( $this, 'action_manage_posts_custom_column' ), 10, 2 );
+				'configure_page_cb' => 'print_configure_view',
+				'settings_help_tab' => array(
+					'id' => 'ef-editorial-metadata-overview',
+					'title' => __( 'Overview', 'edit-flow' ),
+					'content' => __( '<p>Keep track of important details about your content with editorial metadata. This feature allows you to create as many date, text, number, etc. fields as you like, and then use them to store information like contact details, required word count, or the location of an interview.</p><p>Once you’ve set your fields up, editorial metadata integrates with both the calendar and the story budget. Make an editorial metadata item visible to have it appear to the rest of your team. Keep it hidden to restrict the information between the writer and their editor.</p>', 'edit-flow' ),
+				),
+				'settings_help_sidebar' => __( '<p><strong>For more information:</strong></p><p><a href="http://editflow.org/features/editorial-metadata/">Editorial Metadata Documentation</a></p><p><a href="http://wordpress.org/tags/edit-flow?forum_id=10">Edit Flow Forum</a></p><p><a href="https://github.com/danielbachhuber/Edit-Flow">Edit Flow on Github</a></p>', 'edit-flow' ),
+			);
+			EditFlow()->register_module( $this->module_name, $args );
 		}
-		
-		// Add Editorial Metadata to the calendar if the calendar is activated
-		if ( $this->module_enabled( 'calendar' ) )
-			add_filter( 'ef_calendar_item_information_fields', array( $this, 'filter_calendar_item_fields' ), 10, 2 );
-		
-		// Add Editorial Metadata columns to the Story Budget if it exists
-		if ( $this->module_enabled( 'story_budget' ) ) {
-			add_filter( 'ef_story_budget_term_columns', array( $this, 'filter_story_budget_term_columns' ) );
-			// Register an action to handle this data later
-			add_filter( 'ef_story_budget_term_column_value', array( $this, 'filter_story_budget_term_column_values' ), 10, 3 );
-		}		
-		
-		// Load necessary scripts and stylesheets
-		add_action( 'admin_enqueue_scripts', array( $this, 'add_admin_scripts' ) );	
-		
-	}
-	
-	/**
-	 * Load default editorial metadata the first time the module is loaded
-	 *
-	 * @since 0.7
-	 */
-	function install() {
-		// Our default metadata fields
-		$default_metadata = array(
-			array(
-				'name' => __( 'First Draft Date', 'edit-flow' ),
-				'slug' => 'first-draft-date',
-				'type' => 'date',
-				'description' => __( 'When the first draft needs to be ready.', 'edit-flow' ),
-			),
-			array(
-				'name' => __( 'Assignment', 'edit-flow' ),
-				'slug' => 'assignment',
-				'type' => 'paragraph',
-				'description' => __( 'What the post needs to cover.', 'edit-flow' ),
-			),
-			array(
-				'name' => __( 'Needs Photo', 'edit-flow' ),
-				'slug' => 'needs-photo',
-				'type' => 'checkbox',
-				'description' => __( 'Checked if this post needs a photo.', 'edit-flow' ),
-			),
-			array(
-				'name' => __( 'Word Count', 'edit-flow' ),
-				'slug' => 'word-count',
-				'type' => 'number',
-				'description' => __( 'Required post length in words.', 'edit-flow' ),
-			),
-		);
-		// Load the metadata fields if the slugs don't conflict
-		foreach ( $default_metadata as $args ) {
-			if ( !term_exists( $args['slug'], self::metadata_taxonomy ) ) {
-				$this->insert_editorial_metadata_term( $args );
+
+		/**
+		 * Initialize the module. Conditionally loads if the module is enabled
+		 */
+		public function init() {
+
+			// Register the taxonomy we use for Editorial Metadata with WordPress core
+			$this->register_taxonomy();
+
+			// Anything that needs to happen in the admin
+			add_action( 'admin_init', array( $this, 'action_admin_init' ) );
+
+			// Register our settings
+			add_action( 'admin_init', array( $this, 'register_settings' ) );
+
+			// Actions relevant to the configuration view (adding, editing, or sorting existing Editorial Metadata)
+			add_action( 'admin_init', array( $this, 'handle_add_editorial_metadata' ) );
+			add_action( 'admin_init', array( $this, 'handle_edit_editorial_metadata' ) );
+			add_action( 'admin_init', array( $this, 'handle_change_editorial_metadata_visibility' ) );
+			add_action( 'admin_init', array( $this, 'handle_delete_editorial_metadata' ) );
+			add_action( 'wp_ajax_inline_save_term', array( $this, 'handle_ajax_inline_save_term' ) );
+			add_action( 'wp_ajax_update_term_positions', array( $this, 'handle_ajax_update_term_positions' ) );
+
+			add_action( 'add_meta_boxes', array( $this, 'handle_post_metaboxes' ) );
+			add_action( 'save_post', array( $this, 'save_meta_box' ), 10, 2 );
+
+			// Add Editorial Metadata columns to the Manage Posts view
+			$supported_post_types = $this->get_post_types_for_module( $this->module );
+			foreach ( $supported_post_types as $post_type ) {
+				add_filter( "manage_{$post_type}_posts_columns", array( $this, 'filter_manage_posts_columns' ) );
+				add_action( "manage_{$post_type}_posts_custom_column", array( $this, 'action_manage_posts_custom_column' ), 10, 2 );
+			}
+
+			// Add Editorial Metadata to the calendar if the calendar is activated
+			if ( $this->module_enabled( 'calendar' ) ) {
+				add_filter( 'ef_calendar_item_information_fields', array( $this, 'filter_calendar_item_fields' ), 10, 2 );
+			}
+
+			// Add Editorial Metadata columns to the Story Budget if it exists
+			if ( $this->module_enabled( 'story_budget' ) ) {
+				add_filter( 'ef_story_budget_term_columns', array( $this, 'filter_story_budget_term_columns' ) );
+				// Register an action to handle this data later
+				add_filter( 'ef_story_budget_term_column_value', array( $this, 'filter_story_budget_term_column_values' ), 10, 3 );
+			}
+
+			// Load necessary scripts and stylesheets
+			add_action( 'admin_enqueue_scripts', array( $this, 'add_admin_scripts' ) );
+		}
+
+		/**
+		 * Load default editorial metadata the first time the module is loaded
+		 *
+		 * @since 0.7
+		 */
+		public function install() {
+			// Our default metadata fields
+			$default_metadata = array(
+				array(
+					'name' => __( 'First Draft Date', 'edit-flow' ),
+					'slug' => 'first-draft-date',
+					'type' => 'date',
+					'description' => __( 'When the first draft needs to be ready.', 'edit-flow' ),
+				),
+				array(
+					'name' => __( 'Assignment', 'edit-flow' ),
+					'slug' => 'assignment',
+					'type' => 'paragraph',
+					'description' => __( 'What the post needs to cover.', 'edit-flow' ),
+				),
+				array(
+					'name' => __( 'Needs Photo', 'edit-flow' ),
+					'slug' => 'needs-photo',
+					'type' => 'checkbox',
+					'description' => __( 'Checked if this post needs a photo.', 'edit-flow' ),
+				),
+				array(
+					'name' => __( 'Word Count', 'edit-flow' ),
+					'slug' => 'word-count',
+					'type' => 'number',
+					'description' => __( 'Required post length in words.', 'edit-flow' ),
+				),
+			);
+			// Load the metadata fields if the slugs don't conflict
+			foreach ( $default_metadata as $args ) {
+				if ( ! term_exists( $args['slug'], self::metadata_taxonomy ) ) {
+					$this->insert_editorial_metadata_term( $args );
+				}
 			}
 		}
-	}
 
-	/**
-	 * Upgrade our data in case we need to
-	 *
-	 * @since 0.7
-	 */
-	function upgrade( $previous_version ) {
-		global $edit_flow;
+		/**
+		 * Upgrade our data in case we need to
+		 *
+		 * @since 0.7
+		 */
+		public function upgrade( $previous_version ) {
+			global $edit_flow;
 
-		// Upgrade path to v0.7
-		if ( version_compare( $previous_version, '0.7' , '<' ) ) {
-			// Technically we've run this code before so we don't want to auto-install new data
-			$edit_flow->update_module_option( $this->module->name, 'loaded_once', true );
+			// Upgrade path to v0.7
+			if ( version_compare( $previous_version, '0.7', '<' ) ) {
+				// Technically we've run this code before so we don't want to auto-install new data
+				$edit_flow->update_module_option( $this->module->name, 'loaded_once', true );
+			}
+			// Upgrade path to v0.7.4
+			if ( version_compare( $previous_version, '0.7.4', '<' ) ) {
+				// Editorial metadata descriptions become base64_encoded, instead of maybe json_encoded.
+				$this->upgrade_074_term_descriptions( self::metadata_taxonomy );
+			}
 		}
-		// Upgrade path to v0.7.4
-		if ( version_compare( $previous_version, '0.7.4', '<' ) ) {
-			// Editorial metadata descriptions become base64_encoded, instead of maybe json_encoded.
-			$this->upgrade_074_term_descriptions( self::metadata_taxonomy );
+
+		/**
+		 * Anything that needs to happen on the 'admin_init' hook
+		 *
+		 * @since 0.7.4
+		 */
+		public function action_admin_init() {
+
+			// Parse the query when we're ordering by an editorial metadata term
+			add_action( 'parse_query', array( $this, 'action_parse_query' ) );
 		}
-		
-	}
 
-	/**
-	 * Anything that needs to happen on the 'admin_init' hook
-	 *
-	 * @since 0.7.4
-	 */
-	function action_admin_init() {
-
-		// Parse the query when we're ordering by an editorial metadata term
-		add_action( 'parse_query', array( $this, 'action_parse_query' ) );
-	}
-	
-	/**
-	 * Generate <select> HTML for all of the metadata types
-	 */
-	function get_select_html( $description ) {
-		$current_metadata_type = $description->type;
-		$metadata_types = $this->get_supported_metadata_types();
-		?>
-		<select id="<?php echo self::metadata_taxonomy; ?>'_type" name="<?php echo self::metadata_taxonomy; ?>'_type">
-		<?php foreach ( $metadata_types as $metadata_type => $metadata_type_name ) : ?>
-			<option value="<?php echo $metadata_type; ?>" <?php selected( $metadata_type, $current_metadata_type ); ?>><?php echo $metadata_type_name; ?></option>
+		/**
+		 * Generate <select> HTML for all of the metadata types
+		 */
+		public function get_select_html( $description ) {
+			$current_metadata_type = $description->type;
+			$metadata_types = $this->get_supported_metadata_types();
+			?>
+		<select id="<?php echo esc_attr( self::metadata_taxonomy ); ?>'_type" name="<?php echo esc_attr( self::metadata_taxonomy ); ?>'_type">
+			<?php foreach ( $metadata_types as $metadata_type => $metadata_type_name ) : ?>
+			<option value="<?php echo esc_attr( $metadata_type ); ?>" <?php selected( $metadata_type, $current_metadata_type ); ?>><?php echo esc_html( $metadata_type_name ); ?></option>
 		<?php endforeach; ?>
 		</select>
-	<?php
-	}
-	
-	/**
-	 * Prepare an array of supported editorial metadata types
-	 *
-	 * @return array $supported_metadata_types All of the supported metadata
-	 */
-	function get_supported_metadata_types() {
-		$supported_metadata_types = array(
-			'checkbox'		=> __('Checkbox', 'edit-flow'),
-			'date'			=> __('Date', 'edit-flow'),
-			'location'		=> __('Location', 'edit-flow'),
-			'number'		=> __('Number', 'edit-flow'),
-			'paragraph'		=> __('Paragraph', 'edit-flow'),
-			'text'			=> __('Text', 'edit-flow'),
-			'user'			=> __('User', 'edit-flow'),
-		);
-		return $supported_metadata_types;
-	}
-	
-	/**
-	 * Enqueue relevant admin Javascript
-	 */ 
-	function add_admin_scripts() {
-		global $current_screen, $pagenow;
-		
-		// Add the metabox date picker JS and CSS
-		$current_post_type = $this->get_current_post_type();
-		$supported_post_types = $this->get_post_types_for_module( $this->module );
-		if ( in_array( $current_post_type, $supported_post_types ) ) {
-			$this->enqueue_datepicker_resources();
-
-			// Now add the rest of the metabox CSS
-			wp_enqueue_style( 'edit_flow-editorial_metadata-styles', $this->module_url . 'lib/editorial-metadata.css', false, EDIT_FLOW_VERSION, 'all' );
+			<?php
 		}
-		// A bit of custom CSS for the Manage Posts view if we have viewable metadata
-		if ( $current_screen->base == 'edit' && in_array( $current_post_type, $supported_post_types ) ) {
-			$terms = $this->get_editorial_metadata_terms();
-			$viewable_terms = array();
-			foreach( $terms as $term ) {
-				if ( $term->viewable ) 
-					$viewable_terms[] = $term;
+
+		/**
+		 * Prepare an array of supported editorial metadata types
+		 *
+		 * @return array $supported_metadata_types All of the supported metadata
+		 */
+		public function get_supported_metadata_types() {
+			$supported_metadata_types = array(
+				'checkbox'      => __( 'Checkbox', 'edit-flow' ),
+				'date'          => __( 'Date', 'edit-flow' ),
+				'location'      => __( 'Location', 'edit-flow' ),
+				'number'        => __( 'Number', 'edit-flow' ),
+				'paragraph'     => __( 'Paragraph', 'edit-flow' ),
+				'text'          => __( 'Text', 'edit-flow' ),
+				'user'          => __( 'User', 'edit-flow' ),
+			);
+			return $supported_metadata_types;
+		}
+
+		/**
+		 * Enqueue relevant admin Javascript
+		 */
+		public function add_admin_scripts() {
+			global $current_screen, $pagenow;
+
+			// Add the metabox date picker JS and CSS
+			$current_post_type = $this->get_current_post_type();
+			$supported_post_types = $this->get_post_types_for_module( $this->module );
+			if ( in_array( $current_post_type, $supported_post_types ) ) {
+				$this->enqueue_datepicker_resources();
+
+				// Now add the rest of the metabox CSS
+				wp_enqueue_style( 'edit_flow-editorial_metadata-styles', $this->module_url . 'lib/editorial-metadata.css', false, EDIT_FLOW_VERSION, 'all' );
 			}
-			if ( !empty( $viewable_terms ) ) {
-				$css_rules = array(
-					'.wp-list-table.fixed .column-author' => array(
-						'min-width: 7em;',
-						'width: auto;',
-					),
-					'.wp-list-table.fixed .column-tags' => array(
-						'min-width: 7em;',
-						'width: auto;',
-					),
-					'.wp-list-table.fixed .column-categories' => array(
-						'min-width: 7em;',
-						'width: auto;',
-					),
-				);
-				foreach( $viewable_terms as $viewable_term ) {
-					switch( $viewable_term->type ) {
-						case 'checkbox':
-						case 'number':
-						case 'date':
-							$css_rules['.wp-list-table.fixed .column-' . $this->module->slug . '-' . $viewable_term->slug] = array(
-								'min-width: 6em;',
-							);
-							break;
-						case 'location':
-						case 'text':
-						case 'user':
-							$css_rules['.wp-list-table.fixed .column-' . $this->module->slug . '-' . $viewable_term->slug] = array(
-								'min-width: 7em;',
-							);
-							break;
-						case 'paragraph':
-							$css_rules['.wp-list-table.fixed .column-' . $this->module->slug . '-' . $viewable_term->slug] = array(
-								'min-width: 8em;',
-							);
-							break;
+			// A bit of custom CSS for the Manage Posts view if we have viewable metadata
+			if ( 'edit' == $current_screen->base && in_array( $current_post_type, $supported_post_types ) ) {
+				$terms = $this->get_editorial_metadata_terms();
+				$viewable_terms = array();
+				foreach ( $terms as $term ) {
+					if ( $term->viewable ) {
+						$viewable_terms[] = $term;
 					}
 				}
-				// Allow users to filter out rules if there's something wonky
-				$css_rules = apply_filters( 'ef_editorial_metadata_manage_posts_css_rules', $css_rules );
-				echo "<style type=\"text/css\">\n";
-				foreach( (array)$css_rules as $css_property => $rules ) {
-					echo $css_property . " {" . implode( ' ', $rules ) . "}\n";
+				if ( ! empty( $viewable_terms ) ) {
+					$css_rules = array(
+						'.wp-list-table.fixed .column-author' => array(
+							'min-width: 7em;',
+							'width: auto;',
+						),
+						'.wp-list-table.fixed .column-tags' => array(
+							'min-width: 7em;',
+							'width: auto;',
+						),
+						'.wp-list-table.fixed .column-categories' => array(
+							'min-width: 7em;',
+							'width: auto;',
+						),
+					);
+					foreach ( $viewable_terms as $viewable_term ) {
+						switch ( $viewable_term->type ) {
+							case 'checkbox':
+							case 'number':
+							case 'date':
+								$css_rules[ '.wp-list-table.fixed .column-' . $this->module->slug . '-' . $viewable_term->slug ] = array(
+									'min-width: 6em;',
+								);
+								break;
+							case 'location':
+							case 'text':
+							case 'user':
+								$css_rules[ '.wp-list-table.fixed .column-' . $this->module->slug . '-' . $viewable_term->slug ] = array(
+									'min-width: 7em;',
+								);
+								break;
+							case 'paragraph':
+								$css_rules[ '.wp-list-table.fixed .column-' . $this->module->slug . '-' . $viewable_term->slug ] = array(
+									'min-width: 8em;',
+								);
+								break;
+						}
+					}
+					// Allow users to filter out rules if there's something wonky
+					$css_rules = apply_filters( 'ef_editorial_metadata_manage_posts_css_rules', $css_rules );
+					echo "<style type=\"text/css\">\n";
+					foreach ( (array) $css_rules as $css_property => $rules ) {
+						echo wp_kses_post( $css_property . ' {' . implode( ' ', $rules ) . "}\n " );
+					}
+					echo '</style>';
 				}
-				echo '</style>';
 			}
-			
-		}
-		
-		// Load Javascript specific to the editorial metadata configuration view
-		if ( $this->is_whitelisted_settings_view( $this->module->name ) ) {
-			wp_enqueue_script( 'jquery-ui-sortable' );			
-			wp_enqueue_script( 'edit-flow-editorial-metadata-configure', EDIT_FLOW_URL . 'modules/editorial-metadata/lib/editorial-metadata-configure.js', array( 'jquery', 'jquery-ui-sortable', 'edit-flow-settings-js' ), EDIT_FLOW_VERSION, true );
-		}
-	}
-	
-	/**
-	 * Register the post metadata taxonomy
-	 */
-	function register_taxonomy() {
 
-		// We need to make sure taxonomy is registered for all of the post types that support it
-		$supported_post_types = $this->get_post_types_for_module( $this->module );
-	
-		register_taxonomy( self::metadata_taxonomy, $supported_post_types,
-			array(
-				'public' => false,
-				'labels' => array(
-					'name' => _x( 'Editorial Metadata', 'taxonomy general name', 'edit-flow' ),
-					'singular_name' => _x( 'Editorial Metadata', 'taxonomy singular name', 'edit-flow' ),
+			// Load Javascript specific to the editorial metadata configuration view
+			if ( $this->is_whitelisted_settings_view( $this->module->name ) ) {
+				wp_enqueue_script( 'jquery-ui-sortable' );
+				wp_enqueue_script( 'edit-flow-editorial-metadata-configure', EDIT_FLOW_URL . 'modules/editorial-metadata/lib/editorial-metadata-configure.js', array( 'jquery', 'jquery-ui-sortable', 'edit-flow-settings-js' ), EDIT_FLOW_VERSION, true );
+			}
+		}
+
+		/**
+		 * Register the post metadata taxonomy
+		 */
+		public function register_taxonomy() {
+
+			// We need to make sure taxonomy is registered for all of the post types that support it
+			$supported_post_types = $this->get_post_types_for_module( $this->module );
+
+			register_taxonomy( self::metadata_taxonomy, $supported_post_types,
+				array(
+					'public' => false,
+					'labels' => array(
+						'name' => _x( 'Editorial Metadata', 'taxonomy general name', 'edit-flow' ),
+						'singular_name' => _x( 'Editorial Metadata', 'taxonomy singular name', 'edit-flow' ),
 						'search_items' => __( 'Search Editorial Metadata', 'edit-flow' ),
 						'popular_items' => __( 'Popular Editorial Metadata', 'edit-flow' ),
 						'all_items' => __( 'All Editorial Metadata', 'edit-flow' ),
@@ -327,1114 +328,1203 @@ class EF_Editorial_Metadata extends EF_Module {
 						'add_new_item' => __( 'Add New Editorial Metadata', 'edit-flow' ),
 						'new_item_name' => __( 'New Editorial Metadata', 'edit-flow' ),
 					),
-				'rewrite' => false,
-			)
-		);
-	}
-	
-	/*****************************************************
-	 * Post meta box generation and processing
-	 ****************************************************/
-	
-	/**
-	 * Load the post metaboxes for all of the post types that are supported
-	 */
-	function handle_post_metaboxes() {
-		$title = __( 'Editorial Metadata', 'edit-flow' );
-
-		$supported_post_types = $this->get_post_types_for_module( $this->module );
-		foreach ( $supported_post_types as $post_type ) {
-			add_meta_box( self::metadata_taxonomy, $title, array( $this, 'display_meta_box' ), $post_type, 'side' );
+					'rewrite' => false,
+				)
+			);
 		}
-	}
-	
-	/**
-	 * Displays HTML output for Editorial Metadata post meta box
-	 *
-	 * @param object $post Current post
-	 */
-	function display_meta_box( $post ) {
-		echo "<div id='" . self::metadata_taxonomy . "_meta_box'>";
-		// Add nonce for verification upon save
-		echo "<input type='hidden' name='" . self::metadata_taxonomy . "_nonce' value='" . wp_create_nonce( 'ef-save-metabox' ) . "' />";
 
-		if ( current_user_can( 'manage_options' ) ) {
-			// Make the metabox title include a link to edit the Editorial Metadata terms. Logic similar to how Core dashboard widgets work.
-			$url = add_query_arg( 'page', 'ef-editorial-metadata-settings', get_admin_url( null, 'admin.php' ) );
-			echo '<p><a href="'. esc_url( $url ) . '">' . __( 'Configure', 'edit-flow' ) . '</a></p>';
+		/*****************************************************
+		 * Post meta box generation and processing
+		 ****************************************************/
+
+		/**
+		 * Load the post metaboxes for all of the post types that are supported
+		 */
+		public function handle_post_metaboxes() {
+			$title = __( 'Editorial Metadata', 'edit-flow' );
+
+			$supported_post_types = $this->get_post_types_for_module( $this->module );
+			foreach ( $supported_post_types as $post_type ) {
+				add_meta_box( self::metadata_taxonomy, $title, array( $this, 'display_meta_box' ), $post_type, 'side' );
+			}
 		}
-	
-		$terms = $this->get_editorial_metadata_terms();
-		if ( !count( $terms ) ) {
-			$message = __( 'No editorial metadata available.' );
-			if ( current_user_can( 'manage_options' ) )
-				$message .= sprintf( __( ' <a href="%s">Add fields to get started</a>.' ), $this->get_link() );
-			else 
-				$message .= __( ' Encourage your site administrator to configure your editorial workflow by adding editorial metadata.' );
-			echo '<p>' . $message . '</p>';
-		} else {
-			foreach ( $terms as $term ) {
-				$postmeta_key = $this->get_postmeta_key( $term );
-				$current_metadata = esc_attr( $this->get_postmeta_value( $term, $post->ID ) );
-				$type = $term->type;
-				$description = $term->description;
-				if ( $description )
-					$description_span = "<span class='description'>$description</span>";
-				else
-					$description_span = '';
-				echo "<div class='" . self::metadata_taxonomy . " " . self::metadata_taxonomy . "_$type'>";
-				switch( $type ) {
-					case "date":
-						// TODO: Move this to a function
-						if ( !empty( $current_metadata ) ) {
-							// Turn timestamp into a human-readable date
-							$current_metadata = $this->show_date_or_datetime( intval( $current_metadata ) );	
-						}
-						echo "<label for='$postmeta_key'>{$term->name}</label>";
-						if ( $description_span )
-							echo "<label for='$postmeta_key'>$description_span</label>";
-						echo '<input id="' . esc_attr( $postmeta_key ) .'" name="' . esc_attr( $postmeta_key ) . '" type="tex" class="date-time-pick" value="' . esc_attr( $current_metadata ) . '" />';
-						echo '<input type="hidden" id="' . esc_attr( $postmeta_key ) . '_hidden' . '" name="' . esc_attr( $postmeta_key ) . '_hidden' . '" />';
-						break;
-					case "location":
-						echo "<label for='$postmeta_key'>{$term->name}</label>";
-						if ( $description_span )
-							echo "<label for='$postmeta_key'>$description_span</label>";
-						echo "<input id='$postmeta_key' name='$postmeta_key' type='text' value='$current_metadata' />";
-						if ( !empty( $current_metadata ) )
-							echo "<div><a href='http://maps.google.com/?q={$current_metadata}&t=m' target='_blank'>" . sprintf( __( 'View &#8220;%s&#8221; on Google Maps', 'edit-flow' ), $current_metadata ) . "</a></div>";
-						break;
-					case "text":
-						echo "<label for='$postmeta_key'>{$term->name}$description_span</label>";
-						echo "<input id='$postmeta_key' name='$postmeta_key' type='text' value='$current_metadata' />";
-						break;
-					case "paragraph":
-						echo "<label for='$postmeta_key'>{$term->name}$description_span</label>";
-						echo "<textarea id='$postmeta_key' name='$postmeta_key'>$current_metadata</textarea>";
-						break;
-					case "checkbox":
-						echo "<label for='$postmeta_key'>{$term->name}$description_span</label>";
-						echo "<input id='$postmeta_key' name='$postmeta_key' type='checkbox' value='1' " . checked($current_metadata, 1, false) . " />";
-						break;
-					case "user": 
-						echo "<label for='$postmeta_key'>{$term->name}$description_span</label>";
-						$user_dropdown_args = array( 
-								'show_option_all' => __( '-- Select a user --', 'edit-flow' ), 
-								'name'     => $postmeta_key,
-								'selected' => $current_metadata 
-							);
-						$user_dropdown_args = apply_filters( 'ef_editorial_metadata_user_dropdown_args', $user_dropdown_args );
-						wp_dropdown_users( $user_dropdown_args );
-						break;
-					case "number":
-						echo "<label for='$postmeta_key'>{$term->name}$description_span</label>";
-						echo "<input id='$postmeta_key' name='$postmeta_key' type='text' value='$current_metadata' />";
-						break;					
-					default:
-						echo "<p>" . __( 'This editorial metadata type is not yet supported.', 'edit-flow' ) . "</p>";
+
+		/**
+		 * Displays HTML output for Editorial Metadata post meta box
+		 *
+		 * @param object $post Current post
+		 */
+		public function display_meta_box( $post ) {
+			echo "<div id='" . esc_attr( self::metadata_taxonomy ) . "_meta_box'>";
+			// Add nonce for verification upon save
+			echo "<input type='hidden' name='" . esc_attr( self::metadata_taxonomy ) . "_nonce' value='" . esc_js( wp_create_nonce( 'ef-save-metabox' ) ) . "' />";
+
+			if ( current_user_can( 'manage_options' ) ) {
+				// Make the metabox title include a link to edit the Editorial Metadata terms. Logic similar to how Core dashboard widgets work.
+				$url = add_query_arg( 'page', 'ef-editorial-metadata-settings', get_admin_url( null, 'admin.php' ) );
+				echo '<p><a href="' . esc_url( $url ) . '">' . esc_html__( 'Configure', 'edit-flow' ) . '</a></p>';
+			}
+
+			$terms = $this->get_editorial_metadata_terms();
+			if ( ! count( $terms ) ) {
+				$message = __( 'No editorial metadata available.' );
+				if ( current_user_can( 'manage_options' ) ) {
+					/* translators: 1: The link to add editorial metadata fields */
+					$message .= sprintf( __( ' <a href="%s">Add fields to get started</a>.' ), $this->get_link() );
+				} else {
+					$message .= esc_html__( ' Encourage your site administrator to configure your editorial workflow by adding editorial metadata.' );
 				}
-			echo "</div>";
-			echo "<div class='clear'></div>";
-		} // Done iterating through metadata terms
-		}		
-		echo "</div>";
-	}
-	
-	/**
-	 * Show date or datetime
-	 * @param  int $current_date
-	 * @return string
-	 * @since 0.8
-	 */
-	private function show_date_or_datetime( $current_date ) {
-
-		if( date( 'Hi', $current_date ) == '0000')
-			return date_i18n( 'M d Y', $current_date );
-		else
-			return date_i18n( 'M d Y H:i', $current_date );
-	}
-
-	/**
-	 * Save any values in the editorial metadata post meta box
-	 * 
-	 * @param int $id Unique ID for the post being saved
-	 * @param object $post Post object
-	 */
-	function save_meta_box( $id, $post ) {
-
-		// Authentication checks: make sure data came from our meta box and that the current user is allowed to edit the post
-		// TODO: switch to using check_admin_referrer? See core (e.g. edit.php) for usage
-		if ( ! isset( $_POST[self::metadata_taxonomy . "_nonce"] )
-			|| ! wp_verify_nonce( $_POST[self::metadata_taxonomy . "_nonce"], 'ef-save-metabox' ) ) {
-			return $id;
-		}
-		
-		if( ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE )
-			|| ! in_array( $post->post_type, $this->get_post_types_for_module( $this->module ) )
-			|| $post->post_type == 'post' && !current_user_can( 'edit_post', $id )
-			|| $post->post_type == 'page' && !current_user_can( 'edit_page', $id ) ) {
-			return $id;
-		}
-		
-		// Authentication passed, let's save the data		
-		$terms = $this->get_editorial_metadata_terms();
-		$term_slugs = array();
-				
-		foreach ( $terms as $term ) {
-			// Setup the key for this editorial metadata term (same as what's in $_POST)
-			$key = $this->get_postmeta_key( $term );
-			
-			// Get the current editorial metadata
-			// TODO: do we care about the current_metadata at all?
-			//$current_metadata = get_post_meta( $id, $key, true );
-			
-			$new_metadata = isset( $_POST[$key] ) ? $_POST[$key] : '';
-
-			$type = $term->type;
-			if ( empty ( $new_metadata ) ) {
-				delete_post_meta( $id, $key );
+				echo '<p>' . wp_kses( $message, 'a' ) . '</p>';
 			} else {
-
-				// TODO: Move this to a function
-				if ( 'date' === $type ) {
-					$date_to_parse =  isset( $_POST[ $key . '_hidden' ] ) ? $_POST[ $key . '_hidden' ] : '';
-					$date = DateTime::createFromFormat('Y-m-d H:i', $date_to_parse );
-
-					if ( false !== $date ) { 
-						$new_metadata = $date->getTimestamp();
+				foreach ( $terms as $term ) {
+					$postmeta_key = $this->get_postmeta_key( $term );
+					$current_metadata = esc_attr( $this->get_postmeta_value( $term, $post->ID ) );
+					$type = $term->type;
+					$description = $term->description;
+					if ( $description ) {
+						$description_span = "<span class='description'>$description</span>";
 					} else {
-						// Fallback, in case $_POST[ $key . '_hidden' ] was not previosuly set
-						$new_metadata = strtotime( $new_metadata );
+						$description_span = '';
 					}
+					// This is for the escaping of type.
+					// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+					echo "<div class='" . esc_attr( self::metadata_taxonomy ) . ' ' . esc_attr( self::metadata_taxonomy ) . "_$type'>";
+					switch ( $type ) {
+						case 'date':
+							// TODO: Move this to a function
+							if ( ! empty( $current_metadata ) ) {
+								// Turn timestamp into a human-readable date
+								$current_metadata = $this->show_date_or_datetime( intval( $current_metadata ) );
+							}
+							echo '<label for="' . esc_attr( $postmeta_key ) . '">' . esc_html( $term->name ) . '</label>';
+							if ( $description_span ) {
+								echo '<label for="' . esc_attr( $postmeta_key ) . '">' . wp_kses_post( $description_span ) . '</label>';
+							}
+							echo '<input id="' . esc_attr( $postmeta_key ) . '" name="' . esc_attr( $postmeta_key ) . '" type="tex" class="date-time-pick" value="' . esc_attr( $current_metadata ) . '" />';
+							echo '<input type="hidden" id="' . esc_attr( $postmeta_key ) . '_hidden name="' . esc_attr( $postmeta_key ) . '_hidden" />';
+							break;
+						case 'location':
+							echo '<label for="' . esc_attr( $postmeta_key ) . '">' . esc_html( $term->name ) . '</label>';
+							if ( $description_span ) {
+								echo '<label for="' . esc_attr( $postmeta_key ) . '">' . wp_kses_post( $description_span ) . '</label>';
+							}
+							echo '<input id="' . esc_attr( $postmeta_key ) . '" name="' . esc_attr( $postmeta_key ) . '"type=text value="' . esc_attr( $current_metadata ) . '" />';
+							if ( ! empty( $current_metadata ) ) {
+								// translators: %s is the google maps location
+								$google_maps_url = sprintf( esc_html__( 'View &#8220;%s&#8221; on Google Maps', 'edit-flow' ), esc_attr( $current_metadata ) );
+								echo '<div><a href=http://maps.google.com/?q="' . esc_attr( $current_metadata ) . '"&t=m target=_blank>"' . esc_attr( $google_maps_url ) . '"</a></div>';
+							}
+							break;
+						case 'text':
+							echo '<label for="' . esc_attr( $postmeta_key ) . '">' . esc_html( $term->name ) . wp_kses_post( $description_span ) . '</label>';
+							echo '<input id="' . esc_attr( $postmeta_key ) . '" name="' . esc_attr( $postmeta_key ) . '"type=text value="' . esc_attr( $current_metadata ) . '" />';
+							break;
+						case 'paragraph':
+							echo '<label for="' . esc_attr( $postmeta_key ) . '">' . esc_html( $term->name ) . wp_kses_post( $description_span ) . '</label>';
+							echo '<textarea id="' . esc_attr( $postmeta_key ) . '" name="' . esc_attr( $postmeta_key ) . '">' . esc_html( $current_metadata ) . '</textarea>';
+							break;
+						case 'checkbox':
+							echo '<label for="' . esc_attr( $postmeta_key ) . '">' . esc_html( $term->name ) . wp_kses_post( $description_span ) . '</label>';
+							$checked = checked( $current_metadata, 1, false );
+							echo '<input id="' . esc_attr( $postmeta_key ) . '" name="' . esc_attr( $postmeta_key ) . '" type=checkbox value=1 "' . wp_kses_post( $checked ) . '" />';
+							break;
+						case 'user':
+							echo '<label for="' . esc_attr( $postmeta_key ) . '">' . esc_html( $term->name ) . wp_kses_post( $description_span ) . '</label>';
+							$user_dropdown_args = array(
+								'show_option_all' => __( '-- Select a user --', 'edit-flow' ),
+								'name'     => $postmeta_key,
+								'selected' => $current_metadata,
+							);
+							$user_dropdown_args = apply_filters( 'ef_editorial_metadata_user_dropdown_args', $user_dropdown_args );
+							wp_dropdown_users( $user_dropdown_args );
+							break;
+						case 'number':
+							echo '<label for="' . esc_attr( $postmeta_key ) . '">' . esc_html( $term->name ) . wp_kses_post( $description_span ) . '</label>';
+							echo '<input id="' . esc_attr( $postmeta_key ) . '" name="' . esc_attr( $postmeta_key ) . '"type=text value="' . esc_attr( $current_metadata ) . '" />';
+							break;
+						default:
+							echo '<p>' . esc_html__( 'This editorial metadata type is not yet supported.', 'edit-flow' ) . '</p>';
+					}
+					echo '</div>';
+					echo "<div class='clear'></div>";
+				} // Done iterating through metadata terms
+			}
+			echo '</div>';
+		}
+
+		/**
+		 * Show date or datetime
+		 * @param  int $current_date
+		 * @return string
+		 * @since 0.8
+		 */
+		private function show_date_or_datetime( $current_date ) {
+
+			if ( gmdate( 'Hi', $current_date ) == '0000' ) {
+				return date_i18n( 'M d Y', $current_date );
+			} else {
+				return date_i18n( 'M d Y H:i', $current_date );
+			}
+		}
+
+		/**
+		 * Save any values in the editorial metadata post meta box
+		 *
+		 * @param int $id Unique ID for the post being saved
+		 * @param object $post Post object
+		 */
+		public function save_meta_box( $id, $post ) {
+
+			// Authentication checks: make sure data came from our meta box and that the current user is allowed to edit the post
+			// TODO: switch to using check_admin_referrer? See core (e.g. edit.php) for usage
+			if ( ! isset( $_POST[ self::metadata_taxonomy . '_nonce' ] )
+			|| ! wp_verify_nonce( $_POST[ self::metadata_taxonomy . '_nonce' ], 'ef-save-metabox' ) ) {
+				return $id;
+			}
+
+			if ( ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE )
+			|| ! in_array( $post->post_type, $this->get_post_types_for_module( $this->module ) )
+			|| ( 'post' == $post->post_type && ! current_user_can( 'edit_post', $id ) )
+			|| ( 'page' == $post->post_type && ! current_user_can( 'edit_page', $id ) ) ) {
+				return $id;
+			}
+
+			// Authentication passed, let's save the data
+			$terms = $this->get_editorial_metadata_terms();
+			$term_slugs = array();
+
+			foreach ( $terms as $term ) {
+				// Setup the key for this editorial metadata term (same as what's in $_POST)
+				$key = $this->get_postmeta_key( $term );
+
+				// Get the current editorial metadata
+				// TODO: do we care about the current_metadata at all?
+				//$current_metadata = get_post_meta( $id, $key, true );
+
+				$new_metadata = isset( $_POST[ $key ] ) ? $_POST[ $key ] : '';
+
+				$type = $term->type;
+				if ( empty( $new_metadata ) ) {
+					delete_post_meta( $id, $key );
+				} else {
+
+					// TODO: Move this to a function
+					if ( 'date' === $type ) {
+						$date_to_parse = isset( $_POST[ $key . '_hidden' ] ) ? $_POST[ $key . '_hidden' ] : '';
+						$date = DateTime::createFromFormat( 'Y-m-d H:i', $date_to_parse );
+
+						if ( false !== $date ) {
+							$new_metadata = $date->getTimestamp();
+						} else {
+							// Fallback, in case $_POST[ $key . '_hidden' ] was not previosuly set
+							$new_metadata = strtotime( $new_metadata );
+						}
+					}
+					if ( 'number' === $type ) {
+						$new_metadata = (int) $new_metadata;
+					}
+
+					$new_metadata = strip_tags( $new_metadata );
+					update_post_meta( $id, $key, $new_metadata );
+
+					// Add the slugs of the terms with non-empty new metadata to an array
+					$term_slugs[] = $term->slug;
 				}
-				if ( 'number' === $type ) {
-					$new_metadata = (int)$new_metadata;
+				do_action( 'ef_editorial_metadata_field_updated', $key, $new_metadata, $id, $type );
+			}
+
+			// Relate the post to the terms used and taxonomy type (wp_term_relationships table).
+			// This will allow us to update and display the count of metadata in posts in use per term.
+			// TODO: Core only correlates posts with terms if the post_status is publish. Do we care what it is?
+			if ( 'publish' === $post->post_status ) {
+				wp_set_object_terms( $id, $term_slugs, self::metadata_taxonomy );
+			}
+		}
+
+		/**
+		 * Generate a unique key based on the term
+		 *
+		 * @param object $term Term object
+		 * @return string $postmeta_key Unique key
+		 */
+		public function get_postmeta_key( $term ) {
+			$key = self::metadata_postmeta_key;
+			$type = $term->type;
+			$prefix = "{$key}_{$type}";
+			$postmeta_key = "{$prefix}_" . ( is_object( $term ) ? $term->slug : $term );
+			return $postmeta_key;
+		}
+
+		/**
+		 * Returns the value for the given metadata
+		 *
+		 * @param object|string|int term The term object, slug or ID for the metadata field term
+		 * @param int post_id The ID of the post
+		 */
+		public function get_postmeta_value( $term, $post_id ) {
+			if ( ! is_object( $term ) ) {
+				if ( is_int( $term ) ) {
+					$term = $this->get_editorial_metadata_term_by( 'id', $term );
+				} else {
+					$term = $this->get_editorial_metadata_term_by( 'slug', $term );
 				}
-				
-				$new_metadata = strip_tags( $new_metadata );
-				update_post_meta( $id, $key, $new_metadata );
-				
-				// Add the slugs of the terms with non-empty new metadata to an array
-				$term_slugs[] = $term->slug;
 			}
-			do_action( 'ef_editorial_metadata_field_updated', $key, $new_metadata, $id, $type );
+			$postmeta_key = $this->get_postmeta_key( $term );
+			return get_metadata( 'post', $post_id, $postmeta_key, true );
 		}
-		
-		// Relate the post to the terms used and taxonomy type (wp_term_relationships table).
-		// This will allow us to update and display the count of metadata in posts in use per term.
-		// TODO: Core only correlates posts with terms if the post_status is publish. Do we care what it is?
-		if ( $post->post_status === 'publish' ) {
-			wp_set_object_terms( $id, $term_slugs, self::metadata_taxonomy );
-		}
-	}
-	
-	/**
-	 * Generate a unique key based on the term
-	 * 
-	 * @param object $term Term object
-	 * @return string $postmeta_key Unique key
-	 */
-	function get_postmeta_key( $term ) {
-		$key = self::metadata_postmeta_key;
-		$type = $term->type;
-		$prefix = "{$key}_{$type}";
-		$postmeta_key = "{$prefix}_" . ( is_object( $term ) ? $term->slug : $term );
-		return $postmeta_key;
-	}
-	
-	/**
-	 * Returns the value for the given metadata
-	 *
-	 * @param object|string|int term The term object, slug or ID for the metadata field term
-	 * @param int post_id The ID of the post
-	 */
-	function get_postmeta_value( $term, $post_id ) {
-		if( ! is_object( $term ) ) {
-			if ( is_int( $term ) )
-				$term = $this->get_editorial_metadata_term_by( 'id', $term );
-			else
-				$term = $this->get_editorial_metadata_term_by( 'slug', $term );
-		}
-		$postmeta_key = $this->get_postmeta_key( $term );
-		return get_metadata( 'post', $post_id, $postmeta_key, true );
-	}
-	
-	/**
-	 * Get all of the editorial metadata terms as objects and sort by position
-	 * @todo Figure out what we should do with the filter...
-	 * 
-	 * @param array $filter_args Filter to specific arguments
-	 * @return array $ordered_terms The terms as they should be ordered
-	 */ 
-	function get_editorial_metadata_terms( $filter_args = array() ) {
 
-		// Try to fetch from internal object cache
-		$arg_hash = md5( serialize( $filter_args ) );
-		if ( isset( $this->editorial_metadata_terms_cache[ $arg_hash ] ) ) {
-			return $this->editorial_metadata_terms_cache[ $arg_hash ];
-		}
-		
-		$args = array(
-		        'orderby'    => apply_filters( 'ef_editorial_metadata_term_order', 'name' ),
-		        'hide_empty' => false
-			);
+		/**
+		 * Get all of the editorial metadata terms as objects and sort by position
+		 * @todo Figure out what we should do with the filter...
+		 *
+		 * @param array $filter_args Filter to specific arguments
+		 * @return array $ordered_terms The terms as they should be ordered
+		 */
+		public function get_editorial_metadata_terms( $filter_args = array() ) {
 
-		$terms = get_terms( self::metadata_taxonomy, $args );
-		$ordered_terms = array();
-		$hold_to_end = array();
-		// Order the terms
-		foreach ( $terms as $key => $term ) {
-			
-			// Unencode and set all of our psuedo term meta because we need the position and viewable if they exists
-			// First do an array_merge() on the term object to make sure the keys exist, then array_merge()
-			// any values that may already exist
-			$unencoded_description = $this->get_unencoded_description( $term->description );
-			$defaults = array(
-				'description' => '',
-				'viewable' => false,
-				'position' => false,
-			);
-			$term = array_merge( $defaults, (array)$term );
-			if ( is_array( $unencoded_description ) ) {
-				$term = array_merge( $term, $unencoded_description );
+			// Try to fetch from internal object cache
+			$arg_hash = md5( serialize( $filter_args ) );
+			if ( isset( $this->editorial_metadata_terms_cache[ $arg_hash ] ) ) {
+				return $this->editorial_metadata_terms_cache[ $arg_hash ];
 			}
-			$term = (object)$term;
-			// We used to store the description field in a funny way
-			if ( isset( $term->desc ) ) {
-				$term->description = $term->desc;
-				unset( $term->desc );
+
+			$terms = get_terms( array(
+				'taxonomy'   => self::metadata_taxonomy,
+				'orderby'    => apply_filters( 'ef_editorial_metadata_term_order', 'name' ),
+				'hide_empty' => false,
+			));
+
+			$ordered_terms = array();
+			$hold_to_end = array();
+			// Order the terms
+			foreach ( $terms as $key => $term ) {
+
+				// Unencode and set all of our psuedo term meta because we need the position and viewable if they exists
+				// First do an array_merge() on the term object to make sure the keys exist, then array_merge()
+				// any values that may already exist
+				$unencoded_description = $this->get_unencoded_description( $term->description );
+				$defaults = array(
+					'description' => '',
+					'viewable' => false,
+					'position' => false,
+				);
+				$term = array_merge( $defaults, (array) $term );
+				if ( is_array( $unencoded_description ) ) {
+					$term = array_merge( $term, $unencoded_description );
+				}
+				$term = (object) $term;
+				// We used to store the description field in a funny way
+				if ( isset( $term->desc ) ) {
+					$term->description = $term->desc;
+					unset( $term->desc );
+				}
+				// Only add the term to the ordered array if it has a set position and doesn't conflict with another key
+				// Otherwise, hold it for later
+				if ( $term->position && ! array_key_exists( $term->position, $ordered_terms ) ) {
+					$ordered_terms[ (int) $term->position ] = $term;
+				} else {
+					$hold_to_end[] = $term;
+				}
 			}
-			// Only add the term to the ordered array if it has a set position and doesn't conflict with another key
-			// Otherwise, hold it for later
-			if ( $term->position && !array_key_exists( $term->position, $ordered_terms ) )
-				$ordered_terms[(int)$term->position] = $term;
-			else 
-				$hold_to_end[] = $term;
+			// Sort the items numerically by key
+			ksort( $ordered_terms, SORT_NUMERIC );
+			// Append all of the terms that didn't have an existing position
+			foreach ( $hold_to_end as $unpositioned_term ) {
+				$ordered_terms[] = $unpositioned_term;
+			}
+
+			// If filter arguments were passed, do our filtering
+			$ordered_terms = wp_filter_object_list( $ordered_terms, $filter_args );
+
+			// Set the internal object cache
+			$this->editorial_metadata_terms_cache[ $arg_hash ] = $ordered_terms;
+
+			return $ordered_terms;
 		}
-		// Sort the items numerically by key
-		ksort( $ordered_terms, SORT_NUMERIC );
-		// Append all of the terms that didn't have an existing position
-		foreach( $hold_to_end as $unpositioned_term )
-			$ordered_terms[] = $unpositioned_term;
 
-		// If filter arguments were passed, do our filtering
-		$ordered_terms = wp_filter_object_list( $ordered_terms, $filter_args );
+		/**
+		 * Returns a term for single metadata field
+		 *
+		 * @param int|string $field The slug or ID for the metadata field term to return
+		 * @return object $term Term's object representation
+		 */
+		public function get_editorial_metadata_term_by( $field, $value ) {
 
-		// Set the internal object cache
-		$this->editorial_metadata_terms_cache[ $arg_hash ] = $ordered_terms;
+			if ( ! in_array( $field, array( 'id', 'slug', 'name' ) ) ) {
+				return false;
+			}
 
-		return $ordered_terms;
-	}
-	
-	/**
-	 * Returns a term for single metadata field
-	 *
-	 * @param int|string $field The slug or ID for the metadata field term to return 
-	 * @return object $term Term's object representation
-	 */
-	function get_editorial_metadata_term_by( $field, $value ) {
+			if ( 'id' == $field ) {
+				$field = 'term_id';
+			}
 
-		if ( ! in_array( $field, array( 'id', 'slug', 'name' ) ) )
-			return false;
+			$terms = $this->get_editorial_metadata_terms();
+			$term = wp_filter_object_list( $terms, array( $field => $value ) );
 
-		if ( 'id' == $field )
-			$field = 'term_id';
+			if ( ! empty( $term ) ) {
+				return array_shift( $term );
+			} else {
+				return false;
+			}
+		}
 
-		$terms = $this->get_editorial_metadata_terms();
-		$term = wp_filter_object_list( $terms, array( $field => $value ) );
+		/**
+		 * Register editorial metadata fields as columns in the manage posts view
+		 * Only adds columns for the currently active post types - logic controlled in $this->init()
+		 *
+		 * @since 0.7
+		 * @uses apply_filters( 'manage_posts_columns' ) in wp-admin/includes/class-wp-posts-list-table.php
+		 *
+		 * @param array $posts_columns Existing post columns prepared by WP_List_Table
+		 * @param array $posts_columns Previous post columns with the new values
+		 */
+		public function filter_manage_posts_columns( $posts_columns ) {
+			$screen = get_current_screen();
+			if ( $screen ) {
+				add_filter( "manage_{$screen->id}_sortable_columns", array( $this, 'filter_manage_posts_sortable_columns' ) );
+				$terms = $this->get_editorial_metadata_terms( array( 'viewable' => true ) );
+				foreach ( $terms as $term ) {
+					// Prefixing slug with module slug because it isn't stored prefixed and we want to avoid collisions
+					$key = $this->module->slug . '-' . $term->slug;
+					$posts_columns[ $key ] = $term->name;
+				}
+			}
+			return $posts_columns;
+		}
 
-		if ( ! empty( $term ) )
-			return array_shift( $term );
-		else
-			return false;
-	}
-	
-	/**
-	 * Register editorial metadata fields as columns in the manage posts view
-	 * Only adds columns for the currently active post types - logic controlled in $this->init()
-	 *
-	 * @since 0.7
-	 * @uses apply_filters( 'manage_posts_columns' ) in wp-admin/includes/class-wp-posts-list-table.php
-	 *
-	 * @param array $posts_columns Existing post columns prepared by WP_List_Table
-	 * @param array $posts_columns Previous post columns with the new values
-	 */
-	function filter_manage_posts_columns( $posts_columns ) {
-		$screen = get_current_screen();
-		if ( $screen ) {
-			add_filter( "manage_{$screen->id}_sortable_columns", array( $this, 'filter_manage_posts_sortable_columns' ) );
-			$terms = $this->get_editorial_metadata_terms( array( 'viewable' => true ) );
-			foreach( $terms as $term ) {
+		/**
+		 * Register any viewable date editorial metadata as a sortable column
+		 *
+		 * @since 0.7.4
+		 *
+		 * @param array $sortable_columns Any existing sortable columns (e.g. Title)
+		 * @return array $sortable_columms Sortable columns with editorial metadata date fields added
+		 */
+		public function filter_manage_posts_sortable_columns( $sortable_columns ) {
+
+			$terms = $this->get_editorial_metadata_terms( array(
+				'viewable' => true,
+				'type' => 'date',
+			) );
+			foreach ( $terms as $term ) {
 				// Prefixing slug with module slug because it isn't stored prefixed and we want to avoid collisions
 				$key = $this->module->slug . '-' . $term->slug;
-				$posts_columns[$key] = $term->name;
+				$sortable_columns[ $key ] = $key;
+			}
+			return $sortable_columns;
+		}
+
+		/**
+		 * If we're ordering by a sortable column, let's modify the query
+		 *
+		 * @since 0.7.4
+		 */
+		public function action_parse_query( $query ) {
+
+			if ( is_admin() && false !== stripos( get_query_var( 'orderby' ), $this->module->slug ) ) {
+				$term_slug = sanitize_key( str_replace( $this->module->slug . '-', '', get_query_var( 'orderby' ) ) );
+				$term = $this->get_editorial_metadata_term_by( 'slug', $term_slug );
+				$meta_key = $this->get_postmeta_key( $term );
+				set_query_var( 'meta_key', $meta_key );
+				set_query_var( 'orderby', 'meta_value_num' );
 			}
 		}
-		return $posts_columns;
-	}
-	
-	/**
-	 * Register any viewable date editorial metadata as a sortable column
-	 *
-	 * @since 0.7.4
-	 *
-	 * @param array $sortable_columns Any existing sortable columns (e.g. Title)
-	 * @return array $sortable_columms Sortable columns with editorial metadata date fields added
-	 */
-	function filter_manage_posts_sortable_columns( $sortable_columns ) {
 
-		$terms = $this->get_editorial_metadata_terms( array( 'viewable' => true, 'type' => 'date' ) );
-		foreach( $terms as $term ) {
-			// Prefixing slug with module slug because it isn't stored prefixed and we want to avoid collisions
-			$key = $this->module->slug . '-' . $term->slug;
-			$sortable_columns[$key] = $key;
+		/**
+		 * Handle the output of an editorial metadata custom column
+		 * Logic for the post types this is called on is controlled in $this->init()
+		 *
+		 * @since 0.7
+		 * @uses do_action( 'manage_posts_custom_column' ) in wp-admin/includes/class-wp-posts-list-table.php
+		 *
+		 * @param string $column_name Unique string for the column
+		 * @param int $post_id ID for the post of the row
+		 */
+		public function action_manage_posts_custom_column( $column_name, $post_id ) {
+
+			$terms = $this->get_editorial_metadata_terms();
+			// We're looking for the proper term to display its saved value
+			foreach ( $terms as $term ) {
+				$key = $this->module->slug . '-' . $term->slug;
+				if ( $column_name != $key ) {
+					continue;
+				}
+
+				$current_metadata = $this->get_postmeta_value( $term, $post_id );
+				echo esc_html( $this->generate_editorial_metadata_term_output( $term, $current_metadata ) );
+			}
 		}
-		return $sortable_columns;
-	}
 
-	/**
-	 * If we're ordering by a sortable column, let's modify the query
-	 *
-	 * @since 0.7.4
-	 */
-	function action_parse_query( $query ) {
+		/**
+		 * If the Edit Flow Calendar is enabled, add viewable Editorial Metadata terms
+		 *
+		 * @since 0.7
+		 * @uses apply_filters( 'ef_calendar_item_information_fields' )
+		 *
+		 * @param array $calendar_fields Additional data fields to include on the calendar
+		 * @param int $post_id Unique ID for the post data we're building
+		 * @return array $calendar_fields Calendar fields with our viewable Editorial Metadata added
+		 */
+		public function filter_calendar_item_fields( $calendar_fields, $post_id ) {
 
-		if ( is_admin() && false !== stripos( get_query_var( 'orderby' ), $this->module->slug ) ) {
-			$term_slug = sanitize_key( str_replace( $this->module->slug . '-', '', get_query_var( 'orderby') ) );
-			$term = $this->get_editorial_metadata_term_by( 'slug', $term_slug );
-			$meta_key = $this->get_postmeta_key( $term );
-			set_query_var( 'meta_key', $meta_key );
-			set_query_var( 'orderby', 'meta_value_num' );
-		}
-	}
-	
-	/**
-	 * Handle the output of an editorial metadata custom column
-	 * Logic for the post types this is called on is controlled in $this->init()
-	 *
-	 * @since 0.7
-	 * @uses do_action( 'manage_posts_custom_column' ) in wp-admin/includes/class-wp-posts-list-table.php
-	 *
-	 * @param string $column_name Unique string for the column
-	 * @param int $post_id ID for the post of the row
-	 */
-	function action_manage_posts_custom_column( $column_name, $post_id ) {
-		
-		$terms = $this->get_editorial_metadata_terms();
-		// We're looking for the proper term to display its saved value
-		foreach( $terms as $term ) {
-			$key = $this->module->slug . '-' . $term->slug;
-			if ( $column_name != $key )
-				continue;
 
-			$current_metadata = $this->get_postmeta_value( $term, $post_id );
-			echo $this->generate_editorial_metadata_term_output( $term, $current_metadata );
-		}
-		
-	}
-	
-	/**
-	 * If the Edit Flow Calendar is enabled, add viewable Editorial Metadata terms
-	 *
-	 * @since 0.7
-	 * @uses apply_filters( 'ef_calendar_item_information_fields' )
-	 *
-	 * @param array $calendar_fields Additional data fields to include on the calendar
-	 * @param int $post_id Unique ID for the post data we're building
-	 * @return array $calendar_fields Calendar fields with our viewable Editorial Metadata added
-	 */
-	function filter_calendar_item_fields( $calendar_fields, $post_id ) {
+			// Make sure we respect which post type we're on
+			if ( ! in_array( get_post_type( $post_id ), $this->get_post_types_for_module( $this->module ) ) ) {
+				return $calendar_fields;
+			}
 
-		
-		// Make sure we respect which post type we're on
-		if ( !in_array( get_post_type( $post_id ), $this->get_post_types_for_module( $this->module ) ) )
+			$terms = $this->get_editorial_metadata_terms( array( 'viewable' => true ) );
+
+			foreach ( $terms as $term ) {
+				$key = $this->module->slug . '-' . $term->slug;
+
+				// Default values
+				$current_metadata = $this->get_postmeta_value( $term, $post_id );
+				$term_data = array(
+					'label' => $term->name,
+					'value' => $this->generate_editorial_metadata_term_output( $term, $current_metadata ),
+				);
+				$term_data['editable'] = true;
+				$term_data['type'] = $term->type;
+				$calendar_fields[ $key ] = $term_data;
+			}
 			return $calendar_fields;
-			
-		$terms = $this->get_editorial_metadata_terms( array( 'viewable' => true ) );
-		
-		foreach( $terms as $term ) {
-			$key = $this->module->slug . '-' . $term->slug;
-
-			// Default values
-			$current_metadata = $this->get_postmeta_value( $term, $post_id );
-			$term_data = array(
-				'label' => $term->name,
-				'value' => $this->generate_editorial_metadata_term_output( $term, $current_metadata ),
-			);
-			$term_data['editable'] = true;
-			$term_data['type'] = $term->type;
-			$calendar_fields[$key] = $term_data;
 		}
-		return $calendar_fields;
-		
-	}
-	
-	/**
-	 * If the Edit Flow Story Budget is enabled, register our viewable terms as columns
-	 *
-	 * @since 0.7
-	 * @uses apply_filters( 'ef_story_budget_term_columns' )
-	 *
-	 * @param array $term_columns The existing columns on the story budget
-	 * @return array $term_columns Term columns with viewable Editorial Metadata terms
-	 */
-	function filter_story_budget_term_columns( $term_columns ) {
-		
-		$terms = $this->get_editorial_metadata_terms( array( 'viewable' => true ) );
-		foreach( $terms as $term ) {
-			// Prefixing slug with module slug because it isn't stored prefixed and we want to avoid collisions
-			$key = $this->module->slug . '-' . $term->slug;
-			// Switch to underscores
-			$key = str_replace( '-', '_', $key );
-			$term_columns[$key] = $term->name;
-		}		
-		return $term_columns;
-		
-	}
-	
-	/**
-	 * If the Edit Flow Story Budget is enabled,
-	 *
-	 * @since 0.7
-	 * @uses apply_filters( 'ef_story_budget_term_column_value' )
-	 *
-	 * @param object $post The post we're displaying
-	 * @param string $column_name Name of the column, as registered with EF_Story_Budget::register_term_columns
-	 * @param object $parent_term The parent term for the term column
-	 */
-	function filter_story_budget_term_column_values( $column_name, $post, $parent_term ) {
-		
-		$local_column_name = str_replace( '_', '-', $column_name );
-		// Don't accidentally handle values not our own
-		if ( false === strpos( $local_column_name, $this->module->slug ) )
-			return $column_name;
-			
-		$term_slug = str_replace( $this->module->slug . '-', '', $local_column_name );
-		$term = $this->get_editorial_metadata_term_by( 'slug', $term_slug );
-		
-		// Don't allow non-viewable term data to be displayed
-		if ( !$term->viewable )
-			return $column_name;
 
-		$current_metadata = $this->get_postmeta_value( $term, $post->ID );
-		$output = $this->generate_editorial_metadata_term_output( $term, $current_metadata );
+		/**
+		 * If the Edit Flow Story Budget is enabled, register our viewable terms as columns
+		 *
+		 * @since 0.7
+		 * @uses apply_filters( 'ef_story_budget_term_columns' )
+		 *
+		 * @param array $term_columns The existing columns on the story budget
+		 * @return array $term_columns Term columns with viewable Editorial Metadata terms
+		 */
+		public function filter_story_budget_term_columns( $term_columns ) {
 
-		return $output;
-	}
+			$terms = $this->get_editorial_metadata_terms( array( 'viewable' => true ) );
+			foreach ( $terms as $term ) {
+				// Prefixing slug with module slug because it isn't stored prefixed and we want to avoid collisions
+				$key = $this->module->slug . '-' . $term->slug;
+				// Switch to underscores
+				$key = str_replace( '-', '_', $key );
+				$term_columns[ $key ] = $term->name;
+			}
+			return $term_columns;
+		}
 
-	/**
-	 * Generate the presentational output for an editorial metadata term
-	 *
-	 * @since 0.8
-	 *
-	 * @param object      $term    The editorial metadata term
-	 * @return string     $html    How the term should be rendered
-	 */
-	private function generate_editorial_metadata_term_output( $term, $pm_value ) {
+		/**
+		 * If the Edit Flow Story Budget is enabled,
+		 *
+		 * @since 0.7
+		 * @uses apply_filters( 'ef_story_budget_term_column_value' )
+		 *
+		 * @param object $post The post we're displaying
+		 * @param string $column_name Name of the column, as registered with EF_Story_Budget::register_term_columns
+		 * @param object $parent_term The parent term for the term column
+		 */
+		public function filter_story_budget_term_column_values( $column_name, $post, $parent_term ) {
 
-		$output = '';
-		switch( $term->type ) {
-			case "date":
-				if ( empty( $pm_value ) )
-					break;
+			$local_column_name = str_replace( '_', '-', $column_name );
+			// Don't accidentally handle values not our own
+			if ( false === strpos( $local_column_name, $this->module->slug ) ) {
+				return $column_name;
+			}
 
-				// All day vs. day and time
-				$date = date( get_option( 'date_format' ), $pm_value );
-				$time = date( get_option( 'time_format' ), $pm_value );
-				if( date( 'Hi', $pm_value ) == '0000' )
-					$pm_value = $date;
-				else
-					$pm_value = sprintf( __( '%1$s at %2$s', 'edit-flow' ), $date, $time );
-				$output = esc_html( $pm_value );
-				break;
-			case "location":
-			case "text":
-			case "number":
-			case "paragraph":
-				if ( $pm_value )
+			$term_slug = str_replace( $this->module->slug . '-', '', $local_column_name );
+			$term = $this->get_editorial_metadata_term_by( 'slug', $term_slug );
+
+			// Don't allow non-viewable term data to be displayed
+			if ( ! $term->viewable ) {
+				return $column_name;
+			}
+
+			$current_metadata = $this->get_postmeta_value( $term, $post->ID );
+			$output = $this->generate_editorial_metadata_term_output( $term, $current_metadata );
+
+			return $output;
+		}
+
+		/**
+		 * Generate the presentational output for an editorial metadata term
+		 *
+		 * @since 0.8
+		 *
+		 * @param object      $term    The editorial metadata term
+		 * @return string     $html    How the term should be rendered
+		 */
+		private function generate_editorial_metadata_term_output( $term, $pm_value ) {
+
+			$output = '';
+			switch ( $term->type ) {
+				case 'date':
+					if ( empty( $pm_value ) ) {
+						break;
+					}
+
+					// All day vs. day and time
+					$date = gmdate( get_option( 'date_format' ), $pm_value );
+					$time = gmdate( get_option( 'time_format' ), $pm_value );
+					if ( '0000' == gmdate( 'Hi', $pm_value ) ) {
+						$pm_value = $date;
+					} else {
+						// translators: 1: date, 2: time
+						$pm_value = sprintf( __( '%1$s at %2$s', 'edit-flow' ), $date, $time );
+					}
 					$output = esc_html( $pm_value );
-				break;
-			case "checkbox":
-				if ( $pm_value )
-					$output = __( 'Yes', 'edit-flow' );
-				else
-					$output = __( 'No', 'edit-flow' );
-				break;
-			case "user":
-				if ( empty( $pm_value ) )
 					break;
-				$userdata = get_user_by( 'id', $pm_value );
-				if ( is_object( $userdata ) )
-					$output = esc_html( $userdata->display_name );
-				break;
-			default:
-				break;
+				case 'location':
+				case 'text':
+				case 'number':
+				case 'paragraph':
+					if ( $pm_value ) {
+						$output = esc_html( $pm_value );
+					}
+					break;
+				case 'checkbox':
+					if ( $pm_value ) {
+						$output = __( 'Yes', 'edit-flow' );
+					} else {
+						$output = __( 'No', 'edit-flow' );
+					}
+					break;
+				case 'user':
+					if ( empty( $pm_value ) ) {
+						break;
+					}
+					$userdata = get_user_by( 'id', $pm_value );
+					if ( is_object( $userdata ) ) {
+						$output = esc_html( $userdata->display_name );
+					}
+					break;
+				default:
+					break;
+			}
+			return $output;
 		}
-		return $output;
-	}
-	
-	/**
-	 * Update an existing editorial metadata term if the term_id exists
-	 *
-	 * @since 0.7
-	 *
-	 * @param int $term_id The term's unique ID
-	 * @param array $args Any values that need to be updated for the term
-	 * @return object|WP_Error $updated_term The updated term or a WP_Error object if something disastrous happened
-	 */
-	function update_editorial_metadata_term( $term_id, $args ) {
-		
-		$new_args = array();
-		$old_term = $this->get_editorial_metadata_term_by( 'id', $term_id );
-		if ( $old_term )
-			$old_args = array(
-				'position' => $old_term->position,
-				'name' => $old_term->name,
-				'slug' => $old_term->slug,
-				'description' => $old_term->description,
-				'type' => $old_term->type,
-				'viewable' => $old_term->viewable,
+
+		/**
+		 * Update an existing editorial metadata term if the term_id exists
+		 *
+		 * @since 0.7
+		 *
+		 * @param int $term_id The term's unique ID
+		 * @param array $args Any values that need to be updated for the term
+		 * @return object|WP_Error $updated_term The updated term or a WP_Error object if something disastrous happened
+		 */
+		public function update_editorial_metadata_term( $term_id, $args ) {
+
+			$new_args = array();
+			$old_term = $this->get_editorial_metadata_term_by( 'id', $term_id );
+			if ( $old_term ) {
+				$old_args = array(
+					'position' => $old_term->position,
+					'name' => $old_term->name,
+					'slug' => $old_term->slug,
+					'description' => $old_term->description,
+					'type' => $old_term->type,
+					'viewable' => $old_term->viewable,
+				);
+			}
+			$new_args = array_merge( $old_args, $args );
+
+			// We're encoding metadata that isn't supported by default in the term's description field
+			$args_to_encode = array(
+				'description' => $new_args['description'],
+				'position' => $new_args['position'],
+				'type' => $new_args['type'],
+				'viewable' => $new_args['viewable'],
 			);
-		$new_args = array_merge( $old_args, $args );
-		
-		// We're encoding metadata that isn't supported by default in the term's description field
-		$args_to_encode = array(
-			'description' => $new_args['description'],
-			'position' => $new_args['position'],
-			'type' => $new_args['type'],
-			'viewable' => $new_args['viewable'],
-		);	
-		$encoded_description = $this->get_encoded_description( $args_to_encode );
-		$new_args['description'] = $encoded_description;
-		
-		$updated_term = wp_update_term( $term_id, self::metadata_taxonomy, $new_args );
+			$encoded_description = $this->get_encoded_description( $args_to_encode );
+			$new_args['description'] = $encoded_description;
 
-		// Reset the internal object cache
-		$this->editorial_metadata_terms_cache = array();
+			$updated_term = wp_update_term( $term_id, self::metadata_taxonomy, $new_args );
 
-		$updated_term = $this->get_editorial_metadata_term_by( 'id', $term_id );
-		return $updated_term;
-	}
-	
-	/**
-	 * Insert a new editorial metadata term
-	 * @todo Handle conflicts with existing terms at that position (if relevant)
-	 *
-	 * @since 0.7
-	 */
-	function insert_editorial_metadata_term( $args ) {
+			// Reset the internal object cache
+			$this->editorial_metadata_terms_cache = array();
 
-		
-		// Term is always added to the end of the list
-		$default_position = count( $this->get_editorial_metadata_terms() ) + 2;
-		$defaults = array(
-			'position' => $default_position,
-			'name' => '',
-			'slug' => '',
-			'description' => '',
-			'type' => '',
-			'viewable' => false,
-		);
-		$args = array_merge( $defaults, $args );
-		$term_name = $args['name'];
-		unset( $args['name'] );
-		
-		// We're encoding metadata that isn't supported by default in the term's description field
-		$args_to_encode = array(
-			'description' => $args['description'],
-			'position' => $args['position'],
-			'type' => $args['type'],
-			'viewable' => $args['viewable'],
-		);	
-		$encoded_description = $this->get_encoded_description( $args_to_encode );
-		$args['description'] = $encoded_description;
-
-		$inserted_term = wp_insert_term( $term_name, self::metadata_taxonomy, $args );
-
-		// Reset the internal object cache
-		$this->editorial_metadata_terms_cache = array();
-
-		return $inserted_term;
-	}
-	
-	/**
-	 * Settings and other management code
-	 */
-	
-	/**
-	 * Delete an existing editorial metadata term
-	 *
-	 * @since 0.7
-	 * 
-	 * @param int $term_id The term we want deleted
-	 * @return bool $result Whether or not the term was deleted
-	 */
-	function delete_editorial_metadata_term( $term_id ) {
-		$result = wp_delete_term( $term_id, self::metadata_taxonomy );
-
-		// Reset the internal object cache
-		$this->editorial_metadata_terms_cache = array();
-
-		return $result;
-	}
-	
-	/**
-	 * Generate a link to one of the editorial metadata actions
-	 *
-	 * @since 0.7
-	 *
-	 * @param array $args (optional) Action and any query args to add to the URL
-	 * @return string $link Direct link to complete the action
-	 */
-	function get_link( $args = array() ) {
-		if ( !isset( $args['action'] ) )
-			$args['action'] = '';
-		if ( !isset( $args['page'] ) )
-			$args['page'] = $this->module->settings_slug;
-		// Add other things we may need depending on the action
-		switch( $args['action'] ) {
-			case 'make-viewable':
-			case 'make-hidden':
-			case 'delete-term':
-				$args['nonce'] = wp_create_nonce( $args['action'] );
-				break;
-			default:
-				break;
+			$updated_term = $this->get_editorial_metadata_term_by( 'id', $term_id );
+			return $updated_term;
 		}
-		return add_query_arg( $args, get_admin_url( null, 'admin.php' ) );
-	}	
-	
-	/**
-	 * Handles a request to add a new piece of editorial metadata
-	 */
-	function handle_add_editorial_metadata() {
 
-		if ( !isset( $_POST['submit'], $_POST['form-action'], $_GET['page'] ) 
-			|| $_GET['page'] != $this->module->settings_slug || $_POST['form-action'] != 'add-term' )
+		/**
+		 * Insert a new editorial metadata term
+		 * @todo Handle conflicts with existing terms at that position (if relevant)
+		 *
+		 * @since 0.7
+		 */
+		public function insert_editorial_metadata_term( $args ) {
+
+
+			// Term is always added to the end of the list
+			$default_position = count( $this->get_editorial_metadata_terms() ) + 2;
+			$defaults = array(
+				'position' => $default_position,
+				'name' => '',
+				'slug' => '',
+				'description' => '',
+				'type' => '',
+				'viewable' => false,
+			);
+			$args = array_merge( $defaults, $args );
+			$term_name = $args['name'];
+			unset( $args['name'] );
+
+			// We're encoding metadata that isn't supported by default in the term's description field
+			$args_to_encode = array(
+				'description' => $args['description'],
+				'position' => $args['position'],
+				'type' => $args['type'],
+				'viewable' => $args['viewable'],
+			);
+			$encoded_description = $this->get_encoded_description( $args_to_encode );
+			$args['description'] = $encoded_description;
+
+			$inserted_term = wp_insert_term( $term_name, self::metadata_taxonomy, $args );
+
+			// Reset the internal object cache
+			$this->editorial_metadata_terms_cache = array();
+
+			return $inserted_term;
+		}
+
+		/**
+		 * Settings and other management code
+		 */
+
+		/**
+		 * Delete an existing editorial metadata term
+		 *
+		 * @since 0.7
+		 *
+		 * @param int $term_id The term we want deleted
+		 * @return bool $result Whether or not the term was deleted
+		 */
+		public function delete_editorial_metadata_term( $term_id ) {
+			$result = wp_delete_term( $term_id, self::metadata_taxonomy );
+
+			// Reset the internal object cache
+			$this->editorial_metadata_terms_cache = array();
+
+			return $result;
+		}
+
+		/**
+		 * Generate a link to one of the editorial metadata actions
+		 *
+		 * @since 0.7
+		 *
+		 * @param array $args (optional) Action and any query args to add to the URL
+		 * @return string $link Direct link to complete the action
+		 */
+		public function get_link( $args = array() ) {
+			if ( ! isset( $args['action'] ) ) {
+				$args['action'] = '';
+			}
+			if ( ! isset( $args['page'] ) ) {
+				$args['page'] = $this->module->settings_slug;
+			}
+			// Add other things we may need depending on the action
+			switch ( $args['action'] ) {
+				case 'make-viewable':
+				case 'make-hidden':
+				case 'delete-term':
+					$args['nonce'] = wp_create_nonce( $args['action'] );
+					break;
+				default:
+					break;
+			}
+			return add_query_arg( $args, get_admin_url( null, 'admin.php' ) );
+		}
+
+		/**
+		 * Handles a request to add a new piece of editorial metadata
+		 */
+		public function handle_add_editorial_metadata() {
+
+			if ( ! isset( $_POST['submit'], $_POST['form-action'], $_GET['page'] )
+			|| $_GET['page'] != $this->module->settings_slug || 'add-term' != $_POST['form-action'] ) {
 				return;
-				
-		if ( !wp_verify_nonce( $_POST['_wpnonce'], 'editorial-metadata-add-nonce' ) )
-			wp_die( $this->module->messages['nonce-failed'] );
-			
-		if ( !current_user_can( 'manage_options' ) )
-			wp_die( $this->module->messages['invalid-permissions'] );			
-		
-		// Sanitize all of the user-entered values
-		$term_name = sanitize_text_field( trim( $_POST['metadata_name'] ) );
-		$term_slug = ( !empty( $_POST['metadata_slug'] ) ) ? sanitize_title( $_POST['metadata_slug'] ) : sanitize_title( $term_name );
-		$term_description = stripslashes( wp_filter_post_kses( trim( $_POST['metadata_description'] ) ) );
-		$term_type = sanitize_key( $_POST['metadata_type'] );
-		
-		$_REQUEST['form-errors'] = array();
-		
-		/**
-		 * Form validation for adding new editorial metadata term
-		 *
-		 * Details
-		 * - "name", "slug", and "type" are required fields
-		 * - "description" can accept a limited amount of HTML, and is optional
-		 */
-		// Field is required
-		if ( empty( $term_name ) )
-			$_REQUEST['form-errors']['name'] = __( 'Please enter a name for the editorial metadata.', 'edit-flow' );
-		// Field is required
-		if ( empty( $term_slug ) )
-			$_REQUEST['form-errors']['slug'] = __( 'Please enter a slug for the editorial metadata.', 'edit-flow' );
-		if ( term_exists( $term_slug ) )
-			$_REQUEST['form-errors']['name'] = __( 'Name conflicts with existing term. Please choose another.', 'edit-flow' );
-		// Check to ensure a term with the same name doesn't exist
-		if ( $this->get_editorial_metadata_term_by( 'name', $term_name, self::metadata_taxonomy ) )
-			$_REQUEST['form-errors']['name'] = __( 'Name already in use. Please choose another.', 'edit-flow' );
-		// Check to ensure a term with the same slug doesn't exist
-		if ( $this->get_editorial_metadata_term_by( 'slug', $term_slug ) )
-			$_REQUEST['form-errors']['slug'] = __( 'Slug already in use. Please choose another.', 'edit-flow' );
-		// Check to make sure the status doesn't already exist as another term because otherwise we'd get a weird slug
-		// Check that the term name doesn't exceed 200 chars
-		if ( strlen( $term_name ) > 200 )
-			$_REQUEST['form-errors']['name'] = __( 'Name cannot exceed 200 characters. Please try a shorter name.', 'edit-flow' );
-		// Metadata type needs to pass our whitelist check
-		$metadata_types = $this->get_supported_metadata_types();
-		if ( empty( $_POST['metadata_type'] ) || !isset( $metadata_types[$_POST['metadata_type'] ] ) )
-			$_REQUEST['form-errors']['type'] = __( 'Please select a valid metadata type.', 'edit-flow' );
-		// Metadata viewable needs to be a valid Yes or No
-		$term_viewable = false;
-		if ( $_POST['metadata_viewable'] == 'yes' )
-			$term_viewable = true;
-		
-		// Kick out if there are any errors
-		if ( count( $_REQUEST['form-errors'] ) ) {
-			$_REQUEST['error'] = 'form-error';
-			return;
-		}
+			}
 
-		// Try to add the status
-		$args = array(
-			'name' => $term_name,
-			'description' => $term_description,
-			'slug' => $term_slug,
-			'type' => $term_type,
-			'viewable' => $term_viewable,
-		);
-		$return = $this->insert_editorial_metadata_term( $args );
-		if ( is_wp_error( $return ) )
-			wp_die( __( 'Error adding term.', 'edit-flow' ) );
+			if ( ! isset( $_POST['_wpnonce'] ) || ! wp_verify_nonce( $_POST['_wpnonce'], 'editorial-metadata-add-nonce' ) ) {
+				wp_die( esc_html( $this->module->messages['nonce-failed'] ) );
+			}
 
-		$redirect_url = add_query_arg( array( 'page' => $this->module->settings_slug, 'message' => 'term-added' ), get_admin_url( null, 'admin.php' ) );
-		wp_redirect( $redirect_url );
-		exit;
-	}
-	
-	/**
-	 * Handles a request to edit an editorial metadata
-	 */
-	function handle_edit_editorial_metadata() {
-		if ( !isset( $_POST['submit'], $_GET['page'], $_GET['action'], $_GET['term-id'] ) 
-			|| $_GET['page'] != $this->module->settings_slug || $_GET['action'] != 'edit-term' )
-				return; 
-				
-		if ( !wp_verify_nonce( $_POST['_wpnonce'], 'editorial-metadata-edit-nonce' ) )
-			wp_die( $this->module->messages['nonce-failed'] );
-			
-		if ( !current_user_can( 'manage_options' ) )
-			wp_die( $this->module->messages['invalid-permissions'] );			
-		
-		if ( !$existing_term = $this->get_editorial_metadata_term_by( 'id', (int)$_GET['term-id'] ) )
-			wp_die( $this->module->messages['term-missing'] );			
-		
-		$new_name = sanitize_text_field( trim( $_POST['name'] ) );
-		$new_description = stripslashes( wp_filter_post_kses( strip_tags( trim( $_POST['description'] ) ) ) );
-			
-		/**
-		 * Form validation for editing editorial metadata term
-		 *
-		 * Details
-		 * - "name", "slug", and "type" are required fields
-		 * - "description" can accept a limited amount of HTML, and is optional
-		 */
-		$_REQUEST['form-errors'] = array();	
-		// Check if name field was filled in
-		if( empty( $new_name ) )
-			$_REQUEST['form-errors']['name'] = __( 'Please enter a name for the editorial metadata', 'edit-flow' );
-			
-		// Check that the name isn't numeric
-		if ( is_numeric( $new_name ) )
-			$_REQUEST['form-errors']['name'] = __( 'Please enter a valid, non-numeric name for the editorial metadata.', 'edit-flow' );
+			if ( ! current_user_can( 'manage_options' ) ) {
+				wp_die( esc_html( $this->module->messages['invalid-permissions'] ) );
+			}
 
-		$term_exists = term_exists( sanitize_title( $new_name ) );
-		if ( $term_exists && $term_exists != $existing_term->term_id )
-			$_REQUEST['form-errors']['name'] = __( 'Metadata name conflicts with existing term. Please choose another.', 'edit-flow' );
-			
-		// Check to ensure a term with the same name doesn't exist,
-		$search_term = $this->get_editorial_metadata_term_by( 'name', $new_name );
-		if ( is_object( $search_term ) && $search_term->term_id != $existing_term->term_id )
-			$_REQUEST['form-errors']['name'] = __( 'Name already in use. Please choose another.', 'edit-flow' );
-		// or that the term name doesn't map to an existing term's slug			
-		$search_term = $this->get_editorial_metadata_term_by( 'slug', sanitize_title( $new_name ) );
-		if ( is_object( $search_term ) && $search_term->term_id != $existing_term->term_id )
-			$_REQUEST['form-errors']['name'] = __( 'Name conflicts with slug for another term. Please choose something else.', 'edit-flow' );					
-		
-		// Check that the term name doesn't exceed 200 chars
-		if ( strlen( $new_name ) > 200 )
-			$_REQUEST['form-errors']['name'] = __( 'Name cannot exceed 200 characters. Please try a shorter name.', 'edit-flow' );
-		// Make sure the viewable state is valid
-		$new_viewable = false;
-		if ( $_POST['viewable'] == 'yes' )
-			$new_viewable = true;
-	
-		// Kick out if there are any errors
-		if ( count( $_REQUEST['form-errors'] ) ) {
-			$_REQUEST['error'] = 'form-error';
-			return;
-		}
-		
-		// Try to add the metadata term
-		$args = array(
-			'name' => $new_name,
-			'description' => $new_description,
-			'viewable' => $new_viewable,
-		);
-		$return = $this->update_editorial_metadata_term( $existing_term->term_id, $args );
-		if ( is_wp_error( $return ) )
-			wp_die( __( 'Error updating term.', 'edit-flow' ) );
-		
-		$redirect_url = add_query_arg( array( 'page' => $this->module->settings_slug, 'message' => 'term-updated' ), get_admin_url( null, 'admin.php' ) );
-		wp_redirect( $redirect_url );
-		exit;
-	}
-	
-	/**
-	 * Handle a $_GET request to change the visibility of an Editorial Metadata term
-	 *
-	 * @since 0.7
-	 */
-	function handle_change_editorial_metadata_visibility() {
-		
-		// Check that the current GET request is our GET request		
-		if ( !isset( $_GET['page'], $_GET['action'], $_GET['term-id'], $_GET['nonce'] )
-			|| $_GET['page'] != $this->module->settings_slug || !in_array( $_GET['action'], array( 'make-viewable', 'make-hidden' ) ) )
-			return;
-		
-		// Check for proper nonce
-		if ( !wp_verify_nonce( $_GET['nonce'], 'make-viewable' ) && !wp_verify_nonce( $_GET['nonce'], 'make-hidden' ) )
-			wp_die( $this->module->messages['nonce-failed'] );
-		
-		// Only allow users with the proper caps
-		if ( !current_user_can( 'manage_options' ) )
-			wp_die( $this->module->messages['invalid-permissions'] );
-		
-		$term_id = (int)$_GET['term-id'];
-		$args = array();
-		if ( $_GET['action'] == 'make-viewable' )
-			$args['viewable'] = true;
-		elseif ( $_GET['action'] == 'make-hidden' )
-			$args['viewable'] = false;
-		
-		$return = $this->update_editorial_metadata_term( $term_id, $args );
-		if ( is_wp_error( $return ) )
-			wp_die( __( 'Error updating term.', 'edit-flow' ) );
+			// Sanitize all of the user-entered values
+			$term_name = isset( $_POST['metadata_name'] ) ? sanitize_text_field( trim( $_POST['metadata_name'] ) ) : '';
+			$term_slug = ( ! empty( $_POST['metadata_slug'] ) ) ? sanitize_title( $_POST['metadata_slug'] ) : sanitize_title( $term_name );
+			$term_description = isset( $_POST['metadata_description'] ) ? stripslashes( wp_filter_nohtml_kses( trim( $_POST['metadata_description'] ) ) ) : '';
+			$term_type = isset( $_POST['metadata_type'] ) ? sanitize_key( $_POST['metadata_type'] ) : '';
 
-		$redirect_url = $this->get_link( array( 'message' => 'term-visibility-changed' ) );
-		wp_redirect( $redirect_url );
-		exit;
-		
-	}
-	
-	/**
-	 * Handle the request to update a given Editorial Metadata term via inline edit
-	 *
-	 * @since 0.7
-	 */
-	function handle_ajax_inline_save_term() {
-		
-		if ( !wp_verify_nonce( $_POST['inline_edit'], 'editorial-metadata-inline-edit-nonce' ) )
-			die( $this->module->messages['nonce-failed'] );
-			
-		if ( !current_user_can( 'manage_options') )
-			die( $this->module->messages['invalid-permissions'] );
-		
-		$term_id = (int) $_POST['term_id'];
-		if ( !$existing_term = $this->get_editorial_metadata_term_by( 'id', $term_id ) )
-			die( $this->module->messages['term-missing'] );
-		
-		$metadata_name = sanitize_text_field( trim( $_POST['name'] ) );
-		$metadata_description = stripslashes( wp_filter_post_kses( trim( $_POST['description'] ) ) );
-		
-		/**
-		 * Form validation for editing editorial metadata term
-		 */	
-		// Check if name field was filled in
-		if ( empty( $metadata_name ) ) {
-			$change_error = new WP_Error( 'invalid', __( 'Please enter a name for the editorial metadata', 'edit-flow' ) );
-			die( $change_error->get_error_message() );
-		}
+			$_REQUEST['form-errors'] = array();
 
-		// Check that the name isn't numeric
-		if( is_numeric( $metadata_name) ) {
-			$change_error = new WP_Error( 'invalid', __( 'Please enter a valid, non-numeric name for the editorial metadata.', 'edit-flow' ) );
-			die( $change_error->get_error_message() );
-		}
-		
-		// Check that the term name doesn't exceed 200 chars
-		if ( strlen( $metadata_name ) > 200 ) {
-			$change_error = new WP_Error( 'invalid', __( 'Name cannot exceed 200 characters. Please try a shorter name.' ) );
-			die( $change_error->get_error_message() );
-		}
-		
-		// Check to make sure the status doesn't already exist as another term because otherwise we'd get a fatal error
-		$term_exists = term_exists( sanitize_title( $metadata_name ) );
-		if ( $term_exists && $term_exists != $term_id ) {
-			$change_error = new WP_Error( 'invalid', __( 'Metadata name conflicts with existing term. Please choose another.', 'edit-flow' ) );
-			die( $change_error->get_error_message() );
-		}		
-		
-		// Check to ensure a term with the same name doesn't exist,
-		$search_term = $this->get_editorial_metadata_term_by( 'name', $metadata_name );
-		if ( is_object( $search_term ) && $search_term->term_id != $existing_term->term_id ) {
-			$change_error = new WP_Error( 'invalid', __( 'Name already in use. Please choose another.', 'edit-flow' ) );
-			die( $change_error->get_error_message() );
-		}
+			/**
+			 * Form validation for adding new editorial metadata term
+			 *
+			 * Details
+			 * - "name", "slug", and "type" are required fields
+			 * - "description" can accept a limited amount of HTML, and is optional
+			 */
+			// Field is required
+			if ( empty( $term_name ) ) {
+				$_REQUEST['form-errors']['name'] = __( 'Please enter a name for the editorial metadata.', 'edit-flow' );
+			}
+			// Field is required
+			if ( empty( $term_slug ) ) {
+				$_REQUEST['form-errors']['slug'] = __( 'Please enter a slug for the editorial metadata.', 'edit-flow' );
+			}
+			if ( term_exists( $term_slug ) ) {
+				$_REQUEST['form-errors']['name'] = __( 'Name conflicts with existing term. Please choose another.', 'edit-flow' );
+			}
+			// Check to ensure a term with the same name doesn't exist
+			if ( $this->get_editorial_metadata_term_by( 'name', $term_name, self::metadata_taxonomy ) ) {
+				$_REQUEST['form-errors']['name'] = __( 'Name already in use. Please choose another.', 'edit-flow' );
+			}
+			// Check to ensure a term with the same slug doesn't exist
+			if ( $this->get_editorial_metadata_term_by( 'slug', $term_slug ) ) {
+				$_REQUEST['form-errors']['slug'] = __( 'Slug already in use. Please choose another.', 'edit-flow' );
+			}
+			// Check to make sure the status doesn't already exist as another term because otherwise we'd get a weird slug
+			// Check that the term name doesn't exceed 200 chars
+			if ( strlen( $term_name ) > 200 ) {
+				$_REQUEST['form-errors']['name'] = __( 'Name cannot exceed 200 characters. Please try a shorter name.', 'edit-flow' );
+			}
+			// Metadata type needs to pass our whitelist check
+			$metadata_types = $this->get_supported_metadata_types();
+			if ( empty( $_POST['metadata_type'] ) || ! isset( $metadata_types[ $_POST['metadata_type'] ] ) ) {
+				$_REQUEST['form-errors']['type'] = __( 'Please select a valid metadata type.', 'edit-flow' );
+			}
+			// Metadata viewable needs to be a valid Yes or No
+			$term_viewable = false;
+			if ( isset( $_POST['metadata_viewable'] ) && 'yes' == $_POST['metadata_viewable'] ) {
+				$term_viewable = true;
+			}
 
-		// or that the term name doesn't map to an existing term's slug			
-		$search_term = $this->get_editorial_metadata_term_by( 'slug', sanitize_title( $metadata_name ) );
-		if ( is_object( $search_term ) && $search_term->term_id != $existing_term->term_id ) {
-			$change_error = new WP_Error( 'invalid', __( 'Name conflicts with slug for another term. Please choose again.', 'edit-flow' ) );
-			die( $change_error->get_error_message() );			
-		}
-		
-		// Prepare the term name and description for saving
-		$args = array(
-			'name' => $metadata_name,
-			'description' => $metadata_description,
-		);
-		$return = $this->update_editorial_metadata_term( $existing_term->term_id, $args );
-		if( !is_wp_error( $return ) ) {	
-			set_current_screen( 'edit-editorial-metadata' );					
-			$wp_list_table = new EF_Editorial_Metadata_List_Table();
-			$wp_list_table->prepare_items();
-			echo $wp_list_table->single_row( $return );
-			die();
-		} else {
-			$change_error = new WP_Error( 'invalid', sprintf( __( 'Could not update the term: <strong>%s</strong>', 'edit-flow' ), $status_name ) );
-			die( $change_error->get_error_message() );
-		}
-		
-	}
-	
-	/**
-	 * Handle the ajax request to update all of the term positions
-	 *
-	 * @since 0.7
-	 */
-	function handle_ajax_update_term_positions() {
+			// Kick out if there are any errors
+			// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotValidated
+			if ( count( $_REQUEST['form-errors'] ) ) {
+				$_REQUEST['error'] = 'form-error';
+				return;
+			}
 
-		if ( !wp_verify_nonce( $_POST['editorial_metadata_sortable_nonce'], 'editorial-metadata-sortable' ) )
-			$this->print_ajax_response( 'error', $this->module->messages['nonce-failed'] );
-		
-		if ( !current_user_can( 'manage_options') )
-			$this->print_ajax_response( 'error', $this->module->messages['invalid-permissions'] );
-		
-		if ( !isset( $_POST['term_positions'] ) || !is_array( $_POST['term_positions'] ) )
-			$this->print_ajax_response( 'error', __( 'Terms not set.', 'edit-flow' ) );
-			
-		foreach ( $_POST['term_positions'] as $position => $term_id ) {
-			
-			// Have to add 1 to the position because the index started with zero
+			// Try to add the status
 			$args = array(
-				'position' => (int)$position + 1,
+				'name' => $term_name,
+				'description' => $term_description,
+				'slug' => $term_slug,
+				'type' => $term_type,
+				'viewable' => $term_viewable,
 			);
-			$return = $this->update_editorial_metadata_term( (int)$term_id, $args );
-			// @todo check that this was a valid return
+			$return = $this->insert_editorial_metadata_term( $args );
+			if ( is_wp_error( $return ) ) {
+				wp_die( esc_html__( 'Error adding term.', 'edit-flow' ) );
+			}
+
+			$redirect_url = add_query_arg( array(
+				'page' => $this->module->settings_slug,
+				'message' => 'term-added',
+			), get_admin_url( null, 'admin.php' ) );
+			wp_redirect( $redirect_url );
+			exit;
 		}
-		$this->print_ajax_response( 'success', $this->module->messages['term-position-updated'] );	
-	}
-	
-	/**
-	 * Handles a request to delete an editorial metadata term
-	 */
-	function handle_delete_editorial_metadata() {
-		if ( !isset( $_GET['page'], $_GET['action'], $_GET['term-id'] ) 
-			|| $_GET['page'] != $this->module->settings_slug || $_GET['action'] != 'delete-term' )
+
+		/**
+		 * Handles a request to edit an editorial metadata
+		 */
+		public function handle_edit_editorial_metadata() {
+			if ( ! isset( $_POST['submit'], $_GET['page'], $_GET['action'], $_GET['term-id'] )
+			|| $_GET['page'] != $this->module->settings_slug || 'edit-term' != $_GET['action'] ) {
 				return;
-				
-		if ( !wp_verify_nonce( $_GET['nonce'], 'delete-term' ) )
-			wp_die( $this->module->messages['nonce-failed'] );
-			
-		if ( !current_user_can( 'manage_options' ) )
-			wp_die( $this->module->messages['invalid-permissions'] );
-			
-		if ( !$existing_term = $this->get_editorial_metadata_term_by( 'id', (int)$_GET['term-id'] ) )
-			wp_die( $this->module->messages['term-missing'] );			
-			
-		$result = $this->delete_editorial_metadata_term( $existing_term->term_id );
-		if ( !$result || is_wp_error( $result ) )
-			wp_die( __( 'Error deleting term.', 'edit-flow' ) );
-			
-		$redirect_url = add_query_arg( array( 'page' => $this->module->settings_slug, 'message' => 'term-deleted' ), get_admin_url( null, 'admin.php' ) );
-		wp_redirect( $redirect_url );
-		exit;		
-	}
-	
-	/**
-	 * Register settings for notifications so we can partially use the Settings API
-	 * (We use the Settings API for form generation, but not saving)
-	 * 
-	 * @since 0.7
-	 * @uses add_settings_section(), add_settings_field()
-	 */
-	function register_settings() {
+			}
+
+			if ( ! isset( $_POST['_wpnonce'] ) || ! wp_verify_nonce( $_POST['_wpnonce'], 'editorial-metadata-edit-nonce' ) ) {
+				wp_die( esc_html( $this->module->messages['nonce-failed'] ) );
+			}
+
+			if ( ! current_user_can( 'manage_options' ) ) {
+				wp_die( esc_html( $this->module->messages['invalid-permissions'] ) );
+			}
+
+			if ( ! $existing_term = $this->get_editorial_metadata_term_by( 'id', (int) $_GET['term-id'] ) ) {
+				wp_die( esc_html( $this->module->messages['term-missing'] ) );
+			}
+
+			$new_name = isset( $_POST['name'] ) ? sanitize_text_field( trim( $_POST['name'] ) ) : '';
+			$denew_descriptionscription = isset( $_POST['description'] ) ? stripslashes( wp_filter_nohtml_kses( trim( $_POST['description'] ) ) ) : '';
+
+			/**
+			 * Form validation for editing editorial metadata term
+			 *
+			 * Details
+			 * - "name", "slug", and "type" are required fields
+			 * - "description" can accept a limited amount of HTML, and is optional
+			 */
+			$_REQUEST['form-errors'] = array();
+			// Check if name field was filled in
+			if ( empty( $new_name ) ) {
+				$_REQUEST['form-errors']['name'] = __( 'Please enter a name for the editorial metadata', 'edit-flow' );
+			}
+
+			// Check that the name isn't numeric
+			if ( is_numeric( $new_name ) ) {
+				$_REQUEST['form-errors']['name'] = __( 'Please enter a valid, non-numeric name for the editorial metadata.', 'edit-flow' );
+			}
+
+			$term_exists = term_exists( sanitize_title( $new_name ) );
+			if ( $term_exists && $term_exists != $existing_term->term_id ) {
+				$_REQUEST['form-errors']['name'] = __( 'Metadata name conflicts with existing term. Please choose another.', 'edit-flow' );
+			}
+
+			// Check to ensure a term with the same name doesn't exist,
+			$search_term = $this->get_editorial_metadata_term_by( 'name', $new_name );
+			if ( is_object( $search_term ) && $search_term->term_id != $existing_term->term_id ) {
+				$_REQUEST['form-errors']['name'] = __( 'Name already in use. Please choose another.', 'edit-flow' );
+			}
+			// or that the term name doesn't map to an existing term's slug
+			$search_term = $this->get_editorial_metadata_term_by( 'slug', sanitize_title( $new_name ) );
+			if ( is_object( $search_term ) && $search_term->term_id != $existing_term->term_id ) {
+				$_REQUEST['form-errors']['name'] = __( 'Name conflicts with slug for another term. Please choose something else.', 'edit-flow' );
+			}
+
+			// Check that the term name doesn't exceed 200 chars
+			if ( strlen( $new_name ) > 200 ) {
+				$_REQUEST['form-errors']['name'] = __( 'Name cannot exceed 200 characters. Please try a shorter name.', 'edit-flow' );
+			}
+			// Make sure the viewable state is valid
+			$new_viewable = false;
+			if ( isset( $_POST['viewable'] ) && 'yes' == $_POST['viewable'] ) {
+				$new_viewable = true;
+			}
+
+			// Kick out if there are any errors
+			// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotValidated
+			if ( count( $_REQUEST['form-errors'] ) ) {
+				$_REQUEST['error'] = 'form-error';
+				return;
+			}
+
+			// Try to add the metadata term
+			$args = array(
+				'name' => $new_name,
+				'description' => $new_description,
+				'viewable' => $new_viewable,
+			);
+			$return = $this->update_editorial_metadata_term( $existing_term->term_id, $args );
+			if ( is_wp_error( $return ) ) {
+				wp_die( esc_html__( 'Error updating term.', 'edit-flow' ) );
+			}
+
+			$redirect_url = add_query_arg( array(
+				'page' => $this->module->settings_slug,
+				'message' => 'term-updated',
+			), get_admin_url( null, 'admin.php' ) );
+			wp_redirect( $redirect_url );
+			exit;
+		}
+
+		/**
+		 * Handle a $_GET request to change the visibility of an Editorial Metadata term
+		 *
+		 * @since 0.7
+		 */
+		public function handle_change_editorial_metadata_visibility() {
+
+			// Check that the current GET request is our GET request
+			if ( ! isset( $_GET['page'], $_GET['action'], $_GET['term-id'], $_GET['nonce'] )
+			|| $_GET['page'] != $this->module->settings_slug || ! in_array( $_GET['action'], array( 'make-viewable', 'make-hidden' ) ) ) {
+				return;
+			}
+
+			// Check for proper nonce
+			if ( ! isset( $_GET['nonce'] ) || ( ! wp_verify_nonce( $_GET['nonce'], 'make-viewable' ) && ! wp_verify_nonce( $_GET['nonce'], 'make-hidden' ) ) ) {
+				wp_die( esc_html( $this->module->messages['nonce-failed'] ) );
+			}
+
+			// Only allow users with the proper caps
+			if ( ! current_user_can( 'manage_options' ) ) {
+				wp_die( esc_html( $this->module->messages['invalid-permissions'] ) );
+			}
+
+			$term_id = (int) $_GET['term-id'];
+			$args = array();
+			if ( 'make-viewable' == $_GET['action'] ) {
+				$args['viewable'] = true;
+			} elseif ( 'make-hidden' == $_GET['action'] ) {
+				$args['viewable'] = false;
+			}
+
+			$return = $this->update_editorial_metadata_term( $term_id, $args );
+			if ( is_wp_error( $return ) ) {
+				wp_die( esc_html__( 'Error updating term.', 'edit-flow' ) );
+			}
+
+			$redirect_url = $this->get_link( array( 'message' => 'term-visibility-changed' ) );
+			wp_redirect( $redirect_url );
+			exit;
+		}
+
+		/**
+		 * Handle the request to update a given Editorial Metadata term via inline edit
+		 *
+		 * @since 0.7
+		 */
+		public function handle_ajax_inline_save_term() {
+
+			if ( ! isset( $_POST['inline_edit'] ) || ! wp_verify_nonce( $_POST['inline_edit'], 'editorial-metadata-inline-edit-nonce' ) ) {
+				die( esc_html( $this->module->messages['nonce-failed'] ) );
+			}
+
+			if ( ! current_user_can( 'manage_options' ) ) {
+				die( esc_html( $this->module->messages['invalid-permissions'] ) );
+			}
+
+			$term_id = isset( $_POST['term_id'] ) ? (int) $_POST['term_id'] : 0;
+			if ( ! $existing_term = $this->get_editorial_metadata_term_by( 'id', $term_id ) ) {
+				die( esc_html( $this->module->messages['term-missing'] ) );
+			}
+
+			$metadata_name = isset( $_POST['name'] ) ? sanitize_text_field( trim( $_POST['name'] ) ) : '';
+			$metadata_description = isset( $_POST['description'] ) ? stripslashes( wp_filter_nohtml_kses( trim( $_POST['description'] ) ) ) : '';
+
+			/**
+			 * Form validation for editing editorial metadata term
+			 */
+			// Check if name field was filled in
+			if ( empty( $metadata_name ) ) {
+				$change_error = new WP_Error( 'invalid', _esc_html__( 'Please enter a name for the editorial metadata', 'edit-flow' ) );
+				die( esc_html( $change_error->get_error_message() ) );
+			}
+
+			// Check that the name isn't numeric
+			if ( is_numeric( $metadata_name ) ) {
+				$change_error = new WP_Error( 'invalid', esc_html__( 'Please enter a valid, non-numeric name for the editorial metadata.', 'edit-flow' ) );
+				die( esc_html( $change_error->get_error_message() ) );
+			}
+
+			// Check that the term name doesn't exceed 200 chars
+			if ( strlen( $metadata_name ) > 200 ) {
+				$change_error = new WP_Error( 'invalid', esc_html__( 'Name cannot exceed 200 characters. Please try a shorter name.' ) );
+				die( esc_html( $change_error->get_error_message() ) );
+			}
+
+			// Check to make sure the status doesn't already exist as another term because otherwise we'd get a fatal error
+			$term_exists = term_exists( sanitize_title( $metadata_name ) );
+			if ( $term_exists && $term_exists != $term_id ) {
+				$change_error = new WP_Error( 'invalid', esc_html____( 'Metadata name conflicts with existing term. Please choose another.', 'edit-flow' ) );
+				die( esc_html( $change_error->get_error_message() ) );
+			}
+
+			// Check to ensure a term with the same name doesn't exist,
+			$search_term = $this->get_editorial_metadata_term_by( 'name', $metadata_name );
+			if ( is_object( $search_term ) && $search_term->term_id != $existing_term->term_id ) {
+				$change_error = new WP_Error( 'invalid', esc_html__( 'Name already in use. Please choose another.', 'edit-flow' ) );
+				die( esc_html( $change_error->get_error_message() ) );
+			}
+
+			// or that the term name doesn't map to an existing term's slug
+			$search_term = $this->get_editorial_metadata_term_by( 'slug', sanitize_title( $metadata_name ) );
+			if ( is_object( $search_term ) && $search_term->term_id != $existing_term->term_id ) {
+				$change_error = new WP_Error( 'invalid', esc_html__( 'Name conflicts with slug for another term. Please choose again.', 'edit-flow' ) );
+				die( esc_html( $change_error->get_error_message() ) );
+			}
+
+			// Prepare the term name and description for saving
+			$args = array(
+				'name' => $metadata_name,
+				'description' => $metadata_description,
+			);
+			$return = $this->update_editorial_metadata_term( $existing_term->term_id, $args );
+			if ( ! is_wp_error( $return ) ) {
+				set_current_screen( 'edit-editorial-metadata' );
+				$wp_list_table = new EF_Editorial_Metadata_List_Table();
+				$wp_list_table->prepare_items();
+				echo wp_kses_post( $wp_list_table->single_row( $return ) );
+				die();
+			} else {
+				/* Translators: 1: the name of the term that could not be found */
+				$change_error = new WP_Error( 'invalid', wp_kses( sprintf( __( 'Could not update the term: <strong>%s</strong>', 'edit-flow' ), $metadata_name ), 'strong' ) );
+				die( esc_html( $change_error->get_error_message() ) );
+			}
+		}
+
+		/**
+		 * Handle the ajax request to update all of the term positions
+		 *
+		 * @since 0.7
+		 */
+		public function handle_ajax_update_term_positions() {
+
+			if ( ! isset( $_POST['editorial_metadata_sortable_nonce'] ) || ! wp_verify_nonce( $_POST['editorial_metadata_sortable_nonce'], 'editorial-metadata-sortable' ) ) {
+				$this->print_ajax_response( 'error', $this->module->messages['nonce-failed'] );
+			}
+
+			if ( ! current_user_can( 'manage_options' ) ) {
+				$this->print_ajax_response( 'error', $this->module->messages['invalid-permissions'] );
+			}
+
+			if ( ! isset( $_POST['term_positions'] ) || ! is_array( $_POST['term_positions'] ) ) {
+				$this->print_ajax_response( 'error', __( 'Terms not set.', 'edit-flow' ) );
+			}
+
+			foreach ( $_POST['term_positions'] as $position => $term_id ) {
+
+				// Have to add 1 to the position because the index started with zero
+				$args = array(
+					'position' => (int) $position + 1,
+				);
+				$return = $this->update_editorial_metadata_term( (int) $term_id, $args );
+				// @todo check that this was a valid return
+			}
+			$this->print_ajax_response( 'success', $this->module->messages['term-position-updated'] );
+		}
+
+		/**
+		 * Handles a request to delete an editorial metadata term
+		 */
+		public function handle_delete_editorial_metadata() {
+			if ( ! isset( $_GET['page'], $_GET['action'], $_GET['term-id'] )
+			|| $_GET['page'] != $this->module->settings_slug || 'delete-term' != $_GET['action'] ) {
+				return;
+			}
+
+			if ( ! isset( $_GET['nonce'] ) || ! wp_verify_nonce( $_GET['nonce'], 'delete-term' ) ) {
+				wp_die( esc_html( $this->module->messages['nonce-failed'] ) );
+			}
+
+			if ( ! current_user_can( 'manage_options' ) ) {
+				wp_die( esc_html( $this->module->messages['invalid-permissions'] ) );
+			}
+
+			if ( ! $existing_term = $this->get_editorial_metadata_term_by( 'id', (int) $_GET['term-id'] ) ) {
+				wp_die( esc_html( $this->module->messages['term-missing'] ) );
+			}
+
+			$result = $this->delete_editorial_metadata_term( $existing_term->term_id );
+			if ( ! $result || is_wp_error( $result ) ) {
+				wp_die( esc_html__( 'Error deleting term.', 'edit-flow' ) );
+			}
+
+			$redirect_url = add_query_arg( array(
+				'page' => $this->module->settings_slug,
+				'message' => 'term-deleted',
+			), get_admin_url( null, 'admin.php' ) );
+			wp_redirect( $redirect_url );
+			exit;
+		}
+
+		/**
+		 * Register settings for notifications so we can partially use the Settings API
+		 * (We use the Settings API for form generation, but not saving)
+		 *
+		 * @since 0.7
+		 * @uses add_settings_section(), add_settings_field()
+		 */
+		public function register_settings() {
 			add_settings_section( $this->module->options_group_name . '_general', false, '__return_false', $this->module->options_group_name );
 			add_settings_field( 'post_types', __( 'Add to these post types:', 'edit-flow' ), array( $this, 'settings_post_types_option' ), $this->module->options_group_name, $this->module->options_group_name . '_general' );
-	}	
+		}
 
-	/**
-	 * Choose the post types for editorial metadata
-	 *
-	 * @since 0.7
-	 */
-	function settings_post_types_option() {
-		global $edit_flow;
-		$edit_flow->settings->helper_option_custom_post_type( $this->module );
-	}
+		/**
+		 * Choose the post types for editorial metadata
+		 *
+		 * @since 0.7
+		 */
+		public function settings_post_types_option() {
+			global $edit_flow;
+			$edit_flow->settings->helper_option_custom_post_type( $this->module );
+		}
 
-	/**
-	 * Validate data entered by the user
-	 *
-	 * @since 0.7
-	 *
-	 * @param array $new_options New values that have been entered by the user
-	 * @return array $new_options Form values after they've been sanitized
-	 */
-	function settings_validate( $new_options ) {
-		
-		// Whitelist validation for the post type options
-		if ( !isset( $new_options['post_types'] ) )
-			$new_options['post_types'] = array();
-		$new_options['post_types'] = $this->clean_post_type_options( $new_options['post_types'], $this->module->post_type_support );		
-		
-		return $new_options;
-	}
-	
-	/**
-	 * Prepare and display the configuration view for editorial metadata.
-	 * There are four primary components:
-	 * - Form to add a new Editorial Metadata term
-	 * - Form generated by the settings API for managing Editorial Metadata options
-	 * - Table of existing Editorial Metadata terms with ability to take actions on each
-	 * - Full page width view for editing a single Editorial Metadata term
-	 *
-	 * @since 0.7
-	 */ 
-	function print_configure_view() {
-		global $edit_flow;
-		$wp_list_table = new EF_Editorial_Metadata_List_Table();
-		$wp_list_table->prepare_items();
-		?>
+		/**
+		 * Validate data entered by the user
+		 *
+		 * @since 0.7
+		 *
+		 * @param array $new_options New values that have been entered by the user
+		 * @return array $new_options Form values after they've been sanitized
+		 */
+		public function settings_validate( $new_options ) {
+
+			// Whitelist validation for the post type options
+			if ( ! isset( $new_options['post_types'] ) ) {
+				$new_options['post_types'] = array();
+			}
+			$new_options['post_types'] = $this->clean_post_type_options( $new_options['post_types'], $this->module->post_type_support );
+
+			return $new_options;
+		}
+
+		/**
+		 * Prepare and display the configuration view for editorial metadata.
+		 * There are four primary components:
+		 * - Form to add a new Editorial Metadata term
+		 * - Form generated by the settings API for managing Editorial Metadata options
+		 * - Table of existing Editorial Metadata terms with ability to take actions on each
+		 * - Full page width view for editing a single Editorial Metadata term
+		 *
+		 * Disabling nonce verification because that is not available here, it's just rendering it. The actual save is done in helper_settings_validate_and_save and that's guarded well.
+		 * phpcs:disable:WordPress.Security.NonceVerification.Missing
+		 * @since 0.7
+		 */
+		public function print_configure_view() {
+			global $edit_flow;
+			$wp_list_table = new EF_Editorial_Metadata_List_Table();
+			$wp_list_table->prepare_items();
+			?>
 		<script type="text/javascript">
 			var ef_confirm_delete_term_string = "<?php echo esc_js( __( 'Are you sure you want to delete this term? Any metadata for this term will remain but will not be visible unless this term is re-added.', 'edit-flow' ) ); ?>";
 		</script>
-		<?php if ( !isset( $_GET['action'] ) || ( isset( $_GET['action'] ) && $_GET['action'] != 'edit-term' ) ): ?>
+			<?php if ( ! isset( $_GET['action'] ) || ( isset( $_GET['action'] ) && 'edit-term' != $_GET['action'] ) ) : ?>
 		<div id="col-right">
 		<div class="col-wrap">
 		<form id="posts-filter" action="" method="post">
-			<?php $wp_list_table->display(); ?>
-			<?php wp_nonce_field( 'editorial-metadata-sortable', 'editorial-metadata-sortable' ); ?>
+				<?php $wp_list_table->display(); ?>
+				<?php wp_nonce_field( 'editorial-metadata-sortable', 'editorial-metadata-sortable' ); ?>
 		</form>
 		</div>
 		</div><!-- /col-right -->
-		<?php $wp_list_table->inline_edit(); ?>
-		<?php endif; ?>	
-		
-		<?php if ( isset( $_GET['action'], $_GET['term-id'] ) && $_GET['action'] == 'edit-term' ): ?>
-		<?php /** Full page width view for editing a given editorial metadata term **/ ?>
-		<?php
-			// Check whether the term exists
-			$term_id = (int)$_GET['term-id'];
-			$term = $this->get_editorial_metadata_term_by( 'id', $term_id );
-			if ( !$term ) {
-				echo '<div class="error"><p>' . $this->module->messages['term-missing'] . '</p></div>';
-				return; 
-			}
-			$metadata_types = $this->get_supported_metadata_types();			
-			$type = $term->type;
-			$edit_term_link = $this->get_link( array( 'action' => 'edit-term', 'term-id' => $term->term_id ) );
-			
-			$name = ( isset( $_POST['name'] ) ) ? stripslashes( $_POST['name'] ) : $term->name;
-			$description = ( isset( $_POST['description'] ) ) ? stripslashes( $_POST['description'] ) : $term->description;
-			if ( $term->viewable )
-				$viewable = 'yes';
-			else
-				$viewable = 'no';
-			$viewable = ( isset( $_POST['viewable'] ) ) ? stripslashes( $_POST['viewable'] ) : $viewable;
-		?>
-		
+				<?php $wp_list_table->inline_edit(); ?>
+		<?php endif; ?>
+
+			<?php if ( isset( $_GET['action'], $_GET['term-id'] ) && 'edit-term' == $_GET['action'] ) : ?>
+				<?php /** Full page width view for editing a given editorial metadata term **/ ?>
+				<?php
+				// Check whether the term exists
+				$term_id = (int) $_GET['term-id'];
+				$term = $this->get_editorial_metadata_term_by( 'id', $term_id );
+				if ( ! $term ) {
+					echo '<div class="error"><p>' . esc_html( $this->module->messages['term-missing'] ) . '</p></div>';
+					return;
+				}
+				$metadata_types = $this->get_supported_metadata_types();
+				$type = $term->type;
+				$edit_term_link = $this->get_link( array(
+					'action' => 'edit-term',
+					'term-id' => $term->term_id,
+				) );
+
+				$name = ( isset( $_POST['name'] ) ) ? stripslashes( $_POST['name'] ) : $term->name;
+				$description = ( isset( $_POST['description'] ) ) ? stripslashes( $_POST['description'] ) : $term->description;
+				if ( $term->viewable ) {
+					$viewable = 'yes';
+				} else {
+					$viewable = 'no';
+				}
+				$viewable = ( isset( $_POST['viewable'] ) ) ? stripslashes( $_POST['viewable'] ) : $viewable;
+				?>
+
 		<form method="post" action="<?php echo esc_url( $edit_term_link ); ?>" >
 		<input type="hidden" name="action" value="editedtag" />
 		<input type="hidden" name="tag_id" value="<?php echo esc_attr( $term->term_id ); ?>" />
-		<input type="hidden" name="taxonomy" value="<?php echo esc_attr( self::metadata_taxonomy ) ?>" />
-		<?php
-			wp_original_referer_field();
-			wp_nonce_field( 'editorial-metadata-edit-nonce' );
-		?>
+		<input type="hidden" name="taxonomy" value="<?php echo esc_attr( self::metadata_taxonomy ); ?>" />
+				<?php
+				wp_original_referer_field();
+				wp_nonce_field( 'editorial-metadata-edit-nonce' );
+				?>
 		<table class="form-table">
 			<tr class="form-field form-required">
 				<th scope="row" valign="top"><label for="name"><?php _e( 'Name' ); ?></label></th>
@@ -1447,7 +1537,7 @@ class EF_Editorial_Metadata extends EF_Module {
 					<input type="text" disabled="disabled" value="<?php echo esc_attr( $term->slug ); ?>" />
 					<p class="description"><?php _e( 'The slug cannot be changed once the term has been created.', 'edit-flow' ); ?></p>
 				</td>
-			</tr>			
+			</tr>
 			<tr class="form-field">
 				<th scope="row" valign="top"><label for="description"><?php _e( 'Description', 'edit-flow' ); ?></label></th>
 				<td>
@@ -1458,7 +1548,7 @@ class EF_Editorial_Metadata extends EF_Module {
 			<tr class="form-field">
 				<th scope="row" valign="top"><?php _e( 'Type', 'edit-flow' ); ?></th>
 				<td>
-					<input type="text" disabled="disabled" value="<?php echo esc_attr( $metadata_types[$type] ); ?>" />
+					<input type="text" disabled="disabled" value="<?php echo esc_attr( $metadata_types[ $type ] ); ?>" />
 					<p class="description"><?php _e( 'The metadata type cannot be changed once created.', 'edit-flow' ); ?></p>
 				</td>
 			</tr>
@@ -1470,57 +1560,81 @@ class EF_Editorial_Metadata extends EF_Module {
 							'no' => __( 'No', 'edit-flow' ),
 							'yes' => __( 'Yes', 'edit-flow' ),
 						);
-					?>
+						?>
 					<select id="viewable" name="viewable">
 					<?php foreach ( $metadata_viewable_options as $metadata_viewable_key => $metadata_viewable_value ) : ?>
-						<option value="<?php echo esc_attr( $metadata_viewable_key ); ?>" <?php selected( $viewable, $metadata_viewable_key ); ?>><?php echo esc_attr( $metadata_viewable_value ); ?></option>
+						<option value="<?php echo esc_attr( $metadata_viewable_key ); ?>" <?php selected( $viewable, $metadata_viewable_key ); ?>><?php echo esc_html( $metadata_viewable_value ); ?></option>
 					<?php endforeach; ?>
 					</select>
 					<?php $edit_flow->settings->helper_print_error_or_description( 'viewable', __( 'When viewable, metadata can be seen on views other than the edit post view (e.g. calendar, manage posts, story budget, etc.)', 'edit-flow' ) ); ?>
 				</td>
 			</tr>
-		<input type="hidden" name="<?php echo self::metadata_taxonomy ?>'_type" value="<?php echo $type; ?>" />
+		<input type="hidden" name="<?php echo esc_attr( self::metadata_taxonomy ); ?>'_type" value="<?php echo esc_attr( $type ); ?>" />
 		</table>
 		<p class="submit">
-		<?php submit_button( __( 'Update Metadata Term', 'edit-flow' ), 'primary', 'submit', false ); ?>
+				<?php submit_button( __( 'Update Metadata Term', 'edit-flow' ), 'primary', 'submit', false ); ?>
 		<a class="cancel-settings-link" href="<?php echo esc_url( add_query_arg( 'page', $this->module->settings_slug, get_admin_url( null, 'admin.php' ) ) ); ?>"><?php _e( 'Cancel', 'edit-flow' ); ?></a>
 		</p>
 		</form>
-		
-		<?php else: ?>
-		<?php /** If not in full-screen edit term mode, we can create new terms or change options **/ ?>
+
+		<?php else : ?>
+			<?php /** If not in full-screen edit term mode, we can create new terms or change options **/ ?>
 		<div id="col-left">
-			<div class="col-wrap">	
+			<div class="col-wrap">
 			<div class="form-wrap">
 			<h3 class="nav-tab-wrapper">
-				<a href="<?php echo esc_url( add_query_arg( array( 'page' => $this->module->settings_slug ), get_admin_url( null, 'admin.php' ) ) ); ?>" class="nav-tab<?php if ( !isset( $_GET['action'] ) || $_GET['action'] != 'change-options' ) echo ' nav-tab-active'; ?>"><?php _e( 'Add New', 'edit-flow' ); ?></a>
-				<a href="<?php echo esc_url( add_query_arg( array( 'page' => $this->module->settings_slug, 'action' => 'change-options' ), get_admin_url( null, 'admin.php' ) ) ); ?>" class="nav-tab<?php if ( isset( $_GET['action'] ) && $_GET['action'] == 'change-options' ) echo ' nav-tab-active'; ?>"><?php _e( 'Options', 'edit-flow' ); ?></a>
+				<a href="<?php echo esc_url( add_query_arg( array( 'page' => $this->module->settings_slug ), get_admin_url( null, 'admin.php' ) ) ); ?>" class="nav-tab
+									<?php
+									if ( ! isset( $_GET['action'] ) || 'change-options' != $_GET['action'] ) {
+										echo ' nav-tab-active';}
+									?>
+				"><?php _e( 'Add New', 'edit-flow' ); ?></a>
+				<a href="
+				<?php
+				echo esc_url( add_query_arg( array(
+					'page' => $this->module->settings_slug,
+					'action' => 'change-options',
+				), get_admin_url( null, 'admin.php' ) ) );
+				?>
+							" class="nav-tab
+							<?php
+							if ( isset( $_GET['action'] ) && 'change-options' == $_GET['action'] ) {
+														echo ' nav-tab-active';}
+							?>
+"><?php _e( 'Options', 'edit-flow' ); ?></a>
 			</h3>
-			
-		<?php if ( isset( $_GET['action'] ) && $_GET['action'] == 'change-options' ): ?>
-		<?php /** Basic form built on WP Settings API for outputting Editorial Metadata options **/ ?>
-		<form class="basic-settings" action="<?php echo esc_url( add_query_arg( array( 'page' => $this->module->settings_slug, 'action' => 'change-options' ), get_admin_url( null, 'admin.php' ) ) ); ?>" method="post">
-			<?php settings_fields( $this->module->options_group_name ); ?>
-			<?php do_settings_sections( $this->module->options_group_name ); ?>	
-			<?php echo '<input id="edit_flow_module_name" name="edit_flow_module_name" type="hidden" value="' . esc_attr( $this->module->name ) . '" />'; ?>
-			<?php submit_button(); ?>
+
+			<?php if ( isset( $_GET['action'] ) && 'change-options' == $_GET['action'] ) : ?>
+				<?php /** Basic form built on WP Settings API for outputting Editorial Metadata options **/ ?>
+		<form class="basic-settings" action="
+				<?php
+				echo esc_url( add_query_arg( array(
+					'page' => $this->module->settings_slug,
+					'action' => 'change-options',
+				), get_admin_url( null, 'admin.php' ) ) );
+				?>
+												" method="post">
+				<?php settings_fields( $this->module->options_group_name ); ?>
+				<?php do_settings_sections( $this->module->options_group_name ); ?>
+				<?php echo '<input id="edit_flow_module_name" name="edit_flow_module_name" type="hidden" value="' . esc_attr( $this->module->name ) . '" />'; ?>
+				<?php submit_button(); ?>
 		</form>
-		<?php else: ?>
-		<?php /** Custom form for adding a new Editorial Metadata term **/ ?>
+		<?php else : ?>
+			<?php /** Custom form for adding a new Editorial Metadata term **/ ?>
 			<form class="add:the-list:" action="<?php echo esc_url( add_query_arg( array( 'page' => $this->module->settings_slug ), get_admin_url( null, 'admin.php' ) ) ); ?>" method="post" id="addmetadata" name="addmetadata">
 			<div class="form-field form-required">
 				<label for="metadata_name"><?php _e( 'Name', 'edit-flow' ); ?></label>
-				<input type="text" aria-required="true" size="20" maxlength="200" id="metadata_name" name="metadata_name" value="<?php if ( !empty( $_POST['metadata_name'] ) ) echo esc_attr( stripslashes( $_POST['metadata_name'] ) ) ?>" />
+				<input type="text" aria-required="true" size="20" maxlength="200" id="metadata_name" name="metadata_name" value="<?php /* phpcs:ignore Generic.ControlStructures.InlineControlStructure.NotAllowed */ if ( ! empty( $_POST['metadata_name'] ) ) echo esc_attr( $_POST['metadata_name'] ); ?>" />
 				<?php $edit_flow->settings->helper_print_error_or_description( 'name', __( 'The name is for labeling the metadata field.', 'edit-flow' ) ); ?>
 			</div>
 			<div class="form-field form-required">
 				<label for="metadata_slug"><?php _e( 'Slug', 'edit-flow' ); ?></label>
-				<input type="text" aria-required="true" size="20" maxlength="200" id="metadata_slug" name="metadata_slug" value="<?php if ( !empty( $_POST['metadata_slug'] ) ) echo esc_attr( $_POST['metadata_slug'] ) ?>" />
+				<input type="text" aria-required="true" size="20" maxlength="200" id="metadata_slug" name="metadata_slug" value="<?php /* phpcs:ignore Generic.ControlStructures.InlineControlStructure.NotAllowed */ if ( ! empty( $_POST['metadata_slug'] ) ) echo esc_attr( $_POST['metadata_slug'] ); ?>" />
 				<?php $edit_flow->settings->helper_print_error_or_description( 'slug', __( 'The "slug" is the URL-friendly version of the name. It is usually all lowercase and contains only letters, numbers, and hyphens.', 'edit-flow' ) ); ?>
 			</div>
 			<div class="form-field">
 				<label for="metadata_description"><?php _e( 'Description', 'edit-flow' ); ?></label>
-				<textarea cols="40" rows="5" id="metadata_description" name="metadata_description"><?php if ( !empty( $_POST['metadata_description'] ) ) echo esc_html( stripslashes( $_POST['metadata_description'] ) ) ?></textarea>
+				<textarea cols="40" rows="5" id="metadata_description" name="metadata_description"><?php /* phpcs:ignore Generic.ControlStructures.InlineControlStructure.NotAllowed */ if ( ! empty( $_POST['metadata_description'] ) ) echo esc_textarea( $_POST['metadata_description'] ); ?></textarea>
 				<?php $edit_flow->settings->helper_print_error_or_description( 'description', __( 'The description can be used to communicate with your team about what the metadata is for.', 'edit-flow' ) ); ?>
 			</div>
 			<div class="form-field form-required">
@@ -1532,7 +1646,7 @@ class EF_Editorial_Metadata extends EF_Module {
 				?>
 				<select id="metadata_type" name="metadata_type">
 				<?php foreach ( $metadata_types as $metadata_type => $metadata_type_name ) : ?>
-					<option value="<?php echo esc_attr( $metadata_type ); ?>" <?php selected( $metadata_type, $current_metadata_type ); ?>><?php echo esc_attr( $metadata_type_name ); ?></option>
+					<option value="<?php echo esc_attr( $metadata_type ); ?>" <?php selected( $metadata_type, $current_metadata_type ); ?>><?php echo esc_html( $metadata_type_name ); ?></option>
 				<?php endforeach; ?>
 				</select>
 				<?php $edit_flow->settings->helper_print_error_or_description( 'type', __( 'Indicate the type of editorial metadata.', 'edit-flow' ) ); ?>
@@ -1545,57 +1659,60 @@ class EF_Editorial_Metadata extends EF_Module {
 						'yes' => __( 'Yes', 'edit-flow' ),
 					);
 					$current_metadata_viewable = ( isset( $_POST['metadata_viewable'] ) && in_array( $_POST['metadata_viewable'], array_keys( $metadata_viewable_options ) ) ) ? $_POST['metadata_viewable'] : 'no';
-				?>
+					?>
 				<select id="metadata_viewable" name="metadata_viewable">
 				<?php foreach ( $metadata_viewable_options as $metadata_viewable_key => $metadata_viewable_value ) : ?>
-					<option value="<?php echo esc_attr( $metadata_viewable_key ); ?>" <?php selected( $current_metadata_viewable, $metadata_viewable_key ); ?>><?php echo esc_attr( $metadata_viewable_value ); ?></option>
+					<option value="<?php echo esc_attr( $metadata_viewable_key ); ?>" <?php selected( $current_metadata_viewable, $metadata_viewable_key ); ?>><?php echo esc_html( $metadata_viewable_value ); ?></option>
 				<?php endforeach; ?>
 				</select>
 				<?php $edit_flow->settings->helper_print_error_or_description( 'viewable', __( 'When viewable, metadata can be seen on views other than the edit post view (e.g. calendar, manage posts, story budget, etc.)', 'edit-flow' ) ); ?>
 			</div>
-			<?php wp_nonce_field( 'editorial-metadata-add-nonce' );?>
+			<?php wp_nonce_field( 'editorial-metadata-add-nonce' ); ?>
 			<input type="hidden" id="form-action" name="form-action" value="add-term" />
-			<p class="submit"><?php submit_button( __( 'Add New Metadata Term', 'edit-flow' ), 'primary', 'submit', false ); ?><a class="cancel-settings-link" href="<?php echo EDIT_FLOW_SETTINGS_PAGE; ?>"><?php _e( 'Back to Edit Flow', 'edit-flow' ); ?></a></p>
+			<p class="submit"><?php submit_button( __( 'Add New Metadata Term', 'edit-flow' ), 'primary', 'submit', false ); ?><a class="cancel-settings-link" href="<?php echo esc_url( EDIT_FLOW_SETTINGS_PAGE ); ?>"><?php _e( 'Back to Edit Flow', 'edit-flow' ); ?></a></p>
 			</form>
 		<?php endif; ?>
 			</div>
 			</div>
 		</div>
-		
-		<?php
-		endif;
+
+			<?php
+			endif;
+		}
+
+		//phpcs:enable:WordPress.Security.NonceVerification.Missing
 	}
-	
-}
 
 }
+
+// phpcs:disable Generic.Files.OneObjectStructurePerFile.MultipleFound
 
 /**
  * Management interface for Editorial Metadata. Extends WP_List_Table class
  */
 class EF_Editorial_Metadata_List_Table extends WP_List_Table {
-	
-	var $callback_args;
-	var $taxonomy;
-	var $tax;
+
+	protected $callback_args;
+	protected $taxonomy;
+	protected $tax;
 
 	/**
 	 * Construct the class
 	 */
-	function __construct() {
+	public function __construct() {
 		global $edit_flow;
 
 		$this->taxonomy = EF_Editorial_Metadata::metadata_taxonomy;
-		
+
 		$this->tax = get_taxonomy( $this->taxonomy );
-		
+
 		$columns = $this->get_columns();
 		$hidden = array(
 			'position',
 		);
 		$sortable = array();
-		
-		$this->_column_headers = array( $columns, $hidden, $sortable );		
+
+		$this->_column_headers = array( $columns, $hidden, $sortable );
 
 		parent::__construct( array(
 			'plural' => 'editorial metadata',
@@ -1608,7 +1725,7 @@ class EF_Editorial_Metadata_List_Table extends WP_List_Table {
 	 *
 	 * @since 0.7
 	 */
-	function prepare_items() {
+	public function prepare_items() {
 		global $edit_flow;
 		$this->items = $edit_flow->editorial_metadata->get_editorial_metadata_terms();
 
@@ -1623,27 +1740,27 @@ class EF_Editorial_Metadata_List_Table extends WP_List_Table {
 	 *
 	 * @since 0.7
 	 */
-	function no_items() {
+	public function no_items() {
 		_e( 'No editorial metadata found.', 'edit-flow' );
 	}
-	
+
 	/**
 	 * Register the columns to appear in the table
 	 *
 	 * @since 0.7
 	 */
-	function get_columns() {
-		
+	public function get_columns() {
+
 		$columns = array(
-			'position'	  => __( 'Position', 'edit-flow' ),
+			'position'    => __( 'Position', 'edit-flow' ),
 			'name'        => __( 'Name', 'edit-flow' ),
-			'type'		  => __( 'Metadata Type', 'edit-flow' ),
+			'type'        => __( 'Metadata Type', 'edit-flow' ),
 			'description' => __( 'Description', 'edit-flow' ),
 			'viewable'    => __( 'Viewable', 'edit-flow' ),
-		);		
+		);
 		return $columns;
 	}
-	
+
 	/**
 	 * Prepare a single row of Editorial Metadata
 	 *
@@ -1652,16 +1769,16 @@ class EF_Editorial_Metadata_List_Table extends WP_List_Table {
 	 * @param object $term The current term we're displaying
 	 * @param int $level Level is always zero because it isn't a parent-child tax
 	 */
-	function single_row( $term, $level = 0 ) {
+	public function single_row( $term, $level = 0 ) {
 		static $alternate_class = '';
-		$alternate_class = ( $alternate_class == '' ? ' alternate' : '' );
+		$alternate_class = ( '' == $alternate_class ? ' alternate' : '' );
 		$row_class = ' class="term-static' . $alternate_class . '"';
 
- 		echo '<tr id="term-' . $term->term_id . '"' . $row_class . '>';
- 		echo $this->single_row_columns( $term );
- 		echo '</tr>';
+		echo wp_kses_post( '<tr id="term-' . $term->term_id . '"' . $row_class . '>' );
+		echo wp_kses_post( $this->single_row_columns( $term ) );
+		echo '</tr>';
 	}
-	
+
 	/**
 	 * Handle the column output when there's no method for it
 	 *
@@ -1670,24 +1787,24 @@ class EF_Editorial_Metadata_List_Table extends WP_List_Table {
 	 * @param object $item Editorial Metadata term as an object
 	 * @param string $column_name How the column was registered at birth
 	 */
-	function column_default( $item, $column_name ) {
-		
-		switch( $column_name ) {
+	public function column_default( $item, $column_name ) {
+
+		switch ( $column_name ) {
 			case 'position':
 			case 'type':
 			case 'description':
 				return esc_html( $item->$column_name );
 				break;
 			case 'viewable':
-				if ( $item->viewable )
+				if ( $item->viewable ) {
 					return __( 'Yes', 'edit-flow' );
-				else 
+				} else {
 					return __( 'No', 'edit-flow' );
+				}
 				break;
 			default:
 				break;
 		}
-		
 	}
 
 	/**
@@ -1697,28 +1814,41 @@ class EF_Editorial_Metadata_List_Table extends WP_List_Table {
 	 *
 	 * @param object $item Editorial Metadata term as an object
 	 */
-	function column_name( $item ) {
+	public function column_name( $item ) {
 		global $edit_flow;
-		$item_edit_link = esc_url( $edit_flow->editorial_metadata->get_link( array( 'action' => 'edit-term', 'term-id' => $item->term_id ) ) );
-		$item_delete_link = esc_url( $edit_flow->editorial_metadata->get_link( array( 'action' => 'delete-term', 'term-id' => $item->term_id ) ) );
-		
+		$item_edit_link = esc_url( $edit_flow->editorial_metadata->get_link( array(
+			'action' => 'edit-term',
+			'term-id' => $item->term_id,
+		) ) );
+		$item_delete_link = esc_url( $edit_flow->editorial_metadata->get_link( array(
+			'action' => 'delete-term',
+			'term-id' => $item->term_id,
+		) ) );
+
 		$out = '<strong><a class="row-title" href="' . $item_edit_link . '">' . esc_html( $item->name ) . '</a></strong>';
-		
+
 		$actions = array();
-		$actions['edit'] = "<a href='$item_edit_link'>" . __( 'Edit', 'edit-flow' ) . "</a>";
+		$actions['edit'] = "<a href='$item_edit_link'>" . __( 'Edit', 'edit-flow' ) . '</a>';
 		$actions['inline hide-if-no-js'] = '<a href="#" class="editinline">' . __( 'Quick&nbsp;Edit' ) . '</a>';
-		if ( $item->viewable )
-			$actions['change-visibility make-hidden'] = '<a title="' . esc_attr( __( 'Hidden metadata can only be viewed on the edit post view.', 'edit-flow' ) ) . '" href="' . esc_url( $edit_flow->editorial_metadata->get_link( array( 'action' => 'make-hidden', 'term-id' => $item->term_id ) ) ) . '">' . __( 'Make Hidden', 'edit-flow' ) . '</a>';
-		else
-			$actions['change-visibility make-viewable'] = '<a title="' . esc_attr( __( 'When viewable, metadata can be seen on views other than the edit post view (e.g. calendar, manage posts, story budget, etc.)', 'edit-flow' ) ) . '" href="' . esc_url( $edit_flow->editorial_metadata->get_link( array( 'action' => 'make-viewable', 'term-id' => $item->term_id ) ) ) . '">' . __( 'Make Viewable', 'edit-flow' ) . '</a>';
-		$actions['delete delete-status'] = "<a href='$item_delete_link'>" . __( 'Delete', 'edit-flow' ) . "</a>";
-		
+		if ( $item->viewable ) {
+			$actions['change-visibility make-hidden'] = '<a title="' . esc_attr( __( 'Hidden metadata can only be viewed on the edit post view.', 'edit-flow' ) ) . '" href="' . esc_url( $edit_flow->editorial_metadata->get_link( array(
+				'action' => 'make-hidden',
+				'term-id' => $item->term_id,
+			) ) ) . '">' . __( 'Make Hidden', 'edit-flow' ) . '</a>';
+		} else {
+			$actions['change-visibility make-viewable'] = '<a title="' . esc_attr( __( 'When viewable, metadata can be seen on views other than the edit post view (e.g. calendar, manage posts, story budget, etc.)', 'edit-flow' ) ) . '" href="' . esc_url( $edit_flow->editorial_metadata->get_link( array(
+				'action' => 'make-viewable',
+				'term-id' => $item->term_id,
+			) ) ) . '">' . __( 'Make Viewable', 'edit-flow' ) . '</a>';
+		}
+		$actions['delete delete-status'] = "<a href='$item_delete_link'>" . __( 'Delete', 'edit-flow' ) . '</a>';
+
 		$out .= $this->row_actions( $actions, false );
 		$out .= '<div class="hidden" id="inline_' . $item->term_id . '">';
 		$out .= '<div class="name">' . $item->name . '</div>';
-		$out .= '<div class="description">' . $item->description . '</div>';	
+		$out .= '<div class="description">' . $item->description . '</div>';
 		$out .= '</div>';
-		
+
 		return $out;
 	}
 
@@ -1727,11 +1857,11 @@ class EF_Editorial_Metadata_List_Table extends WP_List_Table {
 	 *
 	 * @since 0.7
 	 */
-	function inline_edit() {
+	public function inline_edit() {
 
-?>
+		?>
 	<form method="get" action=""><table style="display: none"><tbody id="inlineedit">
-		<tr id="inline-edit" class="inline-edit-row" style="display: none"><td colspan="<?php echo $this->get_column_count(); ?>" class="colspanchange">
+		<tr id="inline-edit" class="inline-edit-row" style="display: none"><td colspan="<?php echo esc_attr( $this->get_column_count() ); ?>" class="colspanchange">
 			<fieldset><div class="inline-edit-col">
 				<h4><?php _e( 'Quick Edit' ); ?></h4>
 				<label>
@@ -1746,7 +1876,7 @@ class EF_Editorial_Metadata_List_Table extends WP_List_Table {
 		<p class="inline-edit-save submit">
 			<a accesskey="c" href="#inline-edit" title="<?php _e( 'Cancel' ); ?>" class="cancel button-secondary alignleft"><?php _e( 'Cancel' ); ?></a>
 			<?php $update_text = __( 'Update Metadata Term', 'edit-flow' ); ?>
-			<a accesskey="s" href="#inline-edit" title="<?php echo esc_attr( $update_text ); ?>" class="save button-primary alignright"><?php echo $update_text; ?></a>
+			<a accesskey="s" href="#inline-edit" title="<?php echo esc_attr( $update_text ); ?>" class="save button-primary alignright"><?php echo esc_html( $update_text ); ?></a>
 			<img class="waiting" style="display:none;" src="<?php echo esc_url( admin_url( 'images/wpspin_light.gif' ) ); ?>" alt="" />
 			<span class="error" style="display:none;"></span>
 			<?php wp_nonce_field( 'editorial-metadata-inline-edit-nonce', 'inline_edit', false ); ?>
@@ -1754,6 +1884,6 @@ class EF_Editorial_Metadata_List_Table extends WP_List_Table {
 		</p>
 		</td></tr>
 		</tbody></table></form>
-	<?php
+		<?php
 	}
 }

--- a/modules/editorial-metadata/editorial-metadata.php
+++ b/modules/editorial-metadata/editorial-metadata.php
@@ -460,7 +460,7 @@ if ( ! class_exists( 'EF_Editorial_Metadata' ) ) {
 		 */
 		private function show_date_or_datetime( $current_date ) {
 
-			if ( gmdate( 'Hi', $current_date ) == '0000' ) {
+			if ( date( 'Hi', $current_date ) == '0000' ) {
 				return date_i18n( 'M d Y', $current_date );
 			} else {
 				return date_i18n( 'M d Y H:i', $current_date );
@@ -863,9 +863,9 @@ if ( ! class_exists( 'EF_Editorial_Metadata' ) ) {
 					}
 
 					// All day vs. day and time
-					$date = gmdate( get_option( 'date_format' ), $pm_value );
-					$time = gmdate( get_option( 'time_format' ), $pm_value );
-					if ( '0000' == gmdate( 'Hi', $pm_value ) ) {
+					$date = date( get_option( 'date_format' ), $pm_value );
+					$time = date( get_option( 'time_format' ), $pm_value );
+					if ( '0000' == date( 'Hi', $pm_value ) ) {
 						$pm_value = $date;
 					} else {
 						// translators: 1: date, 2: time

--- a/modules/notifications/notifications.php
+++ b/modules/notifications/notifications.php
@@ -836,7 +836,7 @@ if ( ! class_exists( 'EF_Notifications' ) ) {
 			$body .= sprintf( __( 'You are receiving this email because you are subscribed to "%s".', 'edit-flow' ), ef_draft_or_post_title( $post->ID ) );
 			$body .= "\r\n";
 			/* translators: 1: date */
-			$body .= sprintf( __( 'This email was sent %s.', 'edit-flow' ), gmdate( 'r' ) );
+			$body .= sprintf( __( 'This email was sent %s.', 'edit-flow' ), date( 'r' ) );
 			$body .= "\r\n \r\n";
 			$body .= get_option( 'blogname' ) . ' | ' . get_bloginfo( 'url' ) . ' | ' . admin_url( '/' ) . "\r\n";
 			return $body;

--- a/modules/settings/settings.php
+++ b/modules/settings/settings.php
@@ -210,7 +210,7 @@ if ( ! class_exists( 'EF_Settings' ) ) {
 			<h2><a href="<?php echo esc_url( EDIT_FLOW_SETTINGS_PAGE ); ?>"><?php _e( 'Edit Flow', 'edit-flow' ); ?></a>:&nbsp;<?php echo esc_attr( $current_module->title ); ?>
 									<?php
 									if ( isset( $display_text ) ) {
-										echo wp_kses( $display_text, 'a' ); }
+										echo wp_kses_post( $display_text ); }
 									?>
 			</h2>
 			<?php else : ?>
@@ -218,17 +218,17 @@ if ( ! class_exists( 'EF_Settings' ) ) {
 			<h2><?php _e( 'Edit Flow', 'edit-flow' ); ?>
 						  <?php
 							if ( isset( $display_text ) ) {
-								echo wp_kses( $display_text, 'a' ); }
+								echo wp_kses_post( $display_text ); }
 							?>
 			</h2>
 			<?php endif; ?>
 
 			<div class="explanation">
 				<?php if ( $current_module->short_description ) : ?>
-				<h3><?php echo wp_kses( $current_module->short_description, 'a' ); ?></h3>
+				<h3><?php echo wp_kses_post( $current_module->short_description ); ?></h3>
 				<?php endif; ?>
 				<?php if ( $current_module->extended_description ) : ?>
-				<p><?php echo wp_kses( $current_module->extended_description, 'a' ); ?></p>
+				<p><?php echo wp_kses_post( $current_module->extended_description ); ?></p>
 				<?php endif; ?>
 			</div>
 			<?php

--- a/modules/story-budget/story-budget.php
+++ b/modules/story-budget/story-budget.php
@@ -345,7 +345,7 @@ class EF_Story_Budget extends EF_Module {
 					for ( $i = 1; $i <= $this->max_num_columns; ++$i ) {
 						?>
 					.columns-number-<?php echo (int) $i; ?> .postbox {
-						flex-basis: <?php echo 99 / /* phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped */ $i; ?>%;
+						flex-basis: <?php echo floatval( 99 / $i ); ?>%;
 					}
 						<?php
 					}

--- a/modules/story-budget/story-budget.php
+++ b/modules/story-budget/story-budget.php
@@ -433,8 +433,8 @@ class EF_Story_Budget extends EF_Module {
 		$ending_date = $beginning_date + ( $days_to_show * DAY_IN_SECONDS );
 
 		$args['date_query'] = array(
-			'after'     => gmdate( 'Y-m-d', $beginning_date ),
-			'before'    => gmdate( 'Y-m-d', $ending_date ),
+			'after'     => date( 'Y-m-d', $beginning_date ),
+			'before'    => date( 'Y-m-d', $ending_date ),
 			'inclusive' => true,
 		);
 
@@ -717,7 +717,7 @@ class EF_Story_Budget extends EF_Module {
 		}
 
 		if ( ! $user_filters['start_date'] ) {
-			$user_filters['start_date'] = gmdate( 'Y-m-d' );
+			$user_filters['start_date'] = date( 'Y-m-d' );
 		}
 
 		if ( ! $user_filters['number_days'] ) {

--- a/modules/story-budget/story-budget.php
+++ b/modules/story-budget/story-budget.php
@@ -7,24 +7,27 @@
  */
 class EF_Story_Budget extends EF_Module {
 
-	var $taxonomy_used = 'category';
+	public $taxonomy_used = 'category';
 
-	var $module;
+	public $module;
 
-	var $num_columns = 0;
+	public $num_columns = 0;
 
-	var $max_num_columns;
+	public $max_num_columns;
 
-	var $no_matching_posts = true;
+	public $no_matching_posts = true;
 
-	var $terms = array();
+	public $terms = array();
 
-	var $user_filters;
+	public $user_filters;
 
+	// phpcs:ignore Generic.NamingConventions.UpperCaseConstantName.ClassConstantNotUpperCase
 	const screen_id = 'dashboard_page_story-budget';
 
+	// phpcs:ignore Generic.NamingConventions.UpperCaseConstantName.ClassConstantNotUpperCase
 	const usermeta_key_prefix = 'ef_story_budget_';
 
+	// phpcs:ignore Generic.NamingConventions.UpperCaseConstantName.ClassConstantNotUpperCase
 	const default_num_columns = 1;
 
 	private $term_columns;
@@ -32,12 +35,13 @@ class EF_Story_Budget extends EF_Module {
 	/**
 	 * Register the module with Edit Flow but don't do anything else
 	 */
-	function __construct() {
+	public function __construct() {
 
 		$this->module_url = $this->get_module_url( __FILE__ );
 		// Register the module with Edit Flow
 		$args = array(
 			'title' => __( 'Story Budget', 'edit-flow' ),
+			// translators: %s is a link to the story budget page
 			'short_description' => sprintf( __( 'View the status of all your content <a href="%s">at a glance</a>.', 'edit-flow' ), admin_url( 'index.php?page=story-budget' ) ),
 			'extended_description' => __( 'Use the story budget to see how content on your site is progressing. Filter by specific categories or date ranges to see details about each post in progress.', 'edit-flow' ),
 			'module_url' => $this->module_url,
@@ -50,17 +54,17 @@ class EF_Story_Budget extends EF_Module {
 			'autoload' => false,
 		);
 		$this->module = EditFlow()->register_module( 'story_budget', $args );
-
 	}
 
 	/**
 	 * Initialize the rest of the stuff in the class if the module is active
 	 */
-	function init() {
+	public function init() {
 
 		$view_story_budget_cap = apply_filters( 'ef_view_story_budget_cap', 'ef_view_story_budget' );
-		if ( !current_user_can( $view_story_budget_cap ) )
+		if ( ! current_user_can( $view_story_budget_cap ) ) {
 			return;
+		}
 
 		$this->num_columns = $this->get_num_columns();
 		$this->max_num_columns = apply_filters( 'ef_story_budget_max_num_columns', 3 );
@@ -78,7 +82,6 @@ class EF_Story_Budget extends EF_Module {
 		// Load necessary scripts and stylesheets
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_admin_scripts' ) );
 		add_action( 'admin_enqueue_scripts', array( $this, 'action_enqueue_admin_styles' ) );
-
 	}
 
 	/**
@@ -86,15 +89,15 @@ class EF_Story_Budget extends EF_Module {
 	 *
 	 * @since 0.7
 	 */
-	function install() {
+	public function install() {
 
 		$story_budget_roles = array(
 			'administrator' => array( 'ef_view_story_budget' ),
-			'editor' =>        array( 'ef_view_story_budget' ),
-			'author' =>        array( 'ef_view_story_budget' ),
-			'contributor' =>   array( 'ef_view_story_budget' )
+			'editor' => array( 'ef_view_story_budget' ),
+			'author' => array( 'ef_view_story_budget' ),
+			'contributor' => array( 'ef_view_story_budget' ),
 		);
-		foreach( $story_budget_roles as $role => $caps ) {
+		foreach ( $story_budget_roles as $role => $caps ) {
 			$this->add_caps_to_role( $role, $caps );
 		}
 	}
@@ -104,23 +107,23 @@ class EF_Story_Budget extends EF_Module {
 	 *
 	 * @since 0.7
 	 */
-	function upgrade( $previous_version ) {
+	public function upgrade( $previous_version ) {
 		global $edit_flow;
 
 		// Upgrade path to v0.7
-		if ( version_compare( $previous_version, '0.7' , '<' ) ) {
+		if ( version_compare( $previous_version, '0.7', '<' ) ) {
 			// Migrate whether the story budget was enabled or not and clean up old option
-			if ( $enabled = get_option( 'edit_flow_story_budget_enabled' ) )
+			if ( $enabled = get_option( 'edit_flow_story_budget_enabled' ) ) {
 				$enabled = 'on';
-			else
+			} else {
 				$enabled = 'off';
+			}
 			$edit_flow->update_module_option( $this->module->name, 'enabled', $enabled );
 			delete_option( 'edit_flow_story_budget_enabled' );
 
 			// Technically we've run this code before so we don't want to auto-install new data
 			$edit_flow->update_module_option( $this->module->name, 'loaded_once', true );
 		}
-
 	}
 
 	/**
@@ -128,8 +131,8 @@ class EF_Story_Budget extends EF_Module {
 	 *
 	 * @uses add_submenu_page()
 	 */
-	function action_admin_menu() {
-		add_submenu_page( 'index.php', __('Story Budget', 'edit-flow'), __('Story Budget', 'edit-flow'), apply_filters( 'ef_view_story_budget_cap', 'ef_view_story_budget' ), $this->module->slug, array( $this, 'story_budget') );
+	public function action_admin_menu() {
+		add_submenu_page( 'index.php', __( 'Story Budget', 'edit-flow' ), __( 'Story Budget', 'edit-flow' ), apply_filters( 'ef_view_story_budget_cap', 'ef_view_story_budget' ), $this->module->slug, array( $this, 'story_budget' ) );
 	}
 
 	/**
@@ -137,11 +140,12 @@ class EF_Story_Budget extends EF_Module {
 	 *
 	 * @uses enqueue_admin_script()
 	 */
-	function enqueue_admin_scripts() {
+	public function enqueue_admin_scripts() {
 		global $current_screen;
 
-		if ( $current_screen->id != self::screen_id )
+		if ( self::screen_id != $current_screen->id ) {
 			return;
+		}
 
 		$num_columns = $this->get_num_columns();
 		echo '<script type="text/javascript"> var ef_story_budget_number_of_columns="' . esc_js( $this->num_columns ) . '";</script>';
@@ -153,11 +157,12 @@ class EF_Story_Budget extends EF_Module {
 	/**
 	 * Enqueue a screen and print stylesheet for the story budget.
 	 */
-	function action_enqueue_admin_styles() {
+	public function action_enqueue_admin_styles() {
 		global $current_screen;
 
-		if ( $current_screen->id != self::screen_id )
+		if ( self::screen_id != $current_screen->id ) {
 			return;
+		}
 
 		wp_enqueue_style( 'edit_flow-story_budget-styles', $this->module_url . 'lib/story-budget.css', false, EDIT_FLOW_VERSION, 'screen' );
 		wp_enqueue_style( 'edit_flow-story_budget-print-styles', $this->module_url . 'lib/story-budget-print.css', false, EDIT_FLOW_VERSION, 'print' );
@@ -169,7 +174,7 @@ class EF_Story_Budget extends EF_Module {
 	 *
 	 * @since 0.7
 	 */
-	function register_term_columns() {
+	public function register_term_columns() {
 
 		$term_columns = array(
 			'title' => __( 'Title', 'edit-flow' ),
@@ -188,17 +193,18 @@ class EF_Story_Budget extends EF_Module {
 	 *
 	 * @since 0.7
 	 */
-	function handle_form_date_range_change() {
+	public function handle_form_date_range_change() {
 
 		if ( ! isset( $_POST['ef-story-budget-range-submit'], $_POST['ef-story-budget-number-days'], $_POST['ef-story-budget-start-date_hidden'] ) ) {
 			return;
 		}
 
-		if ( !wp_verify_nonce( $_POST['nonce'], 'change-date' ) )
-			wp_die( $this->module->messages['nonce-failed'] );
+		if ( ! isset( $_POST['nonce'] ) || ! wp_verify_nonce( $_POST['nonce'], 'change-date' ) ) {
+			wp_die( esc_html( $this->module->messages['nonce-failed'] ) );
+		}
 
 		$current_user = wp_get_current_user();
-		$new_filters = array (
+		$new_filters = array(
 			'start_date' => $_POST['ef-story-budget-start-date_hidden'],
 			'number_days' => (int) $_POST['ef-story-budget-number-days'],
 		);
@@ -245,7 +251,7 @@ class EF_Story_Budget extends EF_Module {
 	/**
 	 * Get the number of columns to show on the story budget
 	 */
-	function get_num_columns() {
+	public function get_num_columns() {
 
 		if ( empty( $this->num_columns ) ) {
 			$current_user = wp_get_current_user();
@@ -264,18 +270,18 @@ class EF_Story_Budget extends EF_Module {
 	 *
 	 * @since 0.8.3
 	 */
-	function add_screen_options_panel() {
-		require_once( EDIT_FLOW_ROOT . '/common/php/' . 'screen-options.php' );
+	public function add_screen_options_panel() {
+		require_once EDIT_FLOW_ROOT . '/common/php/screen-options.php';
 		add_screen_options_panel( self::usermeta_key_prefix . 'screen_columns', __( 'Screen Layout', 'edit-flow' ), array( $this, 'print_column_prefs' ), self::screen_id, array( $this, 'save_column_prefs' ), true );
 	}
 
 	/**
 	 * Print column number preferences for screen options
 	 */
-	function print_column_prefs() {
+	public function print_column_prefs() {
 		$return_val = __( 'Number of Columns: ', 'edit-flow' );
 		for ( $i = 1; $i <= $this->max_num_columns; ++$i ) {
-			$return_val .= "<label><input type='radio' name='" . esc_attr( self::usermeta_key_prefix ) . "screen_columns' value='" . esc_attr( $i ) . "' " . checked($this->get_num_columns(), $i, false) . " />&nbsp;" . esc_attr( $i ) . "</label>\n";
+			$return_val .= "<label><input type='radio' name='" . esc_attr( self::usermeta_key_prefix ) . "screen_columns' value='" . esc_attr( $i ) . "' " . checked( $this->get_num_columns(), $i, false ) . ' />&nbsp;' . esc_attr( $i ) . "</label>\n";
 		}
 		return $return_val;
 	}
@@ -283,7 +289,7 @@ class EF_Story_Budget extends EF_Module {
 	/**
 	 * Save the current user's preference for number of columns.
 	 */
-	function save_column_prefs( $posted_fields ) {
+	public function save_column_prefs( $posted_fields ) {
 
 		$key = self::usermeta_key_prefix . 'screen_columns';
 		$this->num_columns = (int) $posted_fields[ $key ];
@@ -297,23 +303,23 @@ class EF_Story_Budget extends EF_Module {
 	 * ouput any messages, create the table navigation, then print the columns based on
 	 * get_num_columns(), which will in turn print the stories themselves.
 	 */
-	function story_budget() {
+	public function story_budget() {
 
 		// Update the current user's filters with the variables set in $_GET
 		$this->user_filters = $this->update_user_filters();
 
-		if ( !empty( $this->user_filters[$this->taxonomy_used] ) ) {
+		if ( ! empty( $this->user_filters[ $this->taxonomy_used ] ) ) {
 			$terms = array();
-			$terms[] = get_term( $this->user_filters[$this->taxonomy_used], $this->taxonomy_used );
+			$terms[] = get_term( $this->user_filters[ $this->taxonomy_used ], $this->taxonomy_used );
 		} else {
 			// Get all of the terms from the taxonomy, regardless whether there are published posts
-			$args = array(
+			$terms = get_terms( array(
+				'taxonomy'   => $this->taxonomy_used,
 				'orderby' => 'name',
 				'order' => 'asc',
 				'hide_empty' => 0,
 				'parent' => 0,
-			);
-			$terms = get_terms( $this->taxonomy_used, $args );
+			));
 		}
 		$this->terms = apply_filters( 'ef_story_budget_filter_terms', $terms ); // allow for reordering or any other filtering of terms
 
@@ -328,22 +334,22 @@ class EF_Story_Budget extends EF_Module {
 			<div class="metabox-holder">
 				<?php
 					echo '<div class="postbox-container columns-number-' . absint( $this->num_columns ) . '">';
-					foreach( (array) $this->terms as $term ) {
-						$this->print_term( $term );
-					}
+				foreach ( (array) $this->terms as $term ) {
+					$this->print_term( $term );
+				}
 
 					echo '</div>';
 				?>
 				<style>
 					<?php
-					  for ( $i = 1; $i <= $this->max_num_columns; ++$i ) {
+					for ( $i = 1; $i <= $this->max_num_columns; ++$i ) {
 						?>
 					.columns-number-<?php echo (int) $i; ?> .postbox {
-						flex-basis: <?php echo  99 / $i ?>%;
+						flex-basis: <?php echo 99 / /* phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped */ $i; ?>%;
 					}
-					<?php
-				  }
-				?>
+						<?php
+					}
+					?>
 				</style>
 			</div>
 		</div>
@@ -355,9 +361,9 @@ class EF_Story_Budget extends EF_Module {
 	 *
 	 * @since 0.7
 	 */
-	function story_budget_time_range() {
+	public function story_budget_time_range() {
 		?>
-		<form method="POST" action="<?php echo esc_attr( menu_page_url( $this->module->slug, false ) ); ?>">
+		<form method="POST" action="<?php echo esc_url( menu_page_url( $this->module->slug, false ) ); ?>">
 			<?php _e( 'starting', 'edit-flow' ); ?>
 			<span class="form-value"><?php echo esc_html( date_i18n( get_option( 'date_format' ), strtotime( $this->user_filters['start_date'] ) ) ); ?></span>
 			<input type="text" id="ef-story-budget-start-date" name="ef-story-budget-start-date" size="20" autocomplete="off" class="date-pick" value="<?php echo esc_attr( date_i18n( get_option( 'date_format' ), strtotime( $this->user_filters['start_date'] ) ) ); ?>" />
@@ -382,7 +388,7 @@ class EF_Story_Budget extends EF_Module {
 	 * @param object $term The term we're getting posts for
 	 * @return array $term_posts An array of post objects for the term
 	 */
-	function get_posts_for_term( $term, $args = null ) {
+	public function get_posts_for_term( $term, $args = null ) {
 
 		$defaults = array(
 			'post_status' => null,
@@ -395,7 +401,7 @@ class EF_Story_Budget extends EF_Module {
 		$arg_terms = array(
 			$term->term_id,
 		);
-		$arg_terms = array_merge( $arg_terms, get_term_children( $term->term_id, $this->taxonomy_used ) ) ;
+		$arg_terms = array_merge( $arg_terms, get_term_children( $term->term_id, $this->taxonomy_used ) );
 		$args['tax_query'] = array(
 			array(
 				'taxonomy' => $this->taxonomy_used,
@@ -418,15 +424,17 @@ class EF_Story_Budget extends EF_Module {
 		}
 
 		// Filter by post_author if it's set
-		if ( $args['author'] === '0' ) unset( $args['author'] );
+		if ( '0' === $args['author'] ) {
+			unset( $args['author'] );
+		}
 
 		$beginning_date = strtotime( $this->user_filters['start_date'] );
 		$days_to_show = $this->user_filters['number_days'];
 		$ending_date = $beginning_date + ( $days_to_show * DAY_IN_SECONDS );
 
 		$args['date_query'] = array(
-			'after'     => date( "Y-m-d", $beginning_date ),
-			'before'    => date( "Y-m-d", $ending_date ),
+			'after'     => gmdate( 'Y-m-d', $beginning_date ),
+			'before'    => gmdate( 'Y-m-d', $ending_date ),
 			'inclusive' => true,
 		);
 
@@ -451,23 +459,29 @@ class EF_Story_Budget extends EF_Module {
 	 *
 	 * @param object $term The term to print.
 	 */
-	function print_term( $term ) {
+	public function print_term( $term ) {
 		global $wpdb;
 		$posts = $this->get_posts_for_term( $term, $this->user_filters );
-		if ( !empty( $posts ) )
+		if ( ! empty( $posts ) ) {
 			// Don't display the message for $no_matching_posts
 			$this->no_matching_posts = false;
+		}
 
-	?>
-	<div class="postbox<?php if ( !empty( $posts )) echo ' postbox-has-posts'; ?>">
+		?>
+	<div class="postbox
+		<?php
+		if ( ! empty( $posts ) ) {
+			echo ' postbox-has-posts';}
+		?>
+	">
 		<div class="handlediv" title="<?php _e( 'Click to toggle', 'edit-flow' ); ?>"><br /></div>
 		<h3 class='hndle'><span><?php echo esc_html( $term->name ); ?></span></h3>
 		<div class="inside">
-			<?php if ( !empty( $posts )) : ?>
+			<?php if ( ! empty( $posts ) ) : ?>
 			<table class="widefat post fixed story-budget" cellspacing="0">
 				<thead>
 					<tr>
-						<?php foreach( (array)$this->term_columns as $key => $name ): ?>
+						<?php foreach ( (array) $this->term_columns as $key => $name ) : ?>
 						<th scope="col" id="<?php echo esc_attr( sanitize_key( $key ) ); ?>" class="manage-column column-<?php echo esc_attr( sanitize_key( $key ) ); ?>" ><?php echo esc_html( $name ); ?></th>
 						<?php endforeach; ?>
 					</tr>
@@ -475,17 +489,18 @@ class EF_Story_Budget extends EF_Module {
 				<tfoot></tfoot>
 				<tbody>
 				<?php
-					foreach ($posts as $post)
-						$this->print_post( $post, $term );
+				foreach ( $posts as $post ) {
+					$this->print_post( $post, $term );
+				}
 				?>
 				</tbody>
 			</table>
-			<?php else: ?>
+			<?php else : ?>
 			<div class="message info"><p><?php _e( 'There are no posts for this term in the range or filter specified.', 'edit-flow' ); ?></p></div>
 			<?php endif; ?>
 		</div>
 	</div>
-	<?php
+		<?php
 	}
 
 	/**
@@ -494,19 +509,21 @@ class EF_Story_Budget extends EF_Module {
 	 * @param object $post The post to print.
 	 * @param object $parent_term The top-level term to which this post belongs.
 	 */
-	function print_post( $post, $parent_term ) {
+	public function print_post( $post, $parent_term ) {
 		?>
 		<tr id='post-<?php echo esc_attr( $post->ID ); ?>' class='alternate' valign="top">
-			<?php foreach( (array)$this->term_columns as $key => $name ) {
+			<?php
+			foreach ( (array) $this->term_columns as $key => $name ) {
 				echo '<td>';
 				if ( method_exists( $this, 'term_column_' . $key ) ) {
 					$method = 'term_column_' . $key;
-					echo $this->$method( $post, $parent_term );
+					echo wp_kses_post( $this->$method( $post, $parent_term ) );
 				} else {
-					echo $this->term_column_default( $post, $key, $parent_term );
+					echo wp_kses_post( $this->term_column_default( $post, $key, $parent_term ) );
 				}
 				echo '</td>';
-			} ?>
+			}
+			?>
 		</tr>
 		<?php
 	}
@@ -522,15 +539,16 @@ class EF_Story_Budget extends EF_Module {
 	 * @param object $parent_term The parent term for the term column
 	 * @return string $output Output value for the term column
 	 */
-	function term_column_default( $post, $column_name, $parent_term ) {
+	public function term_column_default( $post, $column_name, $parent_term ) {
 
 		// Hook for other modules to get data into columns
 		$column_value = null;
 		$column_value = apply_filters( 'ef_story_budget_term_column_value', $column_name, $post, $parent_term );
-		if ( !is_null( $column_value ) && $column_value != $column_name )
+		if ( ! is_null( $column_value ) && $column_value != $column_name ) {
 			return $column_value;
+		}
 
-		switch( $column_name ) {
+		switch ( $column_name ) {
 			case 'status':
 				$status_name = get_post_status_object( $post->post_status );
 				return $status_name->label;
@@ -545,12 +563,12 @@ class EF_Story_Budget extends EF_Module {
 				return $output;
 				break;
 			case 'post_modified':
+				// translators: %s is a human-readable time difference
 				return sprintf( esc_html__( '%s ago', 'edit-flow' ), human_time_diff( get_the_time( 'U', $post->ID ), current_time( 'timestamp' ) ) );
 				break;
 			default:
 				break;
 		}
-
 	}
 
 	/**
@@ -558,29 +576,35 @@ class EF_Story_Budget extends EF_Module {
 	 *
 	 * @since 0.7
 	 */
-	function term_column_title( $post, $parent_term ) {
+	public function term_column_title( $post, $parent_term ) {
 		$post_title = _draft_or_post_title( $post->ID );
 
 		$post_type_object = get_post_type_object( $post->post_type );
 		$can_edit_post = current_user_can( $post_type_object->cap->edit_post, $post->ID );
-		if ( $can_edit_post )
+		if ( $can_edit_post ) {
 			$output = '<strong><a href="' . get_edit_post_link( $post->ID ) . '">' . esc_html( $post_title ) . '</a></strong>';
-		else
+		} else {
 			$output = '<strong>' . esc_html( $post_title ) . '</strong>';
+		}
 
 		// Edit or Trash or View
 		$output .= '<div class="row-actions">';
 		$item_actions = array();
-		if ( $can_edit_post )
+		if ( $can_edit_post ) {
 			$item_actions['edit'] = '<a title="' . __( 'Edit this post', 'edit-flow' ) . '" href="' . get_edit_post_link( $post->ID ) . '">' . __( 'Edit', 'edit-flow' ) . '</a>';
-		if ( EMPTY_TRASH_DAYS > 0 && current_user_can( $post_type_object->cap->delete_post, $post->ID ) )
+		}
+		if ( EMPTY_TRASH_DAYS > 0 && current_user_can( $post_type_object->cap->delete_post, $post->ID ) ) {
 			$item_actions['trash'] = '<a class="submitdelete" title="' . __( 'Move this item to the Trash', 'edit-flow' ) . '" href="' . get_delete_post_link( $post->ID ) . '">' . __( 'Trash', 'edit-flow' ) . '</a>';
+		}
 
 		// Display a View or a Preview link depending on whether the post has been published or not
-		if ( in_array( $post->post_status, array( 'publish' ) ) )
+		if ( in_array( $post->post_status, array( 'publish' ) ) ) {
+			// translators: %s is the post title
 			$item_actions['view'] = '<a href="' . get_permalink( $post->ID ) . '" title="' . esc_attr( sprintf( __( 'View &#8220;%s&#8221;', 'edit-flow' ), $post_title ) ) . '" rel="permalink">' . __( 'View', 'edit-flow' ) . '</a>';
-		else if ( $can_edit_post )
+		} else if ( $can_edit_post ) {
+			// translators: %s is the post title
 			$item_actions['previewpost'] = '<a href="' . esc_url( apply_filters( 'preview_post_link', add_query_arg( 'preview', 'true', get_permalink( $post->ID ) ), $post ) ) . '" title="' . esc_attr( sprintf( __( 'Preview &#8220;%s&#8221;', 'edit-flow' ), $post_title ) ) . '" rel="permalink">' . __( 'Preview', 'edit-flow' ) . '</a>';
+		}
 
 		$item_actions = apply_filters( 'ef_story_budget_item_actions', $item_actions, $post->ID );
 		if ( count( $item_actions ) ) {
@@ -599,26 +623,28 @@ class EF_Story_Budget extends EF_Module {
 	/**
 	 * Print any messages that should appear based on the action performed
 	 */
-	function print_messages() {
-	?>
+	public function print_messages() {
+		?>
 
-	<?php
-		if ( isset($_GET['trashed']) || isset($_GET['untrashed']) ) {
+		<?php
+		if ( isset( $_GET['trashed'] ) || isset( $_GET['untrashed'] ) ) {
 
 			echo '<div id="trashed-message" class="updated"><p>';
 
 			// Following mostly stolen from edit.php
 
 			if ( isset( $_GET['trashed'] ) && (int) $_GET['trashed'] ) {
-				printf( _n( 'Item moved to the trash.', '%d items moved to the trash.', $_GET['trashed'] ), number_format_i18n( $_GET['trashed'] ) );
-				$ids = isset($_GET['ids']) ? $_GET['ids'] : 0;
-				echo ' <a href="' . esc_url( wp_nonce_url( "edit.php?post_type=post&doaction=undo&action=untrash&ids=$ids", "bulk-posts" ) ) . '">' . __( 'Undo', 'edit-flow' ) . '</a><br />';
-				unset($_GET['trashed']);
+				// translators: %d is the number of posts trashed
+				printf( esc_html( _n( 'Item moved to the trash.', '%d items moved to the trash.', $_GET['trashed'] ), number_format_i18n( $_GET['trashed'] ) ) );
+				$ids = isset( $_GET['ids'] ) ? $_GET['ids'] : 0;
+				echo ' <a href="' . esc_url( wp_nonce_url( "edit.php?post_type=post&doaction=undo&action=untrash&ids=$ids", 'bulk-posts' ) ) . '">' . esc_html__( 'Undo', 'edit-flow' ) . '</a><br />';
+				unset( $_GET['trashed'] );
 			}
 
-			if ( isset($_GET['untrashed'] ) && (int) $_GET['untrashed'] ) {
-				printf( _n( 'Item restored from the Trash.', '%d items restored from the Trash.', $_GET['untrashed'] ), number_format_i18n( $_GET['untrashed'] ) );
-				unset($_GET['undeleted']);
+			if ( isset( $_GET['untrashed'] ) && (int) $_GET['untrashed'] ) {
+				// translators: %d is the number of posts restored from the trash
+				printf( esc_html( _n( 'Item restored from the Trash.', '%d items restored from the Trash.', $_GET['untrashed'] ), number_format_i18n( $_GET['untrashed'] ) ) );
+				unset( $_GET['undeleted'] );
 			}
 
 			echo '</p></div>';
@@ -628,16 +654,16 @@ class EF_Story_Budget extends EF_Module {
 	/**
 	 * Print the table navigation and filter controls, using the current user's filters if any are set.
 	 */
-	function table_navigation() {
-	?>
+	public function table_navigation() {
+		?>
 	<div class="tablenav" id="ef-story-budget-tablenav">
 		<div class="alignleft actions">
 			<form method="GET" style="float: left;">
 				<input type="hidden" name="page" value="story-budget"/>
 				<?php
-					foreach($this->story_budget_filters() as $select_id => $select_name ) {
-						echo $this->story_budget_filter_options( $select_id, $select_name, $this->user_filters );
-					}
+				foreach ( $this->story_budget_filters() as $select_id => $select_name ) {
+					echo wp_kses_post( $this->story_budget_filter_options( $select_id, $select_name, $this->user_filters ) );
+				}
 				?>
 				<input type="submit" id="post-query-submit" value="<?php _e( 'Filter', 'edit-flow' ); ?>" class="button-primary button" />
 			</form>
@@ -647,8 +673,8 @@ class EF_Story_Budget extends EF_Module {
 				<input type="hidden" name="cat" value=""/>
 				<input type="hidden" name="author" value=""/>
 				<?php
-				foreach( $this->story_budget_filters() as $select_id => $select_name ) {
-					echo '<input type="hidden" name="'.$select_name.'" value="" />';
+				foreach ( $this->story_budget_filters() as $select_id => $select_name ) {
+					echo '<input type="hidden" name="' . esc_attr( $select_name ) . '" value="" />';
 				}
 				?>
 				<input type="submit" id="post-query-clear" value="<?php _e( 'Reset', 'edit-flow' ); ?>" class="button-secondary button" />
@@ -661,23 +687,23 @@ class EF_Story_Budget extends EF_Module {
 		<div class="clear"></div>
 
 	</div><!-- /tablenav -->
-	<?php
+		<?php
 	}
 
 	/**
 	 * Update the current user's filters for story budget display with the filters in $_GET. The filters
 	 * in $_GET take precedence over the current users filters if they exist.
 	 */
-	function update_user_filters() {
+	public function update_user_filters() {
 
 		$current_user = wp_get_current_user();
 
 		$user_filters = array(
-			'post_status' 	=> $this->filter_get_param( 'post_status' ),
-			'cat' 			=> $this->filter_get_param( 'cat' ),
-			'author'     	=> $this->filter_get_param( 'author' ),
-			'start_date' 	=> $this->filter_get_param( 'start_date' ),
-			'number_days'   => $this->filter_get_param( 'number_days' )
+			'post_status'   => $this->filter_get_param( 'post_status' ),
+			'cat'           => $this->filter_get_param( 'cat' ),
+			'author'        => $this->filter_get_param( 'author' ),
+			'start_date'    => $this->filter_get_param( 'start_date' ),
+			'number_days'   => $this->filter_get_param( 'number_days' ),
 		);
 
 		$current_user_filters = array();
@@ -685,18 +711,20 @@ class EF_Story_Budget extends EF_Module {
 
 		// If any of the $_GET vars are missing, then use the current user filter
 		foreach ( $user_filters as $key => $value ) {
-			if ( is_null( $value ) && !empty( $current_user_filters[$key] ) ) {
-				$user_filters[$key] = $current_user_filters[$key];
+			if ( is_null( $value ) && ! empty( $current_user_filters[ $key ] ) ) {
+				$user_filters[ $key ] = $current_user_filters[ $key ];
 			}
 		}
 
-		if ( !$user_filters['start_date'] )
-			$user_filters['start_date'] = date( 'Y-m-d' );
+		if ( ! $user_filters['start_date'] ) {
+			$user_filters['start_date'] = gmdate( 'Y-m-d' );
+		}
 
-		if ( !$user_filters['number_days'] )
+		if ( ! $user_filters['number_days'] ) {
 			$user_filters['number_days'] = 10;
+		}
 
-		$user_filters = apply_filters('ef_story_budget_filter_values', $user_filters, $current_user_filters);
+		$user_filters = apply_filters( 'ef_story_budget_filter_values', $user_filters, $current_user_filters );
 
 		$this->update_user_meta( $current_user->ID, self::usermeta_key_prefix . 'filters', $user_filters );
 		return $user_filters;
@@ -708,15 +736,16 @@ class EF_Story_Budget extends EF_Module {
 	 *
 	 * @return array The filters for the current user, or the default filters if the current user has none.
 	 */
-	function get_user_filters() {
+	public function get_user_filters() {
 
 		$current_user = wp_get_current_user();
 		$user_filters = array();
 		$user_filters = $this->get_user_meta( $current_user->ID, self::usermeta_key_prefix . 'filters', true );
 
 		// If usermeta didn't have filters already, insert defaults into DB
-		if ( empty( $user_filters ) )
+		if ( empty( $user_filters ) ) {
 			$user_filters = $this->update_user_filters();
+		}
 		return $user_filters;
 	}
 
@@ -724,72 +753,72 @@ class EF_Story_Budget extends EF_Module {
 	 *
 	 * @param string $param The parameter to look for in $_GET
 	 * @return null if the parameter is not set in $_GET, empty string if the parameter is empty in $_GET,
-	 *		   or a sanitized version of the parameter from $_GET if set and not empty
+	 *         or a sanitized version of the parameter from $_GET if set and not empty
 	 */
-	function filter_get_param( $param ) {
+	public function filter_get_param( $param ) {
 		// Sure, this could be done in one line. But we're cooler than that: let's make it more readable!
-		if ( !isset( $_GET[$param] ) ) {
+		if ( ! isset( $_GET[ $param ] ) ) {
 			return null;
-		} else if ( empty( $_GET[$param] ) ) {
+		} else if ( empty( $_GET[ $param ] ) ) {
 			return '';
 		}
 
-		return sanitize_key( $_GET[$param] );
+		return sanitize_key( $_GET[ $param ] );
 	}
 
-	function story_budget_filters() {
+	public function story_budget_filters() {
 		$select_filter_names = array();
 
 		$select_filter_names['post_status'] = 'post_status';
 		$select_filter_names['cat'] = 'cat';
 		$select_filter_names['author'] = 'author';
 
-		return apply_filters('ef_story_budget_filter_names', $select_filter_names);
+		return apply_filters( 'ef_story_budget_filter_names', $select_filter_names );
 	}
 
-	function story_budget_filter_options( $select_id, $select_name, $filters ) {
-		switch( $select_id ) {
+	public function story_budget_filter_options( $select_id, $select_name, $filters ) {
+		switch ( $select_id ) {
 			case 'post_status':
-			$post_stati = $this->get_budget_post_stati();
-			?>
+				$post_stati = $this->get_budget_post_stati();
+				?>
 				<select id="post_status" name="post_status"><!-- Status selectors -->
 						<option value=""><?php _e( 'View all statuses', 'edit-flow' ); ?></option>
 						<?php
-							foreach ( $post_stati as $status ) {
-								echo '<option value="' . esc_attr( $status->name ) . '" ' . selected( $status->name, $filters['post_status'] ) . '>' . esc_html( $status->label ) . '</option>';
-							}
-							echo '<option value="unpublish"' . selected('unpublish', $filters['post_status']) . '>' . __( 'Unpublished', 'edit-flow' ) . '</option>';
+						foreach ( $post_stati as $status ) {
+							echo '<option value="' . esc_attr( $status->name ) . '" ' . selected( $status->name, $filters['post_status'] ) . '>' . esc_html( $status->label ) . '</option>';
+						}
+							echo '<option value="unpublish"' . selected( 'unpublish', $filters['post_status'] ) . '>' . esc_html__( 'Unpublished', 'edit-flow' ) . '</option>';
 						?>
 					</select>
-			<?php
-			break;
+				<?php
+				break;
 			case 'cat':
 				// Borrowed from wp-admin/edit.php
-				if ( taxonomy_exists('category') ) {
+				if ( taxonomy_exists( 'category' ) ) {
 					$category_dropdown_args = array(
 						'show_option_all' => __( 'View all categories', 'edit-flow' ),
 						'hide_empty' => 0,
 						'hierarchical' => 1,
 						'show_count' => 0,
 						'orderby' => 'name',
-						'selected' => $this->user_filters['cat']
-						);
+						'selected' => $this->user_filters['cat'],
+					);
 					wp_dropdown_categories( $category_dropdown_args );
 				}
-			break;
+				break;
 			case 'author':
 				$users_dropdown_args = array(
-						'show_option_all' => __( 'View all users', 'edit-flow' ),
-						'name'     => 'author',
-						'selected' => $this->user_filters['author'],
-						'who' => 'authors',
-						);
+					'show_option_all' => __( 'View all users', 'edit-flow' ),
+					'name'     => 'author',
+					'selected' => $this->user_filters['author'],
+					'who' => 'authors',
+				);
 				$users_dropdown_args = apply_filters( 'ef_story_budget_users_dropdown_args', $users_dropdown_args );
 				wp_dropdown_users( $users_dropdown_args );
-			break;
+				break;
 			default:
-				do_action( 'ef_story_budget_filter_display', $select_id, $select_name, $filters);
-			break;
+				do_action( 'ef_story_budget_filter_display', $select_id, $select_name, $filters );
+				break;
 		}
 	}
 
@@ -808,13 +837,12 @@ class EF_Story_Budget extends EF_Module {
 
 		$final_statuses = [];
 
-		foreach( $post_stati as $status ) {
-			if ( !empty( $custom_status_slug_keys[ $status->name ] ) ) {
+		foreach ( $post_stati as $status ) {
+			if ( ! empty( $custom_status_slug_keys[ $status->name ] ) ) {
 				$final_statuses[] = $status;
 			}
 		}
 
 		return apply_filters( 'ef_budget_post_stati', $final_statuses );
 	}
-
 }

--- a/modules/user-groups/user-groups.php
+++ b/modules/user-groups/user-groups.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * class EF_User_Groups
- * 
+ *
  * @todo all of them PHPdocs
  * @todo Resolve whether the notifications component of this class should be moved to "subscriptions"
  * @todo Decide whether it's functional to store user_ids in the term description array
@@ -9,565 +9,605 @@
  *
  */
 
-if ( !class_exists( 'EF_User_Groups' ) ) {
+if ( ! class_exists( 'EF_User_Groups' ) ) {
 
-class EF_User_Groups extends EF_Module {
-	
-	var $module;
-	
-	/**
-	 * Keys for storing data
-	 * - taxonomy_key - used for custom taxonomy
-	 * - term_prefix - Used for custom taxonomy terms
-	 */
-	const taxonomy_key = 'ef_usergroup';
-	const term_prefix = 'ef-usergroup-';
+	class EF_User_Groups extends EF_Module {
 
-	var $manage_usergroups_cap = 'edit_usergroups';
+		public $module;
 
-	/**
-	 * Register the module with Edit Flow but don't do anything else
-	 *
-	 * @since 0.7
-	 */
-	function __construct( ) {
-		
-		$this->module_url = $this->get_module_url( __FILE__ );
-		
-		// Register the User Groups module with Edit Flow
-		$args = array(
-			'title' => __( 'User Groups', 'edit-flow' ),
-			'short_description' => __( 'Organize your users into groups to mimic your organizational structure.', 'edit-flow' ),
-			'extended_description' => __( 'Configure user groups to organize all of the users on your site. Each user can be in many user groups and you can change them at any time.', 'edit-flow' ),
-			'module_url' => $this->module_url,
-			'img_url' => $this->module_url . 'lib/usergroups_s128.png',
-			'slug' => 'user-groups',
-			'default_options' => array(
-				'enabled' => 'on',
-				'post_types' => array(
-					'post' => 'on',
-					'page' => 'off',
-				),
-			),
-			'messages' => array(
-				'usergroup-added' => __( "User group created. Feel free to add users to the usergroup.", 'edit-flow' ),
-				'usergroup-updated' => __( "User group updated.", 'edit-flow' ),
-				'usergroup-missing' => __( "User group doesn't exist.", 'edit-flow' ),
-				'usergroup-deleted' => __( "User group deleted.", 'edit-flow' ),				
-			),
-			'configure_page_cb' => 'print_configure_view',
-			'configure_link_text' => __( 'Manage User Groups', 'edit-flow' ),
-			'autoload' => false,
-			'settings_help_tab' => array(
-				'id' => 'ef-user-groups-overview',
-				'title' => __('Overview', 'edit-flow'),
-				'content' => __('<p>For those with many people involved in the publishing process, user groups helps you keep them organized.</p><p>Currently, user groups are primarily used for subscribing a set of users to a post for notifications.</p>', 'edit-flow'),
-				),
-			'settings_help_sidebar' => __( '<p><strong>For more information:</strong></p><p><a href="http://editflow.org/features/user-groups/">User Groups Documentation</a></p><p><a href="http://wordpress.org/tags/edit-flow?forum_id=10">Edit Flow Forum</a></p><p><a href="https://github.com/danielbachhuber/Edit-Flow">Edit Flow on Github</a></p>', 'edit-flow' ),
-		);
-		$this->module = EditFlow()->register_module( 'user_groups', $args );
-		
-	}
-	
-	/**
-	 * Module startup
-	 */
-	
-	/**
-	 * Initialize the rest of the stuff in the class if the module is active
-	 *
-	 * @since 0.7
-	 */	
-	function init() {
-		
-		// Register the objects where we'll be storing data and relationships
-		$this->register_usergroup_objects();
-
-		$this->manage_usergroups_cap = apply_filters( 'ef_manage_usergroups_cap', $this->manage_usergroups_cap );
-		
-		// Register our settings
-		add_action( 'admin_init', array( $this, 'register_settings' ) );		
-		
-		// Handle any adding, editing or saving
-		add_action( 'admin_init', array( $this, 'handle_add_usergroup' ) );
-		add_action( 'admin_init', array( $this, 'handle_edit_usergroup' ) );
-		add_action( 'admin_init', array( $this, 'handle_delete_usergroup' ) );
-		add_action( 'wp_ajax_inline_save_usergroup', array( $this, 'handle_ajax_inline_save_usergroup' ) );
-	
-		// Usergroups can be managed from the User profile view
-		add_action( 'show_user_profile', array( $this, 'user_profile_page' ) );
-		add_action( 'edit_user_profile', array( $this, 'user_profile_page' ) );
-		add_action( 'user_profile_update_errors', array( $this, 'user_profile_update' ), 10, 3 );
-
-		// Javascript and CSS if we need it
-		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_admin_scripts' ) );
-		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_admin_styles' ) );	
-		
-	}
-	
-	/**
-	 * Load the capabilities onto users the first time the module is run
-	 *
-	 * @since 0.7
-	 */
-	function install() {
-
-		// Add necessary capabilities to allow management of user groups
-		$usergroup_roles = array(
-			'administrator' => array('edit_usergroups'),
-		);
-		foreach( $usergroup_roles as $role => $caps ) {
-			$this->add_caps_to_role( $role, $caps );
-		}
-		
-		// Create our default usergroups
-		$default_usergroups = array( 
-			array( 
-				'name' => __( 'Copy Editors', 'edit-flow' ),
-				'description' => __( 'Making sure the quality is top-notch.', 'edit-flow' ),
-			),
-			array(
-				'name' => __( 'Photographers', 'edit-flow' ), 
-				'description' => __( 'Capturing the story visually.', 'edit-flow' ),
-			),
-			array(
-				'name' => __( 'Reporters', 'edit-flow' ),
-				'description' => __( 'Out in the field, writing stories.', 'edit-flow' ),
-			),
-			array(
-				'name' => __( 'Section Editors', 'edit-flow' ),
-				'description' => __( 'Providing feedback and direction.', 'edit-flow' ),
-			),
-		);
-		foreach( $default_usergroups as $args ) {
-			$this->add_usergroup( $args );
-		}
-		
-	}
-
-	/**
-	 * Upgrade our data in case we need to
-	 *
-	 * @since 0.7
-	 */
-	function upgrade( $previous_version ) {
-		global $edit_flow;
-
-		// Upgrade path to v0.7
-		if ( version_compare( $previous_version, '0.7' , '<' ) ) {
-			global $wpdb;
-
-			// Set all of the user group terms to our new taxonomy
-			$wpdb->update( $wpdb->term_taxonomy, array( 'taxonomy' => self::taxonomy_key ), array( 'taxonomy' => 'following_usergroups' ) );
-
-			// Get all of the users who are a part of user groups and assign them to their new user group values
-			$query = "SELECT * FROM $wpdb->usermeta WHERE meta_key='wp_ef_usergroups';";
-			$usergroup_users = $wpdb->get_results( $query );
-
-			// Sort all of the users based on their usergroup(s)
-			$users_to_add = array();
-			foreach( (array)$usergroup_users as $usergroup_user ) {
-				if ( is_object( $usergroup_user ) )
-					$users_to_add[$usergroup_user->meta_value][] = (int)$usergroup_user->user_id;
-			}
-			// Add user IDs to each usergroup
-			foreach( $users_to_add as $usergroup_slug => $users_array ) {
-				$usergroup = $this->get_usergroup_by( 'slug', $usergroup_slug );
-				$this->add_users_to_usergroup( $users_array, $usergroup->term_id );
-			}
-			// Update the term slugs for each user group
-			$all_usergroups = $this->get_usergroups();
-			foreach( $all_usergroups as $usergroup ) {
-				$new_slug = str_replace( 'ef_', self::term_prefix, $usergroup->slug );
-				$this->update_usergroup( $usergroup->term_id, array( 'slug' => $new_slug ) );
-			}
-
-			// Delete all of the previous usermeta values
-			$wpdb->query( "DELETE FROM $wpdb->usermeta WHERE meta_key='wp_ef_usergroups';" );
-
-			// Technically we've run this code before so we don't want to auto-install new data
-			$edit_flow->update_module_option( $this->module->name, 'loaded_once', true );
-
-		}
-		// Upgrade path to v0.7.4
-		if ( version_compare( $previous_version, '0.7.4', '<' ) ) {
-			// Usergroup descriptions become base64_encoded, instead of maybe json_encoded.
-			$this->upgrade_074_term_descriptions( self::taxonomy_key );
-		}
-
-	}
-	
-	/**
-	 * Individual Usergroups are stored using a custom taxonomy
-	 * Posts are associated with usergroups based on taxonomy relationship
-	 * User associations are stored serialized in the term's description field
-	 *
-	 * @since 0.7
-	 *
-	 * @uses register_taxonomy()
-	 */
-	function register_usergroup_objects() {
-		
-		// Load the currently supported post types so we only register against those
-		$supported_post_types = $this->get_post_types_for_module( $this->module );
-		
-		// Use a taxonomy to manage relationships between posts and usergroups
-		$args = array(
-			'public' => false,
-			'rewrite' => false,
-		);
-		register_taxonomy( self::taxonomy_key, $supported_post_types, $args );
-	}
-	
-	/**
-	 * Enqueue necessary admin scripts
-	 *
-	 * @since 0.7
-	 *
-	 * @uses wp_enqueue_script()
-	 */
-	function enqueue_admin_scripts() {
-		
-		if ( $this->is_whitelisted_functional_view() || $this->is_whitelisted_settings_view( $this->module->name ) ) {
-			wp_enqueue_script( 'jquery-listfilterizer' );
-			wp_enqueue_script( 'jquery-quicksearch' );
-			wp_enqueue_script( 'edit-flow-user-groups-js', $this->module_url . 'lib/user-groups.js', array( 'jquery', 'jquery-listfilterizer', 'jquery-quicksearch' ), EDIT_FLOW_VERSION, true );
-		}
-			
-		if ( $this->is_whitelisted_settings_view( $this->module->name ) )	
-			wp_enqueue_script( 'edit-flow-user-groups-configure-js', $this->module_url . 'lib/user-groups-configure.js', array( 'jquery' ), EDIT_FLOW_VERSION, true );
-	}
-	
-	/**
-	 * Enqueue necessary admin styles, but only on the proper pages
-	 *
-	 * @since 0.7
-	 *
-	 * @uses wp_enqueue_style()	
-	 */
-	function enqueue_admin_styles() {
-
-		
-		if ( $this->is_whitelisted_functional_view() || $this->is_whitelisted_settings_view() ) {
-			wp_enqueue_style( 'jquery-listfilterizer' );
-			wp_enqueue_style( 'edit-flow-user-groups-css', $this->module_url . 'lib/user-groups.css', false, EDIT_FLOW_VERSION );
-		}
-	}
-	
-	/**
-	 * Module ???
-	 */
-	
-	/**
-	 * Handles a POST request to add a new Usergroup. Redirects to edit view after
-	 * for admin to add users to usergroup
-	 * Hooked into 'admin_init' and kicks out right away if no action	
-	 *
-	 * @since 0.7
-	 */
-	function handle_add_usergroup() {
-
-		if ( !isset( $_POST['submit'], $_POST['form-action'], $_GET['page'] ) 
-			|| $_GET['page'] != $this->module->settings_slug || $_POST['form-action'] != 'add-usergroup' )
-				return;
-				
-		if ( !wp_verify_nonce( $_POST['_wpnonce'], 'add-usergroup' ) )
-			wp_die( $this->module->messages['nonce-failed'] );
-			
-		if ( !current_user_can( $this->manage_usergroups_cap ) )
-			wp_die( $this->module->messages['invalid-permissions'] );			
-		
-		// Sanitize all of the user-entered values
-		$name = strip_tags( trim( $_POST['name'] ) );
-		$description = stripslashes( strip_tags( trim( $_POST['description'] ) ) );
-		
-		$_REQUEST['form-errors'] = array();
-		
 		/**
-		 * Form validation for adding new Usergroup
-		 *
-		 * Details
-		 * - 'name' is a required field, but can't match an existing name or slug. Needs to be 40 characters or less
-		 * - "description" can accept a limited amount of HTML, and is optional
+		 * Keys for storing data
+		 * - taxonomy_key - used for custom taxonomy
+		 * - term_prefix - Used for custom taxonomy terms
 		 */
-		// Field is required
-		if ( empty( $name ) )
-			$_REQUEST['form-errors']['name'] = __( 'Please enter a name for the user group.', 'edit-flow' );
-		// Check to ensure a term with the same name doesn't exist
-		if ( $this->get_usergroup_by( 'name', $name ) )
-			$_REQUEST['form-errors']['name'] = __( 'Name already in use. Please choose another.', 'edit-flow' );
-		// Check to ensure a term with the same slug doesn't exist
-		if ( $this->get_usergroup_by( 'slug', sanitize_title( $name ) ) )
-			$_REQUEST['form-errors']['name'] = __( 'Name conflicts with slug for another term. Please choose again.', 'edit-flow' );
-		if ( strlen( $name ) > 40 )
-			$_REQUEST['form-errors']['name'] = __( 'User group name cannot exceed 40 characters. Please try a shorter name.', 'edit-flow' );			
-		// Kick out if there are any errors
-		if ( count( $_REQUEST['form-errors'] ) ) {
-			$_REQUEST['error'] = 'form-error';
-			return;
-		}
+		// phpcs:ignore Generic.NamingConventions.UpperCaseConstantName.ClassConstantNotUpperCase
+		const taxonomy_key = 'ef_usergroup';
+		// phpcs:ignore Generic.NamingConventions.UpperCaseConstantName.ClassConstantNotUpperCase
+		const term_prefix = 'ef-usergroup-';
 
-		// Try to add the Usergroup
-		$args = array(
-			'name' => $name,
-			'description' => $description,
-		);
-		$usergroup = $this->add_usergroup( $args );
-		if ( is_wp_error( $usergroup ) )
-			wp_die( __( 'Error adding usergroup.', 'edit-flow' ) );
+		public $manage_usergroups_cap = 'edit_usergroups';
 
-		$args = array(
-			'action' => 'edit-usergroup',
-			'usergroup-id' => $usergroup->term_id,
-			'message' => 'usergroup-added'
-		);
-		$redirect_url = $this->get_link( $args );
-		wp_redirect( $redirect_url );
-		exit;
-	}
-	
-	/**
-	 * Handles a POST request to edit a Usergroup
-	 * Hooked into 'admin_init' and kicks out right away if no action
-	 *
-	 * @since 0.7	
-	 */ 
-	function handle_edit_usergroup() {
-		if ( !isset( $_POST['submit'], $_POST['form-action'], $_GET['page'] ) 
-			|| $_GET['page'] != $this->module->settings_slug || $_POST['form-action'] != 'edit-usergroup' )
-				return;
-				
-		if ( !wp_verify_nonce( $_POST['_wpnonce'], 'edit-usergroup' ) )
-			wp_die( $this->module->messages['nonce-failed'] );
-			
-		if ( !current_user_can( $this->manage_usergroups_cap ) )
-			wp_die( $this->module->messages['invalid-permissions'] );
-			
-		if ( !$existing_usergroup = $this->get_usergroup_by( 'id', (int)$_POST['usergroup_id'] ) )
-			wp_die( $this->module->messages['usergroup-missing'] );			
-		
-		// Sanitize all of the user-entered values
-		$name = strip_tags( trim( $_POST['name'] ) );
-		$description = stripslashes( strip_tags( trim( $_POST['description'] ) ) );
-		
-		$_REQUEST['form-errors'] = array();
-		
 		/**
-		 * Form validation for editing a Usergroup
+		 * Register the module with Edit Flow but don't do anything else
 		 *
-		 * Details
-		 * - 'name' is a required field, but can't match an existing name or slug. Needs to be 40 characters or less
-		 * - "description" can accept a limited amount of HTML, and is optional
+		 * @since 0.7
 		 */
-		// Field is required
-		if ( empty( $name ) )
-			$_REQUEST['form-errors']['name'] = __( 'Please enter a name for the user group.', 'edit-flow' );
-		// Check to ensure a term with the same name doesn't exist
-		$search_term = $this->get_usergroup_by( 'name', $name );
-		if ( is_object( $search_term ) && $search_term->term_id != $existing_usergroup->term_id )
-			$_REQUEST['form-errors']['name'] = __( 'Name already in use. Please choose another.', 'edit-flow' );
-		// Check to ensure a term with the same slug doesn't exist
-		$search_term = $this->get_usergroup_by( 'slug', sanitize_title( $name ) );
-		if ( is_object( $search_term ) && $search_term->term_id != $existing_usergroup->term_id )
-			$_REQUEST['form-errors']['name'] = __( 'Name conflicts with slug for another term. Please choose again.', 'edit-flow' );
-		if ( strlen( $name ) > 40 )
-			$_REQUEST['form-errors']['name'] = __( 'User group name cannot exceed 40 characters. Please try a shorter name.', 'edit-flow' );			
-		// Kick out if there are any errors
-		if ( count( $_REQUEST['form-errors'] ) ) {
-			$_REQUEST['error'] = 'form-error';
-			return;
+		public function __construct() {
+
+			$this->module_url = $this->get_module_url( __FILE__ );
+
+			// Register the User Groups module with Edit Flow
+			$args = array(
+				'title' => __( 'User Groups', 'edit-flow' ),
+				'short_description' => __( 'Organize your users into groups to mimic your organizational structure.', 'edit-flow' ),
+				'extended_description' => __( 'Configure user groups to organize all of the users on your site. Each user can be in many user groups and you can change them at any time.', 'edit-flow' ),
+				'module_url' => $this->module_url,
+				'img_url' => $this->module_url . 'lib/usergroups_s128.png',
+				'slug' => 'user-groups',
+				'default_options' => array(
+					'enabled' => 'on',
+					'post_types' => array(
+						'post' => 'on',
+						'page' => 'off',
+					),
+				),
+				'messages' => array(
+					'usergroup-added' => __( 'User group created. Feel free to add users to the usergroup.', 'edit-flow' ),
+					'usergroup-updated' => __( 'User group updated.', 'edit-flow' ),
+					'usergroup-missing' => __( "User group doesn't exist.", 'edit-flow' ),
+					'usergroup-deleted' => __( 'User group deleted.', 'edit-flow' ),
+				),
+				'configure_page_cb' => 'print_configure_view',
+				'configure_link_text' => __( 'Manage User Groups', 'edit-flow' ),
+				'autoload' => false,
+				'settings_help_tab' => array(
+					'id' => 'ef-user-groups-overview',
+					'title' => __( 'Overview', 'edit-flow' ),
+					'content' => __( '<p>For those with many people involved in the publishing process, user groups helps you keep them organized.</p><p>Currently, user groups are primarily used for subscribing a set of users to a post for notifications.</p>', 'edit-flow' ),
+				),
+				'settings_help_sidebar' => __( '<p><strong>For more information:</strong></p><p><a href="http://editflow.org/features/user-groups/">User Groups Documentation</a></p><p><a href="http://wordpress.org/tags/edit-flow?forum_id=10">Edit Flow Forum</a></p><p><a href="https://github.com/danielbachhuber/Edit-Flow">Edit Flow on Github</a></p>', 'edit-flow' ),
+			);
+			$this->module = EditFlow()->register_module( 'user_groups', $args );
 		}
 
-		// Try to edit the Usergroup
-		$args = array(
-			'name' => $name,
-			'description' => $description,
-		);
-		// Gracefully handle the case where all users have been unsubscribed from the user group
-		$users = isset( $_POST['usergroup_users'] ) ? (array)$_POST['usergroup_users'] : array();
-		$users = array_map( 'intval', $users );
-		$usergroup = $this->update_usergroup( $existing_usergroup->term_id, $args, $users );
-		if ( is_wp_error( $usergroup ) )
-			wp_die( __( 'Error updating user group.', 'edit-flow' ) );
-
-		$args = array(
-			'message' => 'usergroup-updated',
-		);
-		$redirect_url = $this->get_link( $args );
-		wp_redirect( $redirect_url );
-		exit;
-	}
-	
-	/**
-	 * Handles a request to delete a Usergroup.
-	 * Hooked into 'admin_init' and kicks out right away if no action
-	 *
-	 * @since 0.7
-	 */
-	function handle_delete_usergroup() {
-		if ( !isset( $_GET['page'], $_GET['action'], $_GET['usergroup-id'] ) 
-			|| $_GET['page'] != $this->module->settings_slug || $_GET['action'] != 'delete-usergroup' )
-				return;
-				
-		if ( !wp_verify_nonce( $_GET['nonce'], 'delete-usergroup' ) )
-			wp_die( $this->module->messages['nonce-failed'] );
-			
-		if ( !current_user_can( $this->manage_usergroups_cap ) )
-			wp_die( $this->module->messages['invalid-permissions'] );			
-			
-		$result = $this->delete_usergroup( (int)$_GET['usergroup-id'] );
-		if ( !$result || is_wp_error( $result ) )
-			wp_die( __( 'Error deleting user group.', 'edit-flow' ) );
-			
-		$redirect_url = $this->get_link( array( 'message' => 'usergroup-deleted' ) );
-		wp_redirect( $redirect_url );
-		exit;		
-	}
-	
-	/**
-	 * Handle the request to update a given Usergroup via inline edit
-	 *
-	 * @since 0.7
-	 */
-	function handle_ajax_inline_save_usergroup() {
-		
-		if ( !wp_verify_nonce( $_POST['inline_edit'], 'usergroups-inline-edit-nonce' ) )
-			die( $this->module->messages['nonce-failed'] );
-			
-		if ( !current_user_can( $this->manage_usergroups_cap ) )
-			die( $this->module->messages['invalid-permissions'] );
-		
-		$usergroup_id = (int) $_POST['usergroup_id'];
-		if ( !$existing_term = $this->get_usergroup_by( 'id', $usergroup_id ) )
-			die( $this->module->messages['usergroup-missing'] );
-		
-		$name = strip_tags( trim( $_POST['name'] ) );
-		$description = stripslashes( strip_tags( trim( $_POST['description'] ) ) );
-		
 		/**
-		 * Form validation for editing Usergroup
-		 */	
-		// Check if name field was filled in
-		if ( empty( $name ) ) {
-			$change_error = new WP_Error( 'invalid', __( 'Please enter a name for the user group.', 'edit-flow' ) );
-			die( $change_error->get_error_message() );
+		 * Module startup
+		 */
+
+		/**
+		 * Initialize the rest of the stuff in the class if the module is active
+		 *
+		 * @since 0.7
+		 */
+		public function init() {
+
+			// Register the objects where we'll be storing data and relationships
+			$this->register_usergroup_objects();
+
+			$this->manage_usergroups_cap = apply_filters( 'ef_manage_usergroups_cap', $this->manage_usergroups_cap );
+
+			// Register our settings
+			add_action( 'admin_init', array( $this, 'register_settings' ) );
+
+			// Handle any adding, editing or saving
+			add_action( 'admin_init', array( $this, 'handle_add_usergroup' ) );
+			add_action( 'admin_init', array( $this, 'handle_edit_usergroup' ) );
+			add_action( 'admin_init', array( $this, 'handle_delete_usergroup' ) );
+			add_action( 'wp_ajax_inline_save_usergroup', array( $this, 'handle_ajax_inline_save_usergroup' ) );
+
+			// Usergroups can be managed from the User profile view
+			add_action( 'show_user_profile', array( $this, 'user_profile_page' ) );
+			add_action( 'edit_user_profile', array( $this, 'user_profile_page' ) );
+			add_action( 'user_profile_update_errors', array( $this, 'user_profile_update' ), 10, 3 );
+
+			// Javascript and CSS if we need it
+			add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_admin_scripts' ) );
+			add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_admin_styles' ) );
 		}
-		// Check that the name doesn't exceed 40 chars
-		if ( strlen( $name ) > 40 ) {
-			$change_error = new WP_Error( 'invalid', __( 'User group name cannot exceed 40 characters. Please try a shorter name.' ) );
-			die( $change_error->get_error_message() );
+
+		/**
+		 * Load the capabilities onto users the first time the module is run
+		 *
+		 * @since 0.7
+		 */
+		public function install() {
+
+			// Add necessary capabilities to allow management of user groups
+			$usergroup_roles = array(
+				'administrator' => array( 'edit_usergroups' ),
+			);
+			foreach ( $usergroup_roles as $role => $caps ) {
+				$this->add_caps_to_role( $role, $caps );
+			}
+
+			// Create our default usergroups
+			$default_usergroups = array(
+				array(
+					'name' => __( 'Copy Editors', 'edit-flow' ),
+					'description' => __( 'Making sure the quality is top-notch.', 'edit-flow' ),
+				),
+				array(
+					'name' => __( 'Photographers', 'edit-flow' ),
+					'description' => __( 'Capturing the story visually.', 'edit-flow' ),
+				),
+				array(
+					'name' => __( 'Reporters', 'edit-flow' ),
+					'description' => __( 'Out in the field, writing stories.', 'edit-flow' ),
+				),
+				array(
+					'name' => __( 'Section Editors', 'edit-flow' ),
+					'description' => __( 'Providing feedback and direction.', 'edit-flow' ),
+				),
+			);
+			foreach ( $default_usergroups as $args ) {
+				$this->add_usergroup( $args );
+			}
 		}
-		// Check to ensure a term with the same name doesn't exist
-		$search_term = $this->get_usergroup_by( 'name', $name );
-		if ( is_object( $search_term ) && $search_term->term_id != $existing_term->term_id ) {
-			$change_error = new WP_Error( 'invalid', __( 'Name already in use. Please choose another.', 'edit-flow' ) );
-			die( $change_error->get_error_message() );
+
+		/**
+		 * Upgrade our data in case we need to
+		 *
+		 * @since 0.7
+		 */
+		public function upgrade( $previous_version ) {
+			global $edit_flow;
+
+			// Upgrade path to v0.7
+			if ( version_compare( $previous_version, '0.7', '<' ) ) {
+				global $wpdb;
+
+				// Set all of the user group terms to our new taxonomy
+				$wpdb->update( $wpdb->term_taxonomy, array( 'taxonomy' => self::taxonomy_key ), array( 'taxonomy' => 'following_usergroups' ) );
+
+				// Get all of the users who are a part of user groups and assign them to their new user group values
+				$query = "SELECT * FROM $wpdb->usermeta WHERE meta_key='wp_ef_usergroups';";
+				// There's no userdata here in this query and it's an upgrade query
+				// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+				$usergroup_users = $wpdb->get_results( $query );
+
+				// Sort all of the users based on their usergroup(s)
+				$users_to_add = array();
+				foreach ( (array) $usergroup_users as $usergroup_user ) {
+					if ( is_object( $usergroup_user ) ) {
+						$users_to_add[ $usergroup_user->meta_value ][] = (int) $usergroup_user->user_id;
+					}
+				}
+				// Add user IDs to each usergroup
+				foreach ( $users_to_add as $usergroup_slug => $users_array ) {
+					$usergroup = $this->get_usergroup_by( 'slug', $usergroup_slug );
+					$this->add_users_to_usergroup( $users_array, $usergroup->term_id );
+				}
+				// Update the term slugs for each user group
+				$all_usergroups = $this->get_usergroups();
+				foreach ( $all_usergroups as $usergroup ) {
+					$new_slug = str_replace( 'ef_', self::term_prefix, $usergroup->slug );
+					$this->update_usergroup( $usergroup->term_id, array( 'slug' => $new_slug ) );
+				}
+
+				// Delete all of the previous usermeta values
+				$wpdb->query( "DELETE FROM $wpdb->usermeta WHERE meta_key='wp_ef_usergroups';" );
+
+				// Technically we've run this code before so we don't want to auto-install new data
+				$edit_flow->update_module_option( $this->module->name, 'loaded_once', true );
+
+			}
+			// Upgrade path to v0.7.4
+			if ( version_compare( $previous_version, '0.7.4', '<' ) ) {
+				// Usergroup descriptions become base64_encoded, instead of maybe json_encoded.
+				$this->upgrade_074_term_descriptions( self::taxonomy_key );
+			}
 		}
-		// Check to ensure a term with the same slug doesn't exist
-		$search_term = $this->get_usergroup_by( 'slug', sanitize_title( $name ) );
-		if ( is_object( $search_term ) && $search_term->term_id != $existing_term->term_id ) {
-			$change_error = new WP_Error( 'invalid', __( 'Name conflicts with slug for another term. Please choose again.', 'edit-flow' ) );
-			die( $change_error->get_error_message() );
+
+		/**
+		 * Individual Usergroups are stored using a custom taxonomy
+		 * Posts are associated with usergroups based on taxonomy relationship
+		 * User associations are stored serialized in the term's description field
+		 *
+		 * @since 0.7
+		 *
+		 * @uses register_taxonomy()
+		 */
+		public function register_usergroup_objects() {
+
+			// Load the currently supported post types so we only register against those
+			$supported_post_types = $this->get_post_types_for_module( $this->module );
+
+			// Use a taxonomy to manage relationships between posts and usergroups
+			$args = array(
+				'public' => false,
+				'rewrite' => false,
+			);
+			register_taxonomy( self::taxonomy_key, $supported_post_types, $args );
 		}
-		
-		// Prepare the term name and description for saving
-		$args = array(
-			'name' => $name,
-			'description' => $description,
-		);
-		$return = $this->update_usergroup( $existing_term->term_id, $args );
-		if( !is_wp_error( $return ) ) {	
-			set_current_screen( 'edit-usergroup' );					
-			$wp_list_table = new EF_Usergroups_List_Table();
-			$wp_list_table->prepare_items();
-			echo $wp_list_table->single_row( $return );
-			die();
-		} else {
-			$change_error = new WP_Error( 'invalid', sprintf( __( 'Could not update the user group: <strong>%s</strong>', 'edit-flow' ), $usergroup_name ) );
-			die( $change_error->get_error_message() );
+
+		/**
+		 * Enqueue necessary admin scripts
+		 *
+		 * @since 0.7
+		 *
+		 * @uses wp_enqueue_script()
+		 */
+		public function enqueue_admin_scripts() {
+
+			if ( $this->is_whitelisted_functional_view() || $this->is_whitelisted_settings_view( $this->module->name ) ) {
+				wp_enqueue_script( 'jquery-listfilterizer' );
+				wp_enqueue_script( 'jquery-quicksearch' );
+				wp_enqueue_script( 'edit-flow-user-groups-js', $this->module_url . 'lib/user-groups.js', array( 'jquery', 'jquery-listfilterizer', 'jquery-quicksearch' ), EDIT_FLOW_VERSION, true );
+			}
+
+			if ( $this->is_whitelisted_settings_view( $this->module->name ) ) {
+				wp_enqueue_script( 'edit-flow-user-groups-configure-js', $this->module_url . 'lib/user-groups-configure.js', array( 'jquery' ), EDIT_FLOW_VERSION, true );
+			}
 		}
-		
-	}
-	
-	/**
-	 * Register settings for notifications so we can partially use the Settings API
-	 * (We use the Settings API for form generation, but not saving)
-	 * 
-	 * @since 0.7
-	 * @uses add_settings_section(), add_settings_field()
-	 */
-	function register_settings() {
+
+		/**
+		 * Enqueue necessary admin styles, but only on the proper pages
+		 *
+		 * @since 0.7
+		 *
+		 * @uses wp_enqueue_style()
+		 */
+		public function enqueue_admin_styles() {
+
+
+			if ( $this->is_whitelisted_functional_view() || $this->is_whitelisted_settings_view() ) {
+				wp_enqueue_style( 'jquery-listfilterizer' );
+				wp_enqueue_style( 'edit-flow-user-groups-css', $this->module_url . 'lib/user-groups.css', false, EDIT_FLOW_VERSION );
+			}
+		}
+
+		/**
+		 * Module ???
+		 */
+
+		/**
+		 * Handles a POST request to add a new Usergroup. Redirects to edit view after
+		 * for admin to add users to usergroup
+		 * Hooked into 'admin_init' and kicks out right away if no action
+		 *
+		 * @since 0.7
+		 */
+		public function handle_add_usergroup() {
+
+			if ( ! isset( $_POST['submit'], $_POST['form-action'], $_GET['page'] )
+			|| $_GET['page'] != $this->module->settings_slug || 'add-usergroup' != $_POST['form-action'] ) {
+				return;
+			}
+
+			if ( ! isset( $_POST['_wpnonce'] ) || ! wp_verify_nonce( $_POST['_wpnonce'], 'add-usergroup' ) ) {
+				wp_die( esc_html( $this->module->messages['nonce-failed'] ) );
+			}
+
+			if ( ! current_user_can( $this->manage_usergroups_cap ) ) {
+				wp_die( esc_html( $this->module->messages['invalid-permissions'] ) );
+			}
+
+			// Sanitize all of the user-entered values
+			$name = ( isset( $_POST['name'] ) ) ? sanitize_text_field( trim( $_POST['name'] ) ) : '';
+			$description = ( isset( $_POST['description'] ) ) ? stripslashes( wp_filter_nohtml_kses( trim( $_POST['description'] ) ) ) : '';
+
+			$_REQUEST['form-errors'] = array();
+
+			/**
+			 * Form validation for adding new Usergroup
+			 *
+			 * Details
+			 * - 'name' is a required field, but can't match an existing name or slug. Needs to be 40 characters or less
+			 * - "description" can accept a limited amount of HTML, and is optional
+			 */
+			// Field is required
+			if ( empty( $name ) ) {
+				$_REQUEST['form-errors']['name'] = __( 'Please enter a name for the user group.', 'edit-flow' );
+			}
+			// Check to ensure a term with the same name doesn't exist
+			if ( $this->get_usergroup_by( 'name', $name ) ) {
+				$_REQUEST['form-errors']['name'] = __( 'Name already in use. Please choose another.', 'edit-flow' );
+			}
+			// Check to ensure a term with the same slug doesn't exist
+			if ( $this->get_usergroup_by( 'slug', sanitize_title( $name ) ) ) {
+				$_REQUEST['form-errors']['name'] = __( 'Name conflicts with slug for another term. Please choose again.', 'edit-flow' );
+			}
+			if ( strlen( $name ) > 40 ) {
+				$_REQUEST['form-errors']['name'] = __( 'User group name cannot exceed 40 characters. Please try a shorter name.', 'edit-flow' );
+			}
+			// Kick out if there are any errors
+			// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotValidated
+			if ( count( $_REQUEST['form-errors'] ) ) {
+				$_REQUEST['error'] = 'form-error';
+				return;
+			}
+
+			// Try to add the Usergroup
+			$args = array(
+				'name' => $name,
+				'description' => $description,
+			);
+			$usergroup = $this->add_usergroup( $args );
+			if ( is_wp_error( $usergroup ) ) {
+				wp_die( esc_textarea( __( 'Error adding usergroup.', 'edit-flow' ) ) );
+			}
+
+			$args = array(
+				'action' => 'edit-usergroup',
+				'usergroup-id' => $usergroup->term_id,
+				'message' => 'usergroup-added',
+			);
+			$redirect_url = $this->get_link( $args );
+			wp_redirect( $redirect_url );
+			exit;
+		}
+
+		/**
+		 * Handles a POST request to edit a Usergroup
+		 * Hooked into 'admin_init' and kicks out right away if no action
+		 *
+		 * @since 0.7
+		 */
+		public function handle_edit_usergroup() {
+			if ( ! isset( $_POST['submit'], $_POST['form-action'], $_GET['page'] )
+			|| $_GET['page'] != $this->module->settings_slug || 'edit-usergroup' != $_POST['form-action'] ) {
+				return;
+			}
+
+			if ( ! isset( $_POST['_wpnonce'] ) || ! wp_verify_nonce( $_POST['_wpnonce'], 'edit-usergroup' ) ) {
+				wp_die( esc_html( $this->module->messages['nonce-failed'] ) );
+			}
+
+			if ( ! current_user_can( $this->manage_usergroups_cap ) ) {
+				wp_die( esc_html( $this->module->messages['invalid-permissions'] ) );
+			}
+
+			$usergroup_id = isset( $_POST['usergroup_id'] ) ? (int) $_POST['usergroup_id'] : 0;
+			$existing_usergroup = $this->get_usergroup_by( 'id', $usergroup_id );
+			if ( ! $existing_usergroup ) {
+				wp_die( esc_html( $this->module->messages['usergroup-missing'] ) );
+			}
+
+			// Sanitize all of the user-entered values
+			$name = isset( $_POST['name'] ) ? sanitize_text_field( trim( $_POST['name'] ) ) : '';
+			$description = isset( $_POST['description'] ) ? stripslashes( wp_filter_nohtml_kses( trim( $_POST['description'] ) ) ) : '';
+
+			$_REQUEST['form-errors'] = array();
+
+			/**
+			 * Form validation for editing a Usergroup
+			 *
+			 * Details
+			 * - 'name' is a required field, but can't match an existing name or slug. Needs to be 40 characters or less
+			 * - "description" can accept a limited amount of HTML, and is optional
+			 */
+			// Field is required
+			if ( empty( $name ) ) {
+				$_REQUEST['form-errors']['name'] = __( 'Please enter a name for the user group.', 'edit-flow' );
+			}
+			// Check to ensure a term with the same name doesn't exist
+			$search_term = $this->get_usergroup_by( 'name', $name );
+			if ( is_object( $search_term ) && $search_term->term_id != $existing_usergroup->term_id ) {
+				$_REQUEST['form-errors']['name'] = __( 'Name already in use. Please choose another.', 'edit-flow' );
+			}
+			// Check to ensure a term with the same slug doesn't exist
+			$search_term = $this->get_usergroup_by( 'slug', sanitize_title( $name ) );
+			if ( is_object( $search_term ) && $search_term->term_id != $existing_usergroup->term_id ) {
+				$_REQUEST['form-errors']['name'] = __( 'Name conflicts with slug for another term. Please choose again.', 'edit-flow' );
+			}
+			if ( strlen( $name ) > 40 ) {
+				$_REQUEST['form-errors']['name'] = __( 'User group name cannot exceed 40 characters. Please try a shorter name.', 'edit-flow' );
+			}
+			// Kick out if there are any errors
+			// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotValidated
+			if ( count( $_REQUEST['form-errors'] ) ) {
+				$_REQUEST['error'] = 'form-error';
+				return;
+			}
+
+			// Try to edit the Usergroup
+			$args = array(
+				'name' => $name,
+				'description' => $description,
+			);
+			// Gracefully handle the case where all users have been unsubscribed from the user group
+			$users = isset( $_POST['usergroup_users'] ) ? (array) $_POST['usergroup_users'] : array();
+			$users = array_map( 'intval', $users );
+			$usergroup = $this->update_usergroup( $existing_usergroup->term_id, $args, $users );
+			if ( is_wp_error( $usergroup ) ) {
+				wp_die( esc_textarea( __( 'Error updating user group.', 'edit-flow' ) ) );
+			}
+
+			$args = array(
+				'message' => 'usergroup-updated',
+			);
+			$redirect_url = $this->get_link( $args );
+			wp_redirect( $redirect_url );
+			exit;
+		}
+
+		/**
+		 * Handles a request to delete a Usergroup.
+		 * Hooked into 'admin_init' and kicks out right away if no action
+		 *
+		 * @since 0.7
+		 */
+		public function handle_delete_usergroup() {
+			if ( ! isset( $_GET['page'], $_GET['action'], $_GET['usergroup-id'] )
+			|| $_GET['page'] != $this->module->settings_slug || 'delete-usergroup' != $_GET['action'] ) {
+				return;
+			}
+
+			if ( ! isset( $_GET['nonce'] ) || ! wp_verify_nonce( $_GET['nonce'], 'delete-usergroup' ) ) {
+				wp_die( esc_html( $this->module->messages['nonce-failed'] ) );
+			}
+
+			if ( ! current_user_can( $this->manage_usergroups_cap ) ) {
+				wp_die( esc_html( $this->module->messages['invalid-permissions'] ) );
+			}
+
+			$result = $this->delete_usergroup( (int) $_GET['usergroup-id'] );
+			if ( ! $result || is_wp_error( $result ) ) {
+				wp_die( esc_html__( 'Error deleting user group.', 'edit-flow' ) );
+			}
+
+			$redirect_url = $this->get_link( array( 'message' => 'usergroup-deleted' ) );
+			wp_redirect( $redirect_url );
+			exit;
+		}
+
+		/**
+		 * Handle the request to update a given Usergroup via inline edit
+		 *
+		 * @since 0.7
+		 */
+		public function handle_ajax_inline_save_usergroup() {
+
+			if ( ! isset( $_POST['inline_edit'] ) || ! wp_verify_nonce( $_POST['inline_edit'], 'usergroups-inline-edit-nonce' ) ) {
+				die( esc_html( $this->module->messages['nonce-failed'] ) );
+			}
+
+			if ( ! current_user_can( $this->manage_usergroups_cap ) ) {
+				die( esc_html( $this->module->messages['invalid-permissions'] ) );
+			}
+
+			$usergroup_id = isset( $_POST['usergroup_id'] ) ? (int) $_POST['usergroup_id'] : 0;
+			if ( ! $existing_term = $this->get_usergroup_by( 'id', $usergroup_id ) ) {
+				die( esc_html( $this->module->messages['usergroup-missing'] ) );
+			}
+
+			$name = isset( $_POST['name'] ) ? sanitize_text_field( trim( $_POST['name'] ) ) : '';
+			$description = isset( $_POST['description'] ) ? stripslashes( wp_filter_nohtml_kses( trim( $_POST['description'] ) ) ) : '';
+
+			/**
+			 * Form validation for editing Usergroup
+			 */
+			// Check if name field was filled in
+			if ( empty( $name ) ) {
+				$change_error = new WP_Error( 'invalid', esc_html__( 'Please enter a name for the user group.', 'edit-flow' ) );
+				die( esc_html( $change_error->get_error_message() ) );
+			}
+			// Check that the name doesn't exceed 40 chars
+			if ( strlen( $name ) > 40 ) {
+				$change_error = new WP_Error( 'invalid', esc_html__( 'User group name cannot exceed 40 characters. Please try a shorter name.' ) );
+				die( esc_html( $change_error->get_error_message() ) );
+			}
+			// Check to ensure a term with the same name doesn't exist
+			$search_term = $this->get_usergroup_by( 'name', $name );
+			if ( is_object( $search_term ) && $search_term->term_id != $existing_term->term_id ) {
+				$change_error = new WP_Error( 'invalid', esc_html__( 'Name already in use. Please choose another.', 'edit-flow' ) );
+				die( esc_html( $change_error->get_error_message() ) );
+			}
+			// Check to ensure a term with the same slug doesn't exist
+			$search_term = $this->get_usergroup_by( 'slug', sanitize_title( $name ) );
+			if ( is_object( $search_term ) && $search_term->term_id != $existing_term->term_id ) {
+				$change_error = new WP_Error( 'invalid', esc_html__( 'Name conflicts with slug for another term. Please choose again.', 'edit-flow' ) );
+				die( esc_html( $change_error->get_error_message() ) );
+			}
+
+			// Prepare the term name and description for saving
+			$args = array(
+				'name' => $name,
+				'description' => $description,
+			);
+			$return = $this->update_usergroup( $existing_term->term_id, $args );
+			if ( ! is_wp_error( $return ) ) {
+				set_current_screen( 'edit-usergroup' );
+				$wp_list_table = new EF_Usergroups_List_Table();
+				$wp_list_table->prepare_items();
+				echo wp_kses_post( $wp_list_table->single_row( $return ) );
+				die();
+			} else {
+				// translators: %s is the name of the user group
+				$change_error = new WP_Error( 'invalid', sprintf( __( 'Could not update the user group: <strong>%s</strong>', 'edit-flow' ), $name ) );
+				die( esc_html( $change_error->get_error_message() ) );
+			}
+		}
+
+		/**
+		 * Register settings for notifications so we can partially use the Settings API
+		 * (We use the Settings API for form generation, but not saving)
+		 *
+		 * @since 0.7
+		 * @uses add_settings_section(), add_settings_field()
+		 */
+		public function register_settings() {
 			add_settings_section( $this->module->options_group_name . '_general', false, '__return_false', $this->module->options_group_name );
 			add_settings_field( 'post_types', __( 'Add to these post types:', 'edit-flow' ), array( $this, 'settings_post_types_option' ), $this->module->options_group_name, $this->module->options_group_name . '_general' );
-	}
-	
-	/**
-	 * Choose the post types for Usergroups
-	 *
-	 * @since 0.7
-	 */
-	function settings_post_types_option() {
-		global $edit_flow;
-		$edit_flow->settings->helper_option_custom_post_type( $this->module );
-	}
+		}
 
-	/**
-	 * Validate data entered by the user
-	 *
-	 * @since 0.7
-	 *
-	 * @param array $new_options New values that have been entered by the user
-	 * @return array $new_options Form values after they've been sanitized
-	 */
-	function settings_validate( $new_options ) {
+		/**
+		 * Choose the post types for Usergroups
+		 *
+		 * @since 0.7
+		 */
+		public function settings_post_types_option() {
+			global $edit_flow;
+			$edit_flow->settings->helper_option_custom_post_type( $this->module );
+		}
 
-		
-		// Whitelist validation for the post type options
-		if ( !isset( $new_options['post_types'] ) )
-			$new_options['post_types'] = array();
-		$new_options['post_types'] = $this->clean_post_type_options( $new_options['post_types'], $this->module->post_type_support );		
-		
-		return $new_options;
-	}	
-	
-	/**
-	 * Build a configuration view so we can manage our usergroups
-	 *
-	 * @since 0.7
-	 */
-	function print_configure_view() {
-		global $edit_flow;
-		
-		if ( isset( $_GET['action'], $_GET['usergroup-id'] ) && $_GET['action'] == 'edit-usergroup' ) :
-			/** Full page width view for editing a given usergroup **/
-			// Check whether the usergroup exists
-			$usergroup_id = (int)$_GET['usergroup-id'];
-			$usergroup = $this->get_usergroup_by( 'id', $usergroup_id );
-			if ( !$usergroup ) {
-				echo '<div class="error"><p>' . $this->module->messages['usergroup-missing'] . '</p></div>';
-				return; 
+		/**
+		 * Validate data entered by the user
+		 *
+		 * @since 0.7
+		 *
+		 * @param array $new_options New values that have been entered by the user
+		 * @return array $new_options Form values after they've been sanitized
+		 */
+		public function settings_validate( $new_options ) {
+
+
+			// Whitelist validation for the post type options
+			if ( ! isset( $new_options['post_types'] ) ) {
+				$new_options['post_types'] = array();
 			}
-			$name = ( isset( $_POST['name'] ) ) ? stripslashes( $_POST['name'] ) : $usergroup->name;
-			$description = ( isset( $_POST['description'] ) ) ? stripslashes( $_POST['description'] ) : $usergroup->description;
-		?>
-		<form method="post" action="<?php echo esc_url( $this->get_link( array( 'action' => 'edit-usergroup', 'usergroup-id' => $usergroup_id ) ) ); ?>">
+			$new_options['post_types'] = $this->clean_post_type_options( $new_options['post_types'], $this->module->post_type_support );
+
+			return $new_options;
+		}
+
+		/**
+		 * Build a configuration view so we can manage our usergroups
+		 *
+		 * @since 0.7
+		 * Disabling nonce verification because that is not available here, it's just rendering it. The actual save is done in helper_settings_validate_and_save and that's guarded well.
+		 * phpcs:disable:WordPress.Security.NonceVerification.Missing
+		 */
+		public function print_configure_view() {
+			global $edit_flow;
+
+			if ( isset( $_GET['action'], $_GET['usergroup-id'] ) && 'edit-usergroup' == $_GET['action'] ) :
+				/** Full page width view for editing a given usergroup **/
+				// Check whether the usergroup exists
+				$usergroup_id = (int) $_GET['usergroup-id'];
+				$usergroup = $this->get_usergroup_by( 'id', $usergroup_id );
+				if ( ! $usergroup ) {
+					echo '<div class="error"><p>' . esc_html( $this->module->messages['usergroup-missing'] ) . '</p></div>';
+					return;
+				}
+				$name = ( isset( $_POST['name'] ) ) ? stripslashes( $_POST['name'] ) : $usergroup->name;
+				$description = ( isset( $_POST['description'] ) ) ? strip_tags( stripslashes( $_POST['description'] ) ) : $usergroup->description;
+				?>
+		<form method="post" action="
+				<?php
+				echo esc_url( $this->get_link( array(
+					'action' => 'edit-usergroup',
+					'usergroup-id' => $usergroup_id,
+				) ) );
+				?>
+									">
 		<div id="col-right"><div class="col-wrap"><div id="ef-usergroup-users" class="form-wrap">
 			<h4><?php _e( 'Users', 'edit-flow' ); ?></h4>
-			<?php 
+				<?php
 				$select_form_args = array(
 					'list_class' => 'ef-post_following_list',
-					'input_id' => 'usergroup_users'
+					'input_id' => 'usergroup_users',
 				);
-			?>
-			<?php $this->users_select_form( $usergroup->user_ids , $select_form_args ); ?>
+				?>
+				<?php $this->users_select_form( $usergroup->user_ids, $select_form_args ); ?>
 		</div></div></div>
-		<div id="col-left"><div class="col-wrap"><div class="form-wrap">		
+		<div id="col-left"><div class="col-wrap"><div class="form-wrap">
 			<input type="hidden" name="form-action" value="edit-usergroup" />
 			<input type="hidden" name="usergroup_id" value="<?php echo esc_attr( $usergroup_id ); ?>" />
-			<?php
+				<?php
 				wp_original_referer_field();
 				wp_nonce_field( 'edit-usergroup' );
-			?>
+				?>
 			<div class="form-field form-required">
 				<label for="name"><?php _e( 'Name', 'edit-flow' ); ?></label>
 				<input name="name" id="name" type="text" value="<?php echo esc_attr( $name ); ?>" size="40" maxlength="40" aria-required="true" />
@@ -579,17 +619,18 @@ class EF_User_Groups extends EF_Module {
 				<?php $edit_flow->settings->helper_print_error_or_description( 'description', __( 'The description is primarily for administrative use, to give you some context on what the user group is to be used for.', 'edit-flow' ) ); ?>
 			</div>
 			<p class="submit">
-			<?php submit_button( __( 'Update User Group', 'edit-flow' ), 'primary', 'submit', false ); ?>
+				<?php submit_button( __( 'Update User Group', 'edit-flow' ), 'primary', 'submit', false ); ?>
 			<a class="cancel-settings-link" href="<?php echo esc_url( $this->get_link() ); ?>"><?php _e( 'Cancel', 'edit-flow' ); ?></a>
 			</p>
 		</div></div></div>
 		</form>
-		
-		<?php else :
-			/** Full page width view to allow adding a usergroup and edit the existing ones **/
-			$wp_list_table = new EF_Usergroups_List_Table();
-			$wp_list_table->prepare_items();
-		?>
+
+				<?php
+		else :
+				/** Full page width view to allow adding a usergroup and edit the existing ones **/
+				$wp_list_table = new EF_Usergroups_List_Table();
+				$wp_list_table->prepare_items();
+			?>
 			<script type="text/javascript">
 				var ef_confirm_delete_usergroup_string = "<?php _e( 'Are you sure you want to delete the user group?', 'edit-flow' ); ?>";
 			</script>
@@ -598,64 +639,78 @@ class EF_User_Groups extends EF_Module {
 			</div></div>
 			<div id="col-left"><div class="col-wrap"><div class="form-wrap">
 				<h3 class="nav-tab-wrapper">
-					<a href="<?php echo esc_url( $this->get_link() ); ?>" class="nav-tab<?php if ( !isset( $_GET['action'] ) || $_GET['action'] != 'change-options' ) echo ' nav-tab-active'; ?>"><?php _e( 'Add New', 'edit-flow' ); ?></a>
-					<a href="<?php echo esc_url( $this->get_link( array( 'action' => 'change-options' ) ) ); ?>" class="nav-tab<?php if ( isset( $_GET['action'] ) && $_GET['action'] == 'change-options' ) echo ' nav-tab-active'; ?>"><?php _e( 'Options', 'edit-flow' ); ?></a>
+					<a href="<?php echo esc_url( $this->get_link() ); ?>" class="nav-tab
+										<?php
+										if ( ! isset( $_GET['action'] ) || 'change-options' != $_GET['action'] ) {
+											echo ' nav-tab-active';}
+										?>
+					"><?php _e( 'Add New', 'edit-flow' ); ?></a>
+					<a href="<?php echo esc_url( $this->get_link( array( 'action' => 'change-options' ) ) ); ?>" class="nav-tab
+										<?php
+										if ( isset( $_GET['action'] ) && 'change-options' == $_GET['action'] ) {
+											echo ' nav-tab-active';}
+										?>
+					"><?php _e( 'Options', 'edit-flow' ); ?></a>
 				</h3>
-				<?php if ( isset( $_GET['action'] ) && $_GET['action'] == 'change-options' ): ?>
+				<?php if ( isset( $_GET['action'] ) && 'change-options' == $_GET['action'] ) : ?>
 				<form class="basic-settings" action="<?php echo esc_url( $this->get_link( array( 'action' => 'change-options' ) ) ); ?>" method="post">
 					<?php settings_fields( $this->module->options_group_name ); ?>
-					<?php do_settings_sections( $this->module->options_group_name ); ?>	
+					<?php do_settings_sections( $this->module->options_group_name ); ?>
 					<?php echo '<input id="edit_flow_module_name" name="edit_flow_module_name" type="hidden" value="' . esc_attr( $this->module->name ) . '" />'; ?>
 					<?php submit_button(); ?>
 				</form>
-				<?php else: ?>
-				<?php /** Custom form for adding a new Usergroup **/ ?>
+				<?php else : ?>
+					<?php /** Custom form for adding a new Usergroup **/ ?>
 					<form class="add:the-list:" action="<?php echo esc_url( $this->get_link() ); ?>" method="post" id="addusergroup" name="addusergroup">
 					<div class="form-field form-required">
 						<label for="name"><?php _e( 'Name', 'edit-flow' ); ?></label>
-						<input type="text" aria-required="true" id="name" name="name" maxlength="40" value="<?php if ( !empty( $_POST['name'] ) ) echo esc_attr( $_POST['name'] ); ?>" />
+						<input type="text" aria-required="true" id="name" name="name" maxlength="40" value="<?php /* phpcs:ignore Generic.ControlStructures.InlineControlStructure.NotAllowed */ if ( ! empty( $_POST['name'] ) ) echo esc_attr( $_POST['name'] ); ?>"
 						<?php $edit_flow->settings->helper_print_error_or_description( 'name', __( 'The name is used to identify the user group.', 'edit-flow' ) ); ?>
 					</div>
 					<div class="form-field">
 						<label for="description"><?php _e( 'Description', 'edit-flow' ); ?></label>
-						<textarea cols="40" rows="5" id="description" name="description"><?php if ( !empty( $_POST['description'] ) ) echo esc_html( $_POST['description'] ) ?></textarea>
+						<textarea cols="40" rows="5" id="description" name="description"><?php /* phpcs:ignore Generic.ControlStructures.InlineControlStructure.NotAllowed */ if ( ! empty( $_POST['description'] ) ) echo esc_textarea( $_POST['description'] ); ?></textarea>
 						<?php $edit_flow->settings->helper_print_error_or_description( 'description', __( 'The description is primarily for administrative use, to give you some context on what the user group is to be used for.', 'edit-flow' ) ); ?>
 					</div>
 					<?php wp_nonce_field( 'add-usergroup' ); ?>
 					<?php echo '<input id="form-action" name="form-action" type="hidden" value="add-usergroup" />'; ?>
-					<p class="submit"><?php submit_button( __( 'Add New User Group', 'edit-flow' ), 'primary', 'submit', false ); ?><a class="cancel-settings-link" href="<?php echo EDIT_FLOW_SETTINGS_PAGE; ?>"><?php _e( 'Back to Edit Flow', 'edit-flow' ); ?></a></p>
+					<p class="submit"><?php submit_button( __( 'Add New User Group', 'edit-flow' ), 'primary', 'submit', false ); ?><a class="cancel-settings-link" href="<?php echo esc_url( EDIT_FLOW_SETTINGS_PAGE ); ?>"><?php _e( 'Back to Edit Flow', 'edit-flow' ); ?></a></p>
 					</form>
 				<?php endif; ?>
 			</div></div></div>
-			<?php $wp_list_table->inline_edit(); ?>
-		<?php endif;
-	}
-	
-	/**
-	 * Adds a form to the user profile page to allow adding usergroup selecting options
-	 */
-	function user_profile_page() {
-		global $user_id, $profileuser;
-		
-		if ( !$user_id || !current_user_can( $this->manage_usergroups_cap ) )
-			return;
+				<?php $wp_list_table->inline_edit(); ?>
+			<?php
+		endif;
+		}
+		//phpcs:enable:WordPress.Security.NonceVerification.Missing
 
-		//Don't allow display of user groups from network
-		if ( ( !is_null( get_current_screen() ) ) && ( get_current_screen()->is_network ) )
-			return;
-		
-		// Assemble all necessary data
-		$usergroups = $this->get_usergroups();
-		$selected_usergroups = $this->get_usergroups_for_user( $user_id );
-		$usergroups_form_args = array( 'input_id' => 'ef_usergroups' );
-		?>
+		/**
+		 * Adds a form to the user profile page to allow adding usergroup selecting options
+		 */
+		public function user_profile_page() {
+			global $user_id, $profileuser;
+
+			if ( ! $user_id || ! current_user_can( $this->manage_usergroups_cap ) ) {
+				return;
+			}
+
+			//Don't allow display of user groups from network
+			if ( ( ! is_null( get_current_screen() ) ) && ( get_current_screen()->is_network ) ) {
+				return;
+			}
+
+			// Assemble all necessary data
+			$usergroups = $this->get_usergroups();
+			$selected_usergroups = $this->get_usergroups_for_user( $user_id );
+			$usergroups_form_args = array( 'input_id' => 'ef_usergroups' );
+			?>
 		<table id="ef-user-usergroups" class="form-table"><tbody><tr>
 			<th>
-				<h3><?php _e( 'Usergroups', 'edit-flow' ) ?></h3>
-				<?php if ( $user_id === wp_get_current_user()->ID ) : ?>
-				<p><?php _e( 'Select the user groups that you would like to be a part of:', 'edit-flow' ) ?></p>
+				<h3><?php _e( 'Usergroups', 'edit-flow' ); ?></h3>
+				<?php if ( wp_get_current_user()->ID === $user_id ) : ?>
+				<p><?php _e( 'Select the user groups that you would like to be a part of:', 'edit-flow' ); ?></p>
 				<?php else : ?>
-				<p><?php _e( 'Select the user groups that this user should be a part of:', 'edit-flow' ) ?></p>
+				<p><?php _e( 'Select the user groups that this user should be a part of:', 'edit-flow' ); ?></p>
 				<?php endif; ?>
 			</th>
 			<td>
@@ -667,571 +722,600 @@ class EF_User_Groups extends EF_Module {
 				</script>
 			</td>
 		</tr></tbody></table>
-		<?php wp_nonce_field( 'ef_edit_profile_usergroups_nonce', 'ef_edit_profile_usergroups_nonce' ); ?>
-	<?php 
-	}
-	
-	/**
-	 * Function called when a user's profile is updated
-	 * Adds user to specified usergroups
-	 *
-	 * @since 0.7
-	 *
-	 * @param ???
-	 * @param ???
-	 * @param ???
-	 * @return ???
-	 */
-	function user_profile_update( $errors, $update, $user ) {
-		
-		if ( !$update )
+			<?php wp_nonce_field( 'ef_edit_profile_usergroups_nonce', 'ef_edit_profile_usergroups_nonce' ); ?>
+			<?php
+		}
+
+		/**
+		 * Function called when a user's profile is updated
+		 * Adds user to specified usergroups
+		 *
+		 * @since 0.7
+		 *
+		 * @param ???
+		 * @param ???
+		 * @param ???
+		 * @return ???
+		 */
+		public function user_profile_update( $errors, $update, $user ) {
+
+			if ( ! $update ) {
+				return array( &$errors, $update, &$user );
+			}
+
+			// `get_current_screen()` is defined on most admin pages, but not all.
+			if ( function_exists( 'get_current_screen' ) ) {
+				//Don't allow update of user groups from network
+				$screen = get_current_screen();
+				if ( ! is_null( $screen ) && $screen->is_network ) {
+					return;
+				}
+			}
+
+			if ( isset( $_POST['ef_edit_profile_usergroups_nonce'] ) && current_user_can( $this->manage_usergroups_cap ) && wp_verify_nonce( $_POST['ef_edit_profile_usergroups_nonce'], 'ef_edit_profile_usergroups_nonce' ) ) {
+				// Sanitize the data and save
+				// Gracefully handle the case where the user was unsubscribed from all usergroups
+				$usergroups = isset( $_POST['ef_usergroups'] ) ? array_map( 'intval', (array) $_POST['ef_usergroups'] ) : array();
+				$all_usergroups = $this->get_usergroups();
+				foreach ( $all_usergroups as $usergroup ) {
+					if ( in_array( $usergroup->term_id, $usergroups ) ) {
+						$this->add_user_to_usergroup( $user->ID, $usergroup->term_id );
+					} else {
+						$this->remove_user_from_usergroup( $user->ID, $usergroup->term_id );
+					}
+				}
+			}
+
 			return array( &$errors, $update, &$user );
+		}
 
-		// `get_current_screen()` is defined on most admin pages, but not all.
-		if( function_exists( 'get_current_screen' ) ){
-			//Don't allow update of user groups from network
-			$screen = get_current_screen();
-			if ( ! is_null( $screen ) && $screen->is_network ) {
-				return;
+		/**
+		 * Generate a link to one of the usergroups actions
+		 *
+		 * @since 0.7
+		 *
+		 * @param string $action Action we want the user to take
+		 * @param array $args Any query args to add to the URL
+		 * @return string $link Direct link to delete a usergroup
+		 */
+		public function get_link( $args = array() ) {
+			if ( ! isset( $args['action'] ) ) {
+				$args['action'] = '';
 			}
-		}
-
-		if ( current_user_can( $this->manage_usergroups_cap ) && wp_verify_nonce( $_POST['ef_edit_profile_usergroups_nonce'], 'ef_edit_profile_usergroups_nonce' ) ) {
-			// Sanitize the data and save
-			// Gracefully handle the case where the user was unsubscribed from all usergroups
-			$usergroups = isset( $_POST['ef_usergroups'] ) ? array_map( 'intval', (array)$_POST['ef_usergroups'] ) : array();
-			$all_usergroups = $this->get_usergroups();
-			foreach( $all_usergroups as $usergroup ) {
-				if ( in_array( $usergroup->term_id, $usergroups ) )
-					$this->add_user_to_usergroup( $user->ID, $usergroup->term_id );
-				else
-					$this->remove_user_from_usergroup( $user->ID, $usergroup->term_id );
+			if ( ! isset( $args['page'] ) ) {
+				$args['page'] = $this->module->settings_slug;
 			}
+			// Add other things we may need depending on the action
+			switch ( $args['action'] ) {
+				case 'delete-usergroup':
+					$args['nonce'] = wp_create_nonce( $args['action'] );
+					break;
+				default:
+					break;
+			}
+			return add_query_arg( $args, get_admin_url( null, 'admin.php' ) );
 		}
-			
-		return array( &$errors, $update, &$user );
-	}
-	
-	/**
-	 * Generate a link to one of the usergroups actions
-	 *
-	 * @since 0.7
-	 *
-	 * @param string $action Action we want the user to take
-	 * @param array $args Any query args to add to the URL
-	 * @return string $link Direct link to delete a usergroup
-	 */
-	function get_link( $args = array() ) {
-		if ( !isset( $args['action'] ) )
-			$args['action'] = '';
-		if ( !isset( $args['page'] ) )
-			$args['page'] = $this->module->settings_slug;
-		// Add other things we may need depending on the action
-		switch( $args['action'] ) {
-			case 'delete-usergroup':
-				$args['nonce'] = wp_create_nonce( $args['action'] );
-				break;
-			default:
-				break;
-		}
-		return add_query_arg( $args, get_admin_url( null, 'admin.php' ) );
-	}
-	
-	/**
-	 * Displays a list of usergroups with checkboxes
-	 *
-	 * @since 0.7
-	 *
-	 * @param array $selected List of usergroup keys that should be checked
-	 * @param array $args ???
-	 */
-	function usergroups_select_form( $selected = array(), $args = null ) {
 
-		// TODO add $args for additional options
-		// e.g. showing members assigned to group (John Smith, Jane Doe, and 9 others)
-		// before <tag>, after <tag>, class, id names?
-		$defaults = array(
-			'list_class' => 'ef-post_following_list',
-			'list_id' => 'ef-following_usergroups',
-			'input_id' => 'following_usergroups'
-		);
+		/**
+		 * Displays a list of usergroups with checkboxes
+		 *
+		 * @since 0.7
+		 *
+		 * @param array $selected List of usergroup keys that should be checked
+		 * @param array $args ???
+		 */
+		public function usergroups_select_form( $selected = array(), $args = null ) {
 
-		$parsed_args = wp_parse_args( $args, $defaults );
-		extract( $parsed_args, EXTR_SKIP );
-		$usergroups = $this->get_usergroups();
-		if ( empty($usergroups) ) {
-			?>
-			<p><?php _e('No user groups were found.', 'edit-flow') ?> <a href="<?php echo esc_url( $this->get_link() ); ?>" title="<?php _e('Add a new user group. Opens new window.', 'edit-flow' ) ?>" target="_blank"><?php _e( 'Add a User Group', 'edit-flow' ); ?></a></p>
-			<?php
-		} else {
+			// TODO add $args for additional options
+			// e.g. showing members assigned to group (John Smith, Jane Doe, and 9 others)
+			// before <tag>, after <tag>, class, id names?
+			$defaults = array(
+				'list_class' => 'ef-post_following_list',
+				'list_id' => 'ef-following_usergroups',
+				'input_id' => 'following_usergroups',
+			);
 
-			?>
-			<ul id="<?php echo esc_attr( $list_id ) ?>" class="<?php echo esc_attr( $list_class ) ?>">
-			<?php
-			foreach( $usergroups as $usergroup ) {
-				$checked = ( in_array( $usergroup->term_id, $selected ) ) ? ' checked="checked"' : '';
+			$parsed_args = wp_parse_args( $args, $defaults );
+			extract( $parsed_args, EXTR_SKIP );
+			$usergroups = $this->get_usergroups();
+			if ( empty( $usergroups ) ) {
 				?>
+			<p><?php _e( 'No user groups were found.', 'edit-flow' ); ?> <a href="<?php echo esc_url( $this->get_link() ); ?>" title="<?php _e( 'Add a new user group. Opens new window.', 'edit-flow' ); ?>" target="_blank"><?php _e( 'Add a User Group', 'edit-flow' ); ?></a></p>
+				<?php
+			} else {
+
+				?>
+			<ul id="<?php echo esc_attr( $list_id ); ?>" class="<?php echo esc_attr( $list_class ); ?>">
+				<?php
+				foreach ( $usergroups as $usergroup ) {
+					$checked = ( in_array( $usergroup->term_id, $selected ) ) ? ' checked="checked"' : '';
+					?>
 				<li>
-					<label for="<?php echo $input_id . esc_attr( $usergroup->term_id ); ?>" title="<?php echo esc_attr($usergroup->description) ?>">
+					<label for="<?php echo esc_attr( $input_id ) . esc_attr( $usergroup->term_id ); ?>" title="<?php echo esc_attr( $usergroup->description ); ?>">
 						<div class="ef-user-subscribe-actions">
-							<input type="checkbox" id="<?php echo esc_attr( $input_id . $usergroup->term_id ) ?>" name="<?php echo esc_attr( $input_id )?>[]" value="<?php echo esc_attr( $usergroup->term_id ) ?>"<?php echo $checked ?> />
+							<input type="checkbox" id="<?php echo esc_attr( $input_id . $usergroup->term_id ); ?>" name="<?php echo esc_attr( $input_id ); ?>[]" value="<?php echo esc_attr( $usergroup->term_id ); ?>"<?php echo wp_kses_post( $checked ); ?> />
 						</div>
 						<span class="ef-usergroup_name"><?php echo esc_html( $usergroup->name ); ?></span>
-						<span class="ef-usergroup_description" title="<?php echo esc_attr($usergroup->description) ?>">
-							<?php echo (strlen($usergroup->description) >= 50) ? substr_replace(esc_html($usergroup->description), '...', 50) : esc_html($usergroup->description); ?>
+						<span class="ef-usergroup_description" title="<?php echo esc_attr( $usergroup->description ); ?>">
+							<?php echo ( strlen( $usergroup->description ) >= 50 ) ? esc_html( substr_replace( esc_html( $usergroup->description ), '...', 50 ) ) : esc_html( $usergroup->description ); ?>
 						</span>
 					</label>
 				</li>
+					<?php
+				}
+				?>
+			</ul>
 				<?php
 			}
-			?>
-			</ul>
-			<?php
 		}
-	}
-	
-	/**
-	 * Core Usergroups Module Functionality
-	 */
-	
-	/**
-	 * Get all of the registered usergroups. Returns an array of objects
-	 *
-	 * @since 0.7
-	 * 
-	 * @param array $args Arguments to filter/sort by
-	 * @return array|bool $usergroups Array of Usergroups with relevant data, false if none
-	 */
-	function get_usergroups( $args = array() ) {
-		
-		// We want empty terms by default
-		if ( !isset( $args['hide_empty'] ) )
-			$args['hide_empty'] = 0;
-		
-		$usergroup_terms = get_terms( self::taxonomy_key, $args );	
-		if ( !$usergroup_terms )
-			return false;
-		
-		// Run the usergroups through get_usergroup_by() so we load users too
-		$usergroups = array();
-		foreach( $usergroup_terms as $usergroup_term ) {
-			$usergroups[] = $this->get_usergroup_by( 'id', $usergroup_term->term_id );
-		}
-		return $usergroups;
-	}
-	
-	/**
-	 * Get all of the data associated with a single usergroup
-	 * Usergroup contains:
-	 * - ID (key = term_id)
-	 * - Slug (prefixed with our special key to avoid conflicts)
-	 * - Name
-	 * - Description
-	 * - User IDs (array of IDs)
-	 *
-	 * @since 0.7
-	 *
-	 * @param string $field 'id', 'name', or 'slug'
-	 * @param int|string $value Value for the search field
-	 * @return object|array|WP_Error $usergroup Usergroup information as specified by $output
-	 */
-	function get_usergroup_by( $field, $value ) {
-		
-		$usergroup = get_term_by( $field, $value, self::taxonomy_key );
-		
-		if ( !$usergroup || is_wp_error( $usergroup ) )
-			return $usergroup;
-		
-		// We're using an encoded description field to store extra values
-		// Declare $user_ids ahead of time just in case it's empty
-		$usergroup->user_ids = array();
-		$unencoded_description = $this->get_unencoded_description( $usergroup->description );
-		if ( is_array( $unencoded_description ) ) {
-			foreach( $unencoded_description as $key => $value ) {
-				$usergroup->$key = $value;
+
+		/**
+		 * Core Usergroups Module Functionality
+		 */
+
+		/**
+		 * Get all of the registered usergroups. Returns an array of objects
+		 *
+		 * @since 0.7
+		 *
+		 * @param array $args Arguments to filter/sort by
+		 * @return array|bool $usergroups Array of Usergroups with relevant data, false if none
+		 */
+		public function get_usergroups( $args = array() ) {
+
+			// We want empty terms by default
+			$usergroup_terms = get_terms( array(
+				'taxonomy'   => self::taxonomy_key,
+				'hide_empty' => isset( $args['hide_empty'] ),
+			));
+			if ( ! $usergroup_terms ) {
+				return false;
 			}
+
+			// Run the usergroups through get_usergroup_by() so we load users too
+			$usergroups = array();
+			foreach ( $usergroup_terms as $usergroup_term ) {
+				$usergroups[] = $this->get_usergroup_by( 'id', $usergroup_term->term_id );
+			}
+			return $usergroups;
 		}
 
-		$usergroup = apply_filters( 'ef_usergroup_object', $usergroup );
+		/**
+		 * Get all of the data associated with a single usergroup
+		 * Usergroup contains:
+		 * - ID (key = term_id)
+		 * - Slug (prefixed with our special key to avoid conflicts)
+		 * - Name
+		 * - Description
+		 * - User IDs (array of IDs)
+		 *
+		 * @since 0.7
+		 *
+		 * @param string $field 'id', 'name', or 'slug'
+		 * @param int|string $value Value for the search field
+		 * @return object|array|WP_Error $usergroup Usergroup information as specified by $output
+		 */
+		public function get_usergroup_by( $field, $value ) {
 
-		return $usergroup;
-	}
-	
-	/**
-	 * Create a new usergroup containing:
-	 * - Name
-	 * - Slug (prefixed with our special key to avoid conflicts)
-	 * - Description
-	 * - Users
-	 *
-	 * @since 0.7
-	 *
-	 * @param array $args Name (optional), slug and description for the usergroup
-	 * @param array $user_ids IDs for the users to be added to the Usergroup
-	 * @return object|WP_Error $usergroup Object for the new Usergroup on success, WP_Error otherwise
-	 */
-	function add_usergroup( $args = array(), $user_ids = array() ) {
+			$usergroup = get_term_by( $field, $value, self::taxonomy_key );
 
-		if ( !isset( $args['name'] ) )
-			return new WP_Error( 'invalid', __( 'New user groups must have a name', 'edit-flow' ) );
-			
-		$name = $args['name'];			
-		$default = array(
-			'name' => '',
-			'slug' => self::term_prefix . sanitize_title( $name ),
-			'description' => '',
-		);
-		$args = array_merge( $default, $args );
-			
-		// Encode our extra fields and then store them in the description field
-		$args_to_encode = array(
-			'description' => $args['description'],
-			'user_ids' => array_unique( $user_ids ),
-		);
-		$encoded_description = $this->get_encoded_description( $args_to_encode );
-		$args['description'] = $encoded_description;
-		$usergroup = wp_insert_term( $name, self::taxonomy_key, $args );
-		if ( is_wp_error( $usergroup ) )
+			if ( ! $usergroup || is_wp_error( $usergroup ) ) {
+				return $usergroup;
+			}
+
+			// We're using an encoded description field to store extra values
+			// Declare $user_ids ahead of time just in case it's empty
+			$usergroup->user_ids = array();
+			$unencoded_description = $this->get_unencoded_description( $usergroup->description );
+			if ( is_array( $unencoded_description ) ) {
+				foreach ( $unencoded_description as $key => $value ) {
+					$usergroup->$key = $value;
+				}
+			}
+
+			$usergroup = apply_filters( 'ef_usergroup_object', $usergroup );
+
 			return $usergroup;
-		
-		return $this->get_usergroup_by( 'id', $usergroup['term_id'] );
-	}
-	
-	/**
-	 * Update a usergroup with new data.
-	 * Fields can include:
-	 * - Name
-	 * - Slug (prefixed with our special key, of course)
-	 * - Description
-	 * - Users
-	 *
-	 * @since 0.7
-	 *
-	 * @param int $id Unique ID for the usergroup
-	 * @param array $args Usergroup meta to update (name, slug, description)
-	 * @param array $users Users to be added to the Usergroup. If set, removes existing users first.
-	 * @return object|WP_Error $usergroup Object for the updated Usergroup on success, WP_Error otherwise
-	 */
-	function update_usergroup( $id, $args = array(), $users = null ) {
-		
-		$existing_usergroup = $this->get_usergroup_by( 'id', $id );
-		if ( is_wp_error( $existing_usergroup ) )
-			return new WP_Error( 'invalid', __( "User group doesn't exist.", 'edit-flow' ) );
-		
-		// Encode our extra fields and then store them in the description field
-		$args_to_encode = array();
-		$args_to_encode['description'] = ( isset( $args['description'] ) ) ? $args['description'] : $existing_usergroup->description;
-		$args_to_encode['user_ids'] = ( is_array( $users ) ) ? $users : $existing_usergroup->user_ids;
-		$args_to_encode['user_ids'] = array_unique( $args_to_encode['user_ids'] );
-		$encoded_description = $this->get_encoded_description( $args_to_encode );
-		$args['description'] = $encoded_description;
-		
-		$usergroup = wp_update_term( $id, self::taxonomy_key, $args );
-		if ( is_wp_error( $usergroup ) )
-			return $usergroup;
-		
-		return $this->get_usergroup_by( 'id', $usergroup['term_id'] );
-	}
-	
-	/**
-	 * Delete a usergroup based on its term ID
-	 *
-	 * @since 0.7
-	 *
-	 * @param int $id Unique ID for the Usergroup
-	 * @param bool|WP_Error Returns true on success, WP_Error on failure
-	 */
-	function delete_usergroup( $id ) {
-		
-		$retval = wp_delete_term( $id, self::taxonomy_key );
-		return $retval;
-	}
-	
-	/**
-	 * Add an array of user logins or IDs to a given usergroup
-	 *
-	 * @since 0.7
-	 *
-	 * @param array $user_ids_or_logins User IDs or logins to be added to the usergroup	
-	 * @param int $id Usergroup to perform the action on
-	 * @param bool $reset Delete all of the relationships before adding
-	 * @return bool $success Whether or not we were successful
-	 */
-	function add_users_to_usergroup( $user_ids_or_logins, $id, $reset = true ) {
-		
-		if ( !is_array( $user_ids_or_logins ) )
-			return new WP_Error( 'invalid', __( "Invalid users variable. Should be array.", 'edit-flow' ) );
-		
-		// To dump the existing users from a usergroup, we need to pass an empty array
-		$usergroup = $this->get_usergroup_by( 'id', $id );		
-		if ( $reset ) {
-			$retval = $this->update_usergroup( $id, null, array() );
-			if ( is_wp_error( $retval ) )
-				return $retval;
 		}
-		
-		// Add the new users one by one to an array we'll pass back to the usergroup
-		$new_users = array();
-		foreach ( (array)$user_ids_or_logins as $user_id_or_login ) {
-			if ( !is_numeric( $user_id_or_login ) )
-				$new_users[] = get_user_by( 'login', $user_id_or_login )->ID;
-			else
-				$new_users[] = (int)$user_id_or_login;
+
+		/**
+		 * Create a new usergroup containing:
+		 * - Name
+		 * - Slug (prefixed with our special key to avoid conflicts)
+		 * - Description
+		 * - Users
+		 *
+		 * @since 0.7
+		 *
+		 * @param array $args Name (optional), slug and description for the usergroup
+		 * @param array $user_ids IDs for the users to be added to the Usergroup
+		 * @return object|WP_Error $usergroup Object for the new Usergroup on success, WP_Error otherwise
+		 */
+		public function add_usergroup( $args = array(), $user_ids = array() ) {
+
+			if ( ! isset( $args['name'] ) ) {
+				return new WP_Error( 'invalid', __( 'New user groups must have a name', 'edit-flow' ) );
+			}
+
+			$name = $args['name'];
+			$default = array(
+				'name' => '',
+				'slug' => self::term_prefix . sanitize_title( $name ),
+				'description' => '',
+			);
+			$args = array_merge( $default, $args );
+
+			// Encode our extra fields and then store them in the description field
+			$args_to_encode = array(
+				'description' => $args['description'],
+				'user_ids' => array_unique( $user_ids ),
+			);
+			$encoded_description = $this->get_encoded_description( $args_to_encode );
+			$args['description'] = $encoded_description;
+			$usergroup = wp_insert_term( $name, self::taxonomy_key, $args );
+			if ( is_wp_error( $usergroup ) ) {
+				return $usergroup;
+			}
+
+			return $this->get_usergroup_by( 'id', $usergroup['term_id'] );
 		}
-		$retval = $this->update_usergroup( $id, null, $new_users );
-		if ( is_wp_error( $retval ) )
+
+		/**
+		 * Update a usergroup with new data.
+		 * Fields can include:
+		 * - Name
+		 * - Slug (prefixed with our special key, of course)
+		 * - Description
+		 * - Users
+		 *
+		 * @since 0.7
+		 *
+		 * @param int $id Unique ID for the usergroup
+		 * @param array $args Usergroup meta to update (name, slug, description)
+		 * @param array $users Users to be added to the Usergroup. If set, removes existing users first.
+		 * @return object|WP_Error $usergroup Object for the updated Usergroup on success, WP_Error otherwise
+		 */
+		public function update_usergroup( $id, $args = array(), $users = null ) {
+
+			$existing_usergroup = $this->get_usergroup_by( 'id', $id );
+			if ( is_wp_error( $existing_usergroup ) ) {
+				return new WP_Error( 'invalid', __( "User group doesn't exist.", 'edit-flow' ) );
+			}
+
+			// Encode our extra fields and then store them in the description field
+			$args_to_encode = array();
+			$args_to_encode['description'] = ( isset( $args['description'] ) ) ? $args['description'] : $existing_usergroup->description;
+			$args_to_encode['user_ids'] = ( is_array( $users ) ) ? $users : $existing_usergroup->user_ids;
+			$args_to_encode['user_ids'] = array_unique( $args_to_encode['user_ids'] );
+			$encoded_description = $this->get_encoded_description( $args_to_encode );
+			$args['description'] = $encoded_description;
+
+			$usergroup = wp_update_term( $id, self::taxonomy_key, $args );
+			if ( is_wp_error( $usergroup ) ) {
+				return $usergroup;
+			}
+
+			return $this->get_usergroup_by( 'id', $usergroup['term_id'] );
+		}
+
+		/**
+		 * Delete a usergroup based on its term ID
+		 *
+		 * @since 0.7
+		 *
+		 * @param int $id Unique ID for the Usergroup
+		 * @param bool|WP_Error Returns true on success, WP_Error on failure
+		 */
+		public function delete_usergroup( $id ) {
+
+			$retval = wp_delete_term( $id, self::taxonomy_key );
 			return $retval;
-		return true;
-	}
-	
-	/**
-	 * Add a given user to a Usergroup. Can use User ID or user login
-	 *
-	 * @since 0.7
-	 *
-	 * @param int|string $user_id_or_login User ID or login to be added to the Usergroups
-	 * @param int|array $ids ID for the Usergroup(s)
-	 * @return bool|WP_Error $retval Return true on success, WP_Error on error
-	 */
-	function add_user_to_usergroup( $user_id_or_login, $ids ) {
-		
-		if ( !is_numeric( $user_id_or_login ) )
-			$user_id = get_user_by( 'login', $user_id_or_login )->ID;
-		else
-			$user_id = (int)$user_id_or_login;
-		
-		foreach( (array)$ids as $usergroup_id ) {
-			$usergroup = $this->get_usergroup_by( 'id', $usergroup_id );
-			$usergroup->user_ids[] = $user_id;
-			$retval = $this->update_usergroup( $usergroup_id, null, $usergroup->user_ids );
-			if ( is_wp_error( $retval ) )
-				return $retval;
 		}
-		return true;
-	}
-	
-	/**
-	 * Remove a given user from one or more usergroups
-	 *
-	 * @since 0.7
-	 *
-	 * @param int|string $user_id_or_login User ID or login to be removed from the Usergroups
-	 * @param int|array $ids ID for the Usergroup(s)
-	 * @return bool|WP_Error $retval Return true on success, WP_Error on error
-	 */
-	function remove_user_from_usergroup( $user_id_or_login, $ids ) {
-		
-		if ( !is_numeric( $user_id_or_login ) )
-			$user_id = get_user_by( 'login', $user_id_or_login )->ID;
-		else
-			$user_id = (int)$user_id_or_login;
-		
-		// Remove the user from each usergroup specified
-		foreach( (array)$ids as $usergroup_id ) {
-			$usergroup = $this->get_usergroup_by( 'id', $usergroup_id );
-			// @todo I bet there's a PHP function for this I couldn't look up at 35,000 over the Atlantic
-			foreach( $usergroup->user_ids as $key => $usergroup_user_id ) {
-				if ( $usergroup_user_id == $user_id )
-					unset( $usergroup->user_ids[$key] );
-			}
-			$retval = $this->update_usergroup( $usergroup_id, null, $usergroup->user_ids );
-			if ( is_wp_error( $retval ) )
-				return $retval;
-		}
-		return true;
-		
-	}
-	
-	/**
-	 * Get all of the Usergroup ids or objects for a given user
-	 *
-	 * @since 0.7
-	 *
-	 * @param int|string $user_id_or_login User ID or login to search against
-	 * @param array $ids_or_objects Whether to retrieve an array of IDs or usergroup objects
-	 * @param array|bool $usergroup_objects_or_ids Array of usergroup 'ids' or 'objects', false if none
-	 */
-	function get_usergroups_for_user( $user_id_or_login, $ids_or_objects = 'ids' ) {
 
-		if ( !is_numeric( $user_id_or_login ) )
-			$user_id = get_user_by( 'login', $user_id_or_login )->ID;
-		else
-			$user_id = (int)$user_id_or_login;
-		
-		// Unfortunately, the easiest way to do this is get all usergroups
-		// and then loop through each one to see if the user ID is stored
-		$all_usergroups = $this->get_usergroups();
-		if ( !empty( $all_usergroups) ) {
-			$usergroup_objects_or_ids = array();
-			foreach( $all_usergroups as $usergroup ) {
-				// Not in this usergroup, so keep going
-				if ( !in_array( $user_id, $usergroup->user_ids ) )
-					continue;
-				if ( $ids_or_objects == 'ids' )
-					$usergroup_objects_or_ids[] = (int)$usergroup->term_id;
-				else if ( $ids_or_objects == 'objects' )
-					$usergroup_objects_or_ids[] = $usergroup;			
+		/**
+		 * Add an array of user logins or IDs to a given usergroup
+		 *
+		 * @since 0.7
+		 *
+		 * @param array $user_ids_or_logins User IDs or logins to be added to the usergroup
+		 * @param int $id Usergroup to perform the action on
+		 * @param bool $reset Delete all of the relationships before adding
+		 * @return bool $success Whether or not we were successful
+		 */
+		public function add_users_to_usergroup( $user_ids_or_logins, $id, $reset = true ) {
+
+			if ( ! is_array( $user_ids_or_logins ) ) {
+				return new WP_Error( 'invalid', __( 'Invalid users variable. Should be array.', 'edit-flow' ) );
 			}
-			return $usergroup_objects_or_ids;
-		} else {
-			return false;
+
+			// To dump the existing users from a usergroup, we need to pass an empty array
+			$usergroup = $this->get_usergroup_by( 'id', $id );
+			if ( $reset ) {
+				$retval = $this->update_usergroup( $id, null, array() );
+				if ( is_wp_error( $retval ) ) {
+					return $retval;
+				}
+			}
+
+			// Add the new users one by one to an array we'll pass back to the usergroup
+			$new_users = array();
+			foreach ( (array) $user_ids_or_logins as $user_id_or_login ) {
+				if ( ! is_numeric( $user_id_or_login ) ) {
+					$new_users[] = get_user_by( 'login', $user_id_or_login )->ID;
+				} else {
+					$new_users[] = (int) $user_id_or_login;
+				}
+			}
+			$retval = $this->update_usergroup( $id, null, $new_users );
+			if ( is_wp_error( $retval ) ) {
+				return $retval;
+			}
+			return true;
+		}
+
+		/**
+		 * Add a given user to a Usergroup. Can use User ID or user login
+		 *
+		 * @since 0.7
+		 *
+		 * @param int|string $user_id_or_login User ID or login to be added to the Usergroups
+		 * @param int|array $ids ID for the Usergroup(s)
+		 * @return bool|WP_Error $retval Return true on success, WP_Error on error
+		 */
+		public function add_user_to_usergroup( $user_id_or_login, $ids ) {
+
+			if ( ! is_numeric( $user_id_or_login ) ) {
+				$user_id = get_user_by( 'login', $user_id_or_login )->ID;
+			} else {
+				$user_id = (int) $user_id_or_login;
+			}
+
+			foreach ( (array) $ids as $usergroup_id ) {
+				$usergroup = $this->get_usergroup_by( 'id', $usergroup_id );
+				$usergroup->user_ids[] = $user_id;
+				$retval = $this->update_usergroup( $usergroup_id, null, $usergroup->user_ids );
+				if ( is_wp_error( $retval ) ) {
+					return $retval;
+				}
+			}
+			return true;
+		}
+
+		/**
+		 * Remove a given user from one or more usergroups
+		 *
+		 * @since 0.7
+		 *
+		 * @param int|string $user_id_or_login User ID or login to be removed from the Usergroups
+		 * @param int|array $ids ID for the Usergroup(s)
+		 * @return bool|WP_Error $retval Return true on success, WP_Error on error
+		 */
+		public function remove_user_from_usergroup( $user_id_or_login, $ids ) {
+
+			if ( ! is_numeric( $user_id_or_login ) ) {
+				$user_id = get_user_by( 'login', $user_id_or_login )->ID;
+			} else {
+				$user_id = (int) $user_id_or_login;
+			}
+
+			// Remove the user from each usergroup specified
+			foreach ( (array) $ids as $usergroup_id ) {
+				$usergroup = $this->get_usergroup_by( 'id', $usergroup_id );
+				// @todo I bet there's a PHP function for this I couldn't look up at 35,000 over the Atlantic
+				foreach ( $usergroup->user_ids as $key => $usergroup_user_id ) {
+					if ( $usergroup_user_id == $user_id ) {
+						unset( $usergroup->user_ids[ $key ] );
+					}
+				}
+				$retval = $this->update_usergroup( $usergroup_id, null, $usergroup->user_ids );
+				if ( is_wp_error( $retval ) ) {
+					return $retval;
+				}
+			}
+			return true;
+		}
+
+		/**
+		 * Get all of the Usergroup ids or objects for a given user
+		 *
+		 * @since 0.7
+		 *
+		 * @param int|string $user_id_or_login User ID or login to search against
+		 * @param array $ids_or_objects Whether to retrieve an array of IDs or usergroup objects
+		 * @param array|bool $usergroup_objects_or_ids Array of usergroup 'ids' or 'objects', false if none
+		 */
+		public function get_usergroups_for_user( $user_id_or_login, $ids_or_objects = 'ids' ) {
+
+			if ( ! is_numeric( $user_id_or_login ) ) {
+				$user_id = get_user_by( 'login', $user_id_or_login )->ID;
+			} else {
+				$user_id = (int) $user_id_or_login;
+			}
+
+			// Unfortunately, the easiest way to do this is get all usergroups
+			// and then loop through each one to see if the user ID is stored
+			$all_usergroups = $this->get_usergroups();
+			if ( ! empty( $all_usergroups ) ) {
+				$usergroup_objects_or_ids = array();
+				foreach ( $all_usergroups as $usergroup ) {
+					// Not in this usergroup, so keep going
+					if ( ! in_array( $user_id, $usergroup->user_ids ) ) {
+						continue;
+					}
+					if ( 'ids' == $ids_or_objects ) {
+						$usergroup_objects_or_ids[] = (int) $usergroup->term_id;
+					} else if ( 'objects' == $ids_or_objects ) {
+						$usergroup_objects_or_ids[] = $usergroup;
+					}
+				}
+				return $usergroup_objects_or_ids;
+			} else {
+				return false;
+			}
 		}
 	}
-	
+
 }
 
-}
+// phpcs:disable Generic.Files.OneObjectStructurePerFile.MultipleFound
+
+if ( ! class_exists( 'EF_Usergroups_List_Table' ) ) {
+	/**
+	 * Usergroups uses WordPress' List Table API for generating the Usergroup management table
+	 *
+	 * @since 0.7
+	 */
+	class EF_Usergroups_List_Table extends WP_List_Table {
 
 
-if ( !class_exists( 'EF_Usergroups_List_Table' ) ) {
-/**
- * Usergroups uses WordPress' List Table API for generating the Usergroup management table
- *
- * @since 0.7
- */
-class EF_Usergroups_List_Table extends WP_List_Table
-{
-	
-	var $callback_args;
-	
-	function __construct() {
-		
-		parent::__construct( array(
-			'plural' => 'user groups',
-			'singular' => 'user group',
-			'ajax' => true
-		) );
-		
-	}
-	
-	/**
-	 * @todo Paginate if we have a lot of usergroups
-	 *
-	 * @since 0.7
-	 */
-	function prepare_items() {
-		global $edit_flow;		
-		
-		$columns = $this->get_columns();
-		$hidden = array();
-		$sortable = array();
-		
-		$this->_column_headers = array( $columns, $hidden, $sortable );
-		
-		$this->items = $edit_flow->user_groups->get_usergroups();
-		
-		$this->set_pagination_args( array(
-			'total_items' => count( $this->items ),
-			'per_page' => count( $this->items ),
-		) );
-	}
+		protected $callback_args;
 
-	/**
-	 * Message to be displayed when there are no usergroups
-	 *
-	 * @since 0.7
-	 */
-	function no_items() {
-		_e( 'No user groups found.', 'edit-flow' );
-	}
-	
-	/**
-	 * Columns in our Usergroups table
-	 *
-	 * @since 0.7
-	 */
-	function get_columns() {
+		public function __construct() {
 
-		$columns = array(
-			'name' => __( 'Name', 'edit-flow' ),
-			'description' => __( 'Description', 'edit-flow' ),
-			'users' => __( 'Users in Group', 'edit-flow' ),			
-		);
-		
-		return $columns;
-	}
-	
-	/**
-	 * Process the Usergroup column value for all methods that aren't registered
-	 *
-	 * @since 0.7
-	 */
-	function column_default( $usergroup, $column_name ) {
+			parent::__construct( array(
+				'plural' => 'user groups',
+				'singular' => 'user group',
+				'ajax' => true,
+			) );
+		}
 
-		
-	}
-	
-	/**
-	 * Process the Usergroup name column value.
-	 * Displays the name of the Usergroup, and action links
-	 *
-	 * @since 0.7
-	 */
-	function column_name( $usergroup ) {
-		global $edit_flow;
-		
-		// @todo direct edit link
-		$output = '<strong><a href="' . esc_url( $edit_flow->user_groups->get_link( array( 'action' => 'edit-usergroup', 'usergroup-id' => $usergroup->term_id ) ) ) . '">' . esc_html( $usergroup->name ) . '</a></strong>';
-		
-		$actions = array();
-		$actions['edit edit-usergroup'] = sprintf( '<a href="%1$s">' . __( 'Edit', 'edit-flow' ) . '</a>', $edit_flow->user_groups->get_link( array( 'action' => 'edit-usergroup', 'usergroup-id' => $usergroup->term_id ) ) );
-		$actions['inline hide-if-no-js'] = '<a href="#" class="editinline">' . __( 'Quick&nbsp;Edit' ) . '</a>';
-		$actions['delete delete-usergroup'] = sprintf( '<a href="%1$s">' . __( 'Delete', 'edit-flow' ) . '</a>', $edit_flow->user_groups->get_link( array( 'action' => 'delete-usergroup', 'usergroup-id' => $usergroup->term_id ) ) );
-		
-		$output .= $this->row_actions( $actions, false );
-		$output .= '<div class="hidden" id="inline_' . $usergroup->term_id . '">';
-		$output .= '<div class="name">' . esc_html( $usergroup->name ) . '</div>';
-		$output .= '<div class="description">' . esc_html( $usergroup->description ) . '</div>';	
-		$output .= '</div>';
-		
-		return $output;
-			
-	}
-	
-	/**
-	 * Handle the 'description' column for the table of Usergroups
-	 * Don't need to unencode this because we already did when the usergroup was loaded
-	 *
-	 * @since 0.7
-	 */
-	function column_description( $usergroup ) {
-		return esc_html( $usergroup->description );
-	}
-	
-	/**
-	 * Show the "Total Users" in a given usergroup
-	 *
-	 * @since 0.7
-	 */
-	function column_users( $usergroup ) {
-		global $edit_flow;
-		return '<a href="' . esc_url( $edit_flow->user_groups->get_link( array( 'action' => 'edit-usergroup', 'usergroup-id' => $usergroup->term_id ) ) ) . '">' . count( $usergroup->user_ids ) . '</a>';
-	}
-	
-	/**
-	 * Prepare a single row of information about a usergroup
-	 *
-	 * @since 0.7
-	 */
-	function single_row( $usergroup ) {
-		static $row_class = '';
-		$row_class = ( $row_class == '' ? ' class="alternate"' : '' );
+		/**
+		 * @todo Paginate if we have a lot of usergroups
+		 *
+		 * @since 0.7
+		 */
+		public function prepare_items() {
+			global $edit_flow;
 
-		echo '<tr id="usergroup-' . $usergroup->term_id . '"' . $row_class . '>';
-		echo $this->single_row_columns( $usergroup );
-		echo '</tr>';
-	}
-	
-	/**
-	 * If we use this form, we can have inline editing!
-	 *
-	 * @since 0.7
-	 */
-	function inline_edit() {
-		global $edit_flow;
-?>
+			$columns = $this->get_columns();
+			$hidden = array();
+			$sortable = array();
+
+			$this->_column_headers = array( $columns, $hidden, $sortable );
+
+			$this->items = $edit_flow->user_groups->get_usergroups();
+
+			$this->set_pagination_args( array(
+				'total_items' => count( $this->items ),
+				'per_page' => count( $this->items ),
+			) );
+		}
+
+		/**
+		 * Message to be displayed when there are no usergroups
+		 *
+		 * @since 0.7
+		 */
+		public function no_items() {
+			_e( 'No user groups found.', 'edit-flow' );
+		}
+
+		/**
+		 * Columns in our Usergroups table
+		 *
+		 * @since 0.7
+		 */
+		public function get_columns() {
+
+			$columns = array(
+				'name' => __( 'Name', 'edit-flow' ),
+				'description' => __( 'Description', 'edit-flow' ),
+				'users' => __( 'Users in Group', 'edit-flow' ),
+			);
+
+			return $columns;
+		}
+
+		/**
+		 * Process the Usergroup column value for all methods that aren't registered
+		 *
+		 * @since 0.7
+		 */
+		public function column_default( $usergroup, $column_name ) {
+		}
+
+		/**
+		 * Process the Usergroup name column value.
+		 * Displays the name of the Usergroup, and action links
+		 *
+		 * @since 0.7
+		 */
+		public function column_name( $usergroup ) {
+			global $edit_flow;
+
+			// @todo direct edit link
+			$output = '<strong><a href="' . esc_url( $edit_flow->user_groups->get_link( array(
+				'action' => 'edit-usergroup',
+				'usergroup-id' => $usergroup->term_id,
+			) ) ) . '">' . esc_html( $usergroup->name ) . '</a></strong>';
+
+			$actions = array();
+			$actions['edit edit-usergroup'] = sprintf( '<a href="%1$s">' . __( 'Edit', 'edit-flow' ) . '</a>', $edit_flow->user_groups->get_link( array(
+				'action' => 'edit-usergroup',
+				'usergroup-id' => $usergroup->term_id,
+			) ) );
+			$actions['inline hide-if-no-js'] = '<a href="#" class="editinline">' . __( 'Quick&nbsp;Edit' ) . '</a>';
+			$actions['delete delete-usergroup'] = sprintf( '<a href="%1$s">' . __( 'Delete', 'edit-flow' ) . '</a>', $edit_flow->user_groups->get_link( array(
+				'action' => 'delete-usergroup',
+				'usergroup-id' => $usergroup->term_id,
+			) ) );
+
+			$output .= $this->row_actions( $actions, false );
+			$output .= '<div class="hidden" id="inline_' . $usergroup->term_id . '">';
+			$output .= '<div class="name">' . esc_html( $usergroup->name ) . '</div>';
+			$output .= '<div class="description">' . esc_html( $usergroup->description ) . '</div>';
+			$output .= '</div>';
+
+			return $output;
+		}
+
+		/**
+		 * Handle the 'description' column for the table of Usergroups
+		 * Don't need to unencode this because we already did when the usergroup was loaded
+		 *
+		 * @since 0.7
+		 */
+		public function column_description( $usergroup ) {
+			return esc_html( $usergroup->description );
+		}
+
+		/**
+		 * Show the "Total Users" in a given usergroup
+		 *
+		 * @since 0.7
+		 */
+		public function column_users( $usergroup ) {
+			global $edit_flow;
+			return '<a href="' . esc_url( $edit_flow->user_groups->get_link( array(
+				'action' => 'edit-usergroup',
+				'usergroup-id' => $usergroup->term_id,
+			) ) ) . '">' . count( $usergroup->user_ids ) . '</a>';
+		}
+
+		/**
+		 * Prepare a single row of information about a usergroup
+		 *
+		 * @since 0.7
+		 */
+		public function single_row( $usergroup ) {
+			static $row_class = '';
+			$row_class = ( '' == $row_class ? ' class="alternate"' : '' );
+
+			echo wp_kses_post( '<tr id="usergroup-' . $usergroup->term_id . '"' . $row_class . '>' );
+			echo wp_kses_post( $this->single_row_columns( $usergroup ) );
+			echo '</tr>';
+		}
+
+		/**
+		 * If we use this form, we can have inline editing!
+		 *
+		 * @since 0.7
+		 */
+		public function inline_edit() {
+			global $edit_flow;
+			?>
 	<form method="get" action=""><table style="display: none"><tbody id="inlineedit">
-		<tr id="inline-edit" class="inline-edit-row" style="display: none"><td colspan="<?php echo $this->get_column_count(); ?>" class="colspanchange">
+		<tr id="inline-edit" class="inline-edit-row" style="display: none"><td colspan="<?php echo esc_attr( $this->get_column_count() ); ?>" class="colspanchange">
 			<fieldset><div class="inline-edit-col">
 				<h4><?php _e( 'Quick Edit' ); ?></h4>
 				<label>
@@ -1246,7 +1330,7 @@ class EF_Usergroups_List_Table extends WP_List_Table
 		<p class="inline-edit-save submit">
 			<a accesskey="c" href="#inline-edit" title="<?php _e( 'Cancel' ); ?>" class="cancel button-secondary alignleft"><?php _e( 'Cancel' ); ?></a>
 			<?php $update_text = __( 'Update User Group', 'edit-flow' ); ?>
-			<a accesskey="s" href="#inline-edit" title="<?php echo esc_attr( $update_text ); ?>" class="save button-primary alignright"><?php echo $update_text; ?></a>
+			<a accesskey="s" href="#inline-edit" title="<?php echo esc_attr( $update_text ); ?>" class="save button-primary alignright"><?php echo esc_html( $update_text ); ?></a>
 			<img class="waiting" style="display:none;" src="<?php echo esc_url( admin_url( 'images/wpspin_light.gif' ) ); ?>" alt="" />
 			<span class="error" style="display:none;"></span>
 			<?php wp_nonce_field( 'usergroups-inline-edit-nonce', 'inline_edit', false ); ?>
@@ -1254,8 +1338,7 @@ class EF_Usergroups_List_Table extends WP_List_Table
 		</p>
 		</td></tr>
 		</tbody></table></form>
-	<?php
+			<?php
+		}
 	}
-		
-}
 }

--- a/modules/user-groups/user-groups.php
+++ b/modules/user-groups/user-groups.php
@@ -324,7 +324,7 @@ if ( ! class_exists( 'EF_User_Groups' ) ) {
 			);
 			$usergroup = $this->add_usergroup( $args );
 			if ( is_wp_error( $usergroup ) ) {
-				wp_die( esc_textarea( __( 'Error adding usergroup.', 'edit-flow' ) ) );
+				wp_die( esc_html__( 'Error adding usergroup.', 'edit-flow' ) );
 			}
 
 			$args = array(
@@ -410,7 +410,7 @@ if ( ! class_exists( 'EF_User_Groups' ) ) {
 			$users = array_map( 'intval', $users );
 			$usergroup = $this->update_usergroup( $existing_usergroup->term_id, $args, $users );
 			if ( is_wp_error( $usergroup ) ) {
-				wp_die( esc_textarea( __( 'Error updating user group.', 'edit-flow' ) ) );
+				wp_die( esc_html__( 'Error updating user group.', 'edit-flow' ) );
 			}
 
 			$args = array(
@@ -515,7 +515,7 @@ if ( ! class_exists( 'EF_User_Groups' ) ) {
 			} else {
 				// translators: %s is the name of the user group
 				$change_error = new WP_Error( 'invalid', sprintf( __( 'Could not update the user group: <strong>%s</strong>', 'edit-flow' ), $name ) );
-				die( esc_html( $change_error->get_error_message() ) );
+				die( wp_kses( $change_error->get_error_message(), 'strong' ) );
 			}
 		}
 
@@ -639,18 +639,10 @@ if ( ! class_exists( 'EF_User_Groups' ) ) {
 			</div></div>
 			<div id="col-left"><div class="col-wrap"><div class="form-wrap">
 				<h3 class="nav-tab-wrapper">
-					<a href="<?php echo esc_url( $this->get_link() ); ?>" class="nav-tab
-										<?php
-										if ( ! isset( $_GET['action'] ) || 'change-options' != $_GET['action'] ) {
-											echo ' nav-tab-active';}
-										?>
-					"><?php _e( 'Add New', 'edit-flow' ); ?></a>
-					<a href="<?php echo esc_url( $this->get_link( array( 'action' => 'change-options' ) ) ); ?>" class="nav-tab
-										<?php
-										if ( isset( $_GET['action'] ) && 'change-options' == $_GET['action'] ) {
-											echo ' nav-tab-active';}
-										?>
-					"><?php _e( 'Options', 'edit-flow' ); ?></a>
+					<?php $add_new_nav_class = ! isset( $_GET['action'] ) || 'change-options' != $_GET['action'] ? 'nav-tab-active' : ''; ?>
+					<a href="<?php echo esc_url( $this->get_link() ); ?>" class="nav-tab <?php echo esc_attr( $add_new_nav_class ); ?>"><?php esc_html_e( 'Add New', 'edit-flow' ); ?></a>
+					<?php $options_nav_class = isset( $_GET['action'] ) && 'change-options' == $_GET['action'] ? 'nav-tab-active' : ''; ?>
+					<a href="<?php echo esc_url( $this->get_link( array( 'action' => 'change-options' ) ) ); ?>" class="nav-tab <?php echo esc_attr( $options_nav_class ); ?>"><?php esc_html_e( 'Options', 'edit-flow' ); ?></a>
 				</h3>
 				<?php if ( isset( $_GET['action'] ) && 'change-options' == $_GET['action'] ) : ?>
 				<form class="basic-settings" action="<?php echo esc_url( $this->get_link( array( 'action' => 'change-options' ) ) ); ?>" method="post">
@@ -664,12 +656,12 @@ if ( ! class_exists( 'EF_User_Groups' ) ) {
 					<form class="add:the-list:" action="<?php echo esc_url( $this->get_link() ); ?>" method="post" id="addusergroup" name="addusergroup">
 					<div class="form-field form-required">
 						<label for="name"><?php _e( 'Name', 'edit-flow' ); ?></label>
-						<input type="text" aria-required="true" id="name" name="name" maxlength="40" value="<?php /* phpcs:ignore Generic.ControlStructures.InlineControlStructure.NotAllowed */ if ( ! empty( $_POST['name'] ) ) echo esc_attr( $_POST['name'] ); ?>"
+						<input type="text" aria-required="true" id="name" name="name" maxlength="40" value="<?php echo ( empty( $_POST['name'] ) ? '' : esc_attr( $_POST['name'] ) ); ?>"/>
 						<?php $edit_flow->settings->helper_print_error_or_description( 'name', __( 'The name is used to identify the user group.', 'edit-flow' ) ); ?>
 					</div>
 					<div class="form-field">
 						<label for="description"><?php _e( 'Description', 'edit-flow' ); ?></label>
-						<textarea cols="40" rows="5" id="description" name="description"><?php /* phpcs:ignore Generic.ControlStructures.InlineControlStructure.NotAllowed */ if ( ! empty( $_POST['description'] ) ) echo esc_textarea( $_POST['description'] ); ?></textarea>
+						<textarea cols="40" rows="5" id="description" name="description"><?php echo ( empty( $_POST['description'] ) ? '' : esc_attr( $_POST['description'] ) ); ?></textarea>
 						<?php $edit_flow->settings->helper_print_error_or_description( 'description', __( 'The description is primarily for administrative use, to give you some context on what the user group is to be used for.', 'edit-flow' ) ); ?>
 					</div>
 					<?php wp_nonce_field( 'add-usergroup' ); ?>
@@ -820,7 +812,7 @@ if ( ! class_exists( 'EF_User_Groups' ) ) {
 			$usergroups = $this->get_usergroups();
 			if ( empty( $usergroups ) ) {
 				?>
-			<p><?php _e( 'No user groups were found.', 'edit-flow' ); ?> <a href="<?php echo esc_url( $this->get_link() ); ?>" title="<?php _e( 'Add a new user group. Opens new window.', 'edit-flow' ); ?>" target="_blank"><?php _e( 'Add a User Group', 'edit-flow' ); ?></a></p>
+			<p><?php esc_html_e( 'No user groups were found.', 'edit-flow' ); ?> <a href="<?php echo esc_url( $this->get_link() ); ?>" title="<?php esc_attr_e( 'Add a new user group. Opens new window.', 'edit-flow' ); ?>" target="_blank"><?php esc_html_e( 'Add a User Group', 'edit-flow' ); ?></a></p>
 				<?php
 			} else {
 
@@ -828,12 +820,11 @@ if ( ! class_exists( 'EF_User_Groups' ) ) {
 			<ul id="<?php echo esc_attr( $list_id ); ?>" class="<?php echo esc_attr( $list_class ); ?>">
 				<?php
 				foreach ( $usergroups as $usergroup ) {
-					$checked = ( in_array( $usergroup->term_id, $selected ) ) ? ' checked="checked"' : '';
 					?>
 				<li>
 					<label for="<?php echo esc_attr( $input_id ) . esc_attr( $usergroup->term_id ); ?>" title="<?php echo esc_attr( $usergroup->description ); ?>">
 						<div class="ef-user-subscribe-actions">
-							<input type="checkbox" id="<?php echo esc_attr( $input_id . $usergroup->term_id ); ?>" name="<?php echo esc_attr( $input_id ); ?>[]" value="<?php echo esc_attr( $usergroup->term_id ); ?>"<?php echo wp_kses_post( $checked ); ?> />
+							<input type="checkbox" id="<?php echo esc_attr( $input_id . $usergroup->term_id ); ?>" name="<?php echo esc_attr( $input_id ); ?>[]" value="<?php echo esc_attr( $usergroup->term_id ); ?>"<?php echo checked( in_array( $usergroup->term_id, $selected ) ); ?> />
 						</div>
 						<span class="ef-usergroup_name"><?php echo esc_html( $usergroup->name ); ?></span>
 						<span class="ef-usergroup_description" title="<?php echo esc_attr( $usergroup->description ); ?>">

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -17,6 +17,13 @@
 		<!-- Allow short ternaries -->
 		<exclude name="WordPress.PHP.DisallowShortTernary.Found" />
 
+		<exclude name="WordPress.Files.FileName.NotHyphenatedLowercase" />
+		<exclude name="Universal.Files.SeparateFunctionsFromOO.Mixed" />
+		<exclude name="PEAR.NamingConventions.ValidClassName.StartWithCapital" />
+		<exclude name="PEAR.NamingConventions.ValidClassName.Invalid" />
+
+		<exclude name="WordPressVIPMinimum.Hooks.AlwaysReturnInFilter.MissingReturnStatement" />
+
 		<!-- Generates too many false positives -->
 		<exclude name="WordPress.WP.CapitalPDangit.Misspelled" />
 		<!-- We use trigger_error extensively -->

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -14,29 +14,28 @@
 		<!-- Do not enforce 'class-' prefix -->
 		<exclude name="WordPress.Files.FileName.InvalidClassFileName" />
 
+		<!-- Allow short ternaries -->
+		<exclude name="WordPress.PHP.DisallowShortTernary.Found" />
+
+		<!-- Generates too many false positives -->
+		<exclude name="WordPress.WP.CapitalPDangit.Misspelled" />
+
+		<!-- We use trigger_error extensively -->
+		<exclude name="WordPress.PHP.DevelopmentFunctions.error_log_trigger_error" />
+
+		<!-- ToDo: Remove these exceptions overttime -->
 		<!-- These are for legacy reasons, as EditFlow's main file cannot be altered -->
 		<exclude name="WordPress.Files.FileName.NotHyphenatedLowercase" />
 		<exclude name="Universal.Files.SeparateFunctionsFromOO.Mixed" />
 		<exclude name="PEAR.NamingConventions.ValidClassName.StartWithCapital" />
 		<exclude name="PEAR.NamingConventions.ValidClassName.Invalid" />
-
-		<!-- Allow short ternaries -->
-		<exclude name="WordPress.PHP.DisallowShortTernary.Found" />
-
 		<!-- Allow not returning after the setup theme filter for now -->
 		<exclude name="WordPressVIPMinimum.Hooks.AlwaysReturnInFilter.MissingReturnStatement" />
-
-		<!-- Generates too many false positives -->
-		<exclude name="WordPress.WP.CapitalPDangit.Misspelled" />
-		<!-- We use trigger_error extensively -->
-		<exclude name="WordPress.PHP.DevelopmentFunctions.error_log_trigger_error" />
-
 		<!-- Localization is done in a legacy manner in some places, and its ben left as is for now -->
 		<exclude name="WordPress.WP.I18n.InterpolatedVariableSingular" />
 		<exclude name="WordPress.WP.I18n.InterpolatedVariablePlural" />
 		<exclude name="WordPress.WP.I18n.MissingSingularPlaceholder" />
 		<exclude name="WordPress.WP.I18n.NonSingularStringLiteralText" />
-
 		<!-- This rule is hard to solve given the heavy use of JS in the PHP code right now -->
 		<exclude name="Squiz.PHP.DisallowMultipleAssignments.FoundInControlStructure" />
 	</rule>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -24,6 +24,10 @@
 
 		<exclude name="WordPress.WP.I18n.InterpolatedVariableSingular" />
 		<exclude name="WordPress.WP.I18n.InterpolatedVariablePlural" />
+		<exclude name="WordPress.WP.I18n.MissingSingularPlaceholder" />
+		<exclude name="WordPress.WP.I18n.NonSingularStringLiteralText" />
+
+		<exclude name="Squiz.PHP.DisallowMultipleAssignments.FoundInControlStructure" />
 	</rule>
 
 	<file>.</file>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -14,14 +14,16 @@
 		<!-- Do not enforce 'class-' prefix -->
 		<exclude name="WordPress.Files.FileName.InvalidClassFileName" />
 
-		<!-- Allow short ternaries -->
-		<exclude name="WordPress.PHP.DisallowShortTernary.Found" />
-
+		<!-- These are for legacy reasons, as EditFlow's main file cannot be altered -->
 		<exclude name="WordPress.Files.FileName.NotHyphenatedLowercase" />
 		<exclude name="Universal.Files.SeparateFunctionsFromOO.Mixed" />
 		<exclude name="PEAR.NamingConventions.ValidClassName.StartWithCapital" />
 		<exclude name="PEAR.NamingConventions.ValidClassName.Invalid" />
 
+		<!-- Allow short ternaries -->
+		<exclude name="WordPress.PHP.DisallowShortTernary.Found" />
+
+		<!-- Allow not returning after the setup theme filter for now -->
 		<exclude name="WordPressVIPMinimum.Hooks.AlwaysReturnInFilter.MissingReturnStatement" />
 
 		<!-- Generates too many false positives -->
@@ -29,11 +31,13 @@
 		<!-- We use trigger_error extensively -->
 		<exclude name="WordPress.PHP.DevelopmentFunctions.error_log_trigger_error" />
 
+		<!-- Localization is done in a legacy manner in some places, and its ben left as is for now -->
 		<exclude name="WordPress.WP.I18n.InterpolatedVariableSingular" />
 		<exclude name="WordPress.WP.I18n.InterpolatedVariablePlural" />
 		<exclude name="WordPress.WP.I18n.MissingSingularPlaceholder" />
 		<exclude name="WordPress.WP.I18n.NonSingularStringLiteralText" />
 
+		<!-- This rule is hard to solve given the heavy use of JS in the PHP code right now -->
 		<exclude name="Squiz.PHP.DisallowMultipleAssignments.FoundInControlStructure" />
 	</rule>
 

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -38,6 +38,7 @@
 		<exclude name="WordPress.WP.I18n.NonSingularStringLiteralText" />
 		<!-- This rule is hard to solve given the heavy use of JS in the PHP code right now -->
 		<exclude name="Squiz.PHP.DisallowMultipleAssignments.FoundInControlStructure" />
+		<exclude name="WordPress.DateTime.RestrictedFunctions.date_date" />
 	</rule>
 
 	<file>.</file>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -21,12 +21,14 @@
 		<exclude name="WordPress.WP.CapitalPDangit.Misspelled" />
 		<!-- We use trigger_error extensively -->
 		<exclude name="WordPress.PHP.DevelopmentFunctions.error_log_trigger_error" />
+
+		<exclude name="WordPress.WP.I18n.InterpolatedVariableSingular" />
+		<exclude name="WordPress.WP.I18n.InterpolatedVariablePlural" />
 	</rule>
 
 	<file>.</file>
 
 	<exclude-pattern>*/node_modules/*</exclude-pattern>
-	<exclude-pattern>*/nodeapp/*</exclude-pattern>
 	<exclude-pattern>*/vendor/*</exclude-pattern>
-	<exclude-pattern>*/wordpress/*</exclude-pattern>
+	<exclude-pattern>*/tests/*</exclude-pattern>
 </ruleset>

--- a/vipgo-helper.php
+++ b/vipgo-helper.php
@@ -9,10 +9,18 @@ add_action( 'after_setup_theme', 'EditFlow' );
  * them via filters.
  */
 add_filter( 'ef_kill_add_caps_to_role', '__return_true' );
-add_filter( 'ef_view_calendar_cap', function() {return 'edit_posts'; } );
-add_filter( 'ef_view_story_budget_cap', function() { return 'edit_posts'; } );
-add_filter( 'ef_edit_post_subscriptions_cap', function() { return 'edit_others_posts'; } );
-add_filter( 'ef_manage_usergroups_cap', function() { return 'manage_options'; } );
+add_filter( 'ef_view_calendar_cap', function () {
+	return 'edit_posts';
+} );
+add_filter( 'ef_view_story_budget_cap', function () {
+	return 'edit_posts';
+} );
+add_filter( 'ef_edit_post_subscriptions_cap', function () {
+	return 'edit_others_posts';
+} );
+add_filter( 'ef_manage_usergroups_cap', function () {
+	return 'manage_options';
+} );
 
 /**
  * Edit Flow loads modules after plugins_loaded, which has already been fired when loading via wpcom_vip_load_plugins

--- a/wpcom-helper.php
+++ b/wpcom-helper.php
@@ -9,10 +9,18 @@ add_action( 'after_setup_theme', 'EditFlow' );
  * them with the WP.com + core caps approach
  */
 add_filter( 'ef_kill_add_caps_to_role', '__return_true' );
-add_filter( 'ef_view_calendar_cap', function() { return 'edit_posts'; } );
-add_filter( 'ef_view_story_budget_cap', function() { return 'edit_posts'; } );
-add_filter( 'ef_edit_post_subscriptions_cap', function() { return 'edit_others_posts'; } );
-add_filter( 'ef_manage_usergroups_cap', function() { return 'manage_options'; } );
+add_filter( 'ef_view_calendar_cap', function () {
+	return 'edit_posts';
+} );
+add_filter( 'ef_view_story_budget_cap', function () {
+	return 'edit_posts';
+} );
+add_filter( 'ef_edit_post_subscriptions_cap', function () {
+	return 'edit_others_posts';
+} );
+add_filter( 'ef_manage_usergroups_cap', function () {
+	return 'manage_options';
+} );
 
 /**
  * Edit Flow loads modules after plugins_loaded, which has already been fired on WP.com


### PR DESCRIPTION
## Description

This PR is meant to lint all the PHP classes at once to make development easier. I have skipped the commons folder, just like we skipped it for the JS linting in the interest of not breaking everything. We should revisit that decision or try to refactor it, but I'll set that aside for now.

There's also a bug fix here as the settings updated css wasn't being applied correctly. That's resolved now.