### PR TITLE
Remove unnecessary filters for webhook notifications

### DIFF
--- a/modules/notifications/notifications.php
+++ b/modules/notifications/notifications.php
@@ -878,16 +878,10 @@ if ( ! class_exists( 'EF_Notifications' ) ) {
 		public function send_to_webhook( $message, $action, $user, $post ) {
 			$webhook_url = $this->module->options->webhook_url;
 
-			// apply filters to the URL
-			$webhook_url = apply_filters( 'ef_notification_send_to_webhook_url', $webhook_url, $action, $user, $post );
-
 			// Bail if the webhook URL is not set
 			if ( empty( $webhook_url ) ) {
 				return;
 			}
-
-			// apply filters to the message
-			$message = apply_filters( 'ef_notification_send_to_webhook_message', $message, $action, $user, $post );
 
 			// Set up the payload
 			$payload = [


### PR DESCRIPTION
## Description

This PR simplifies the new webhook integration feature of the notifications module to only 1 singular filter to modify the payload sent to the webhook.

## Steps to Test

1. Check out PR.
1. Go to Notifications.
1. Enable `Send to webhook` and add a valid webhook URL.
1. Verify notifications are sent to the webhook on new editorial comment or extended post status change.
