### PR TITLE
Fix numeric HTML ID in calendar.php

### DIFF
--- a/modules/calendar/calendar.php
+++ b/modules/calendar/calendar.php
@@ -823,7 +823,7 @@ class EF_Calendar extends EF_Module {
 
 					$td_classes = apply_filters( 'ef_calendar_table_td_classes', $td_classes, $week_single_date );
 				?>
-				<td class="<?php echo esc_attr( implode( ' ', $td_classes ) ); ?>" id="<?php echo esc_attr( $week_single_date ); ?>">
+				<td class="<?php echo esc_attr( implode( ' ', $td_classes ) ); ?>" id="date-<?php echo esc_attr( $week_single_date ); ?>">
 					<button class='schedule-new-post-button'>+</button>
 					<?php if ( $week_single_date == date( 'Y-m-d', current_time( 'timestamp' ) ) ): ?>
 						<div class="day-unit-today"><?php esc_html_e( 'Today', 'edit-flow' ); ?></div>


### PR DESCRIPTION
HTML IDs aren't allowed to start with a number, but these `td.day-unit` elements all had IDs like `id='2025-11-25'`. 

I noticed because I was writing an acceptance test that failed when I targeted #2025-08-15 but worked after I added `date-` at the start of the ID. 

Can't imagine how this would affect anyone but me, and either way, we certainly don't want to output invalid HTML. 

Thanks for considering.

