### PR TITLE
Fix the nonce error when doing bulk actions

### DIFF
--- a/modules/notifications/notifications.php
+++ b/modules/notifications/notifications.php
@@ -516,7 +516,7 @@ if ( ! class_exists( 'EF_Notifications' ) ) {
 		public function save_post_subscriptions( $new_status, $old_status, $post ) {
 			global $edit_flow;
 
-			if ( ! empty( $_GET['_wpnonce'] ) && ! wp_verify_nonce( $_GET['_wpnonce'], 'editpost' ) ) {
+			if ( ! empty( $_POST['_wpnonce'] ) && ! wp_verify_nonce( $_POST['_wpnonce'], 'editpost' ) ) {
 				$this->print_ajax_response( 'error', $this->module->messages['nonce-failed'] );
 			}
 


### PR DESCRIPTION
## Description

This will fix the regression that was introduced into notifications wherein if you tried to perform a bulk action on a post, it would fail due to a nonce error.
