### PR TITLE
Calendar: Remove 'taxonomy hierarchical' from editable fields for performance and usability

### DIFF
--- a/modules/calendar/calendar.php
+++ b/modules/calendar/calendar.php
@@ -1102,12 +1102,6 @@ if ( ! class_exists( 'EF_Calendar' ) ) {
 				case 'taxonomy':
 					return '<input type="text" class="metadata-edit-' . esc_attr( $type ) . '" value="' . esc_attr( $value ) . '" />';
 				break;
-				case 'taxonomy hierarchical':
-					return wp_dropdown_categories( array(
-						'echo' => 0,
-						'hide_empty' => 0,
-					) );
-				break;
 			}
 		}
 
@@ -1181,27 +1175,28 @@ if ( ! class_exists( 'EF_Calendar' ) ) {
 				} else {
 					$value = '';
 				}
-				 //Used when editing editorial metadata and post meta
-				if ( is_taxonomy_hierarchical( $taxonomy->name ) ) {
-					$type = 'taxonomy hierarchical';
-				} else {
-					$type = 'taxonomy';
-				}
-
 				$information_fields[ $key ] = array(
 					'label' => $taxonomy->label,
 					'value' => $value,
-					'type' => $type,
 				);
 
-				if ( 'page' == $post->post_type ) {
-					$ed_cap = 'edit_page';
+				// Only allow non-hierarchical taxonomies to be edited in the calendar.
+				// Hierarchical taxonomies (like categories) cause performance issues and
+				// the single-select UI removes all but one category when saved.
+				if ( is_taxonomy_hierarchical( $taxonomy->name ) ) {
+					$information_fields[ $key ]['type'] = 'taxonomy hierarchical';
 				} else {
-					$ed_cap = 'edit_post';
-				}
+					$information_fields[ $key ]['type'] = 'taxonomy';
 
-				if ( current_user_can( $ed_cap, $post->ID ) ) {
-					$information_fields[ $key ]['editable'] = true;
+					if ( 'page' == $post->post_type ) {
+						$ed_cap = 'edit_page';
+					} else {
+						$ed_cap = 'edit_post';
+					}
+
+					if ( current_user_can( $ed_cap, $post->ID ) ) {
+						$information_fields[ $key ]['editable'] = true;
+					}
 				}
 			}
 
@@ -1698,7 +1693,6 @@ if ( ! class_exists( 'EF_Calendar' ) ) {
 			} else {
 				switch ( $_POST['metadata_type'] ) {
 					case 'taxonomy':
-					case 'taxonomy hierarchical':
 						$response = wp_set_post_terms( $post->ID, $incoming_metadata_value, $metadata_term );
 						break;
 					default:


### PR DESCRIPTION
Re: https://github.com/Automattic/Edit-Flow/issues/756

Stop hierarchical taxonomies like categories from being edited inside the calendar, while continuing to allow non-hierarchical taxonomies (tags) to be edited.

This avoids the horrific performance punishment on sites with many categories due to the full list of categories being inserted as a hidden field inside each and every post on the calendar.

It also avoids using a single-select field to update categories, which removes all categories but the one chosen when saved. Users are better off editing the post directly if they need to change the categories, at least unless and until we can offer a proper multi-select category picker in the calendar (a terrible idea because of the performance issues mentioned above).
