### PR TITLE
Update the analytics flag

### DIFF
--- a/common/php/class-module.php
+++ b/common/php/class-module.php
@@ -51,7 +51,7 @@ if ( ! class_exists( 'EF_Module' ) ) {
 		 *
 		 * @since 0.10.0
 		 *
-		 * @return true, if the module is enabled, false otherwise
+		 * @return true, if the feature is enabled, false otherwise
 		 */
 		protected function are_vip_features_enabled() {
 			global $edit_flow;
@@ -60,16 +60,22 @@ if ( ! class_exists( 'EF_Module' ) ) {
 		}
 
 		/**
-		 * Returns whether vip features have been enabled or not.
+		 * Returns whether analytics has been enabled or not.
+		 *
+		 * It's only enabled if the site is a production WPVIP site.
 		 *
 		 * @since 0.10.0
 		 *
-		 * @return true, if the module is enabled, false otherwise
+		 * @return true, if analytics is enabled, false otherwise
 		 */
-		protected function is_analytics_enabled() {
-			global $edit_flow;
+		public function is_analytics_enabled() {
+			// Check if the site is a production WPVIP site and only then enable it
+			$is_analytics_enabled = $this->is_vip_site( true );
 
-			return 'on' === $edit_flow->settings->module->options->analytics;
+			// filter to disable it.
+			$is_analytics_enabled = apply_filters( 'ef_should_analytics_be_enabled', $is_analytics_enabled );
+
+			return $is_analytics_enabled;
 		}
 
 		/**

--- a/modules/settings/settings.php
+++ b/modules/settings/settings.php
@@ -23,7 +23,6 @@ if ( ! class_exists( 'EF_Settings' ) ) {
 				'default_options' => array(
 					'enabled' => 'on',
 					'vip_features' => $this->is_vip_site() ? 'on' : 'off',
-					'analytics' => $this->is_vip_site( true ) ? 'on' : 'off',
 				),
 				'configure_page_cb' => 'print_default_settings',
 				'autoload' => true,
@@ -161,7 +160,6 @@ if ( ! class_exists( 'EF_Settings' ) ) {
 		 */
 		public function register_settings() {
 			add_settings_section( $this->module->options_group_name . '_general', false, '__return_false', $this->module->options_group_name );
-			add_settings_field( 'analytics', __( 'Turn on analytics', 'edit-flow' ), array( $this, 'settings_analytics_option' ), $this->module->options_group_name, $this->module->options_group_name . '_general' );
 			add_settings_field( 'vip_features', __( 'Turn on WordPress VIP features', 'edit-flow' ), array( $this, 'settings_vip_features_option' ), $this->module->options_group_name, $this->module->options_group_name . '_general' );
 		}
 
@@ -253,20 +251,6 @@ if ( ! class_exists( 'EF_Settings' ) ) {
 			foreach ( $options as $value => $label ) {
 				echo '<option value="' . esc_attr( $value ) . '"';
 				echo selected( $this->module->options->vip_features, $value );
-				echo '>' . esc_html( $label ) . '</option>';
-			}
-			echo '</select>';
-		}
-
-		public function settings_analytics_option() {
-			$options = array(
-				'off' => __( 'Disabled', 'edit-flow' ),
-				'on' => __( 'Enabled', 'edit-flow' ),
-			);
-			echo '<select id="analytics" name="' . esc_attr( $this->module->options_group_name ) . '[analytics]">';
-			foreach ( $options as $value => $label ) {
-				echo '<option value="' . esc_attr( $value ) . '"';
-				echo selected( $this->module->options->analytics, $value );
 				echo '>' . esc_html( $label ) . '</option>';
 			}
 			echo '</select>';


### PR DESCRIPTION
## Description

This PR will remove the analytics dropdown and option in favour of enabling it for VIP Production sites by default only. For everyone else it will be **disabled**. 

There's a filter provided to disable or enable it. This can be used by VIP customers to disable it or by .org users to opt into analytics if they want it. 

Once we add in tracks integration, we can link the VIP privacy policy in the readme. I want to emphasize that this will be enabled for VIP customers only, for everyone else it's disabled by default.
