### PR TITLE
Update user-groups.php to avoid resaving usergroup for user already in group

### DIFF
--- a/modules/user-groups/user-groups.php
+++ b/modules/user-groups/user-groups.php
@@ -1062,6 +1062,12 @@ if ( ! class_exists( 'EF_User_Groups' ) ) {
 
 			foreach ( (array) $ids as $usergroup_id ) {
 				$usergroup = $this->get_usergroup_by( 'id', $usergroup_id );
+
+				// Skip if user is already in this group.
+				if ( in_array( $user_id, $usergroup->user_ids, true ) ) {
+					continue;
+				}
+
 				$usergroup->user_ids[] = $user_id;
 				$retval = $this->update_usergroup( $usergroup_id, null, $usergroup->user_ids );
 				if ( is_wp_error( $retval ) ) {


### PR DESCRIPTION
## Description

This small change represents an enormous performance improvement when there are a lot of users and groups. 

Without this check if the user is already in the group it gets re-saved anyway. If the user is in many groups this represents a lot of wasted time, and on our site it was slowing down user saving to the point where it felt broken. 

I see no risk in this check being added to avoid re-saving a user who is already in a group.  I've been running this as a hotfix in my plugin for years and saving users to groups works fine.

Thank you for considering it.

## Steps to Test

Outline the steps to test and verify the PR here.

* Add and remove users from groups
* Make sure everything works fine
* Enjoy the speedup caused by not resaving when you don't have to
