### PR TITLE
Calendar: Update HTML ID on td.day-unit to have date- at the start to avoid invalid HTML due to numeric-start of an ID

### DIFF
--- a/modules/calendar/calendar.php
+++ b/modules/calendar/calendar.php
@@ -839,7 +839,7 @@ if ( ! class_exists( 'EF_Calendar' ) ) {
 
 						$td_classes = apply_filters( 'ef_calendar_table_td_classes', $td_classes, $week_single_date );
 						?>
-				<td class="<?php echo esc_attr( implode( ' ', $td_classes ) ); ?>" id="<?php echo esc_attr( $week_single_date ); ?>">
+				<td class="<?php echo esc_attr( implode( ' ', $td_classes ) ); ?>" id="date-<?php echo esc_attr( $week_single_date ); ?>">
 					<button class='schedule-new-post-button'>+</button>
 						<?php if ( date( 'Y-m-d', current_time( 'timestamp' ) ) == $week_single_date ) : ?>
 						<div class="day-unit-today"><?php esc_html_e( 'Today', 'edit-flow' ); ?></div>

--- a/modules/calendar/lib/calendar.js
+++ b/modules/calendar/lib/calendar.js
@@ -213,8 +213,10 @@ jQuery( document ).ready( function ( $ ) {
 			) {
 				let post_id = $( ui.item ).attr( 'id' ).split( '-' );
 				post_id = post_id[ post_id.length - 1 ];
-				const prev_date = $( this ).closest( '.day-unit' ).attr( 'id' );
-				const next_date = $( ui.item ).closest( '.day-unit' ).attr( 'id' );
+				const prev_date_id = $( this ).closest( '.day-unit' ).attr( 'id' );
+				const prev_date = prev_date_id.substr( 'date-'.length );
+				const next_date_id = $( ui.item ).closest( '.day-unit' ).attr( 'id' );
+				const next_date = next_date_id.substr( 'date-'.length );
 				const nonce = $( document ).find( '#ef-calendar-modify' ).val();
 				$( '.edit-flow-message' ).remove();
 				dispatch( 'edit-flow/calendar' ).setCalendarIsLoading( true );


### PR DESCRIPTION
(Updated after previous false-start PR, this one accounts for JS as far as I know)

HTML IDs aren't allowed to start with a number, but these `td.day-unit` elements all had IDs like `id='2025-11-25'`.

I noticed because I was writing an acceptance test that failed when I targeted `#2025-08-15` but worked after I added `date-` at the start of the ID.

This also fixes the use of these IDs in `calendar.js`, by extracting `date-` from the ID before sending the date value to AJAX.

Thanks for considering.

## Steps to Test

Outline the steps to test and verify the PR here.

* Go to calendar
* Move an item to a different date
* Reload the page and make sure it moves
* IMPORTANT: This will seem to not work if you have object caching enabled because of https://github.com/Automattic/Edit-Flow/issues/505 !!! Disable object caching or the test outlined above will fail both with and without this PR.

**Are there behaviors other than switching dates on an article that need to be reviewed? Please let me know.** 
