### PR TITLE
Increase minimum supported WordPress version to 6.4

### DIFF
--- a/.github/workflows/php-tests.yml
+++ b/.github/workflows/php-tests.yml
@@ -19,7 +19,7 @@ jobs:
         include:
           # Check lowest supported WP version, with the lowest supported PHP.
           - php: '8.0'
-            wp: '6.0'
+            wp: '6.4'
             allowed_failure: false
           # Check latest WP with the highest supported PHP.
           - php: 'latest'

--- a/edit_flow.php
+++ b/edit_flow.php
@@ -5,7 +5,7 @@
  * Description: Remixing the WordPress admin for better editorial workflow options.
  * Author: Daniel Bachhuber, Scott Bressler, Mohammad Jangda, Automattic, and others
  * Version: 0.10.0
- * Requires at least: 6.0
+ * Requires at least: 6.4
  * Requires PHP: 8.0
  * License: GPL-3
  * License URI: https://www.gnu.org/licenses/gpl-3.0.html

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,6 +1,8 @@
 <?xml version="1.0"?>
 <ruleset name="Custom ruleset for Edit Flow">
 
+	<config name="minimum_supported_wp_version" value="6.4"/>
+
 	<rule ref="WordPress-Extra"/>
 	<rule ref="WordPress-VIP-Go">
 		<!-- These disallow anonymous functions as action callbacks -->

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: batmoo, danielbachhuber, sbressler, automattic
 Donate link: http://editflow.org/contribute/
 Tags: edit flow, workflow, editorial, newsroom, management, journalism, post status, custom status, notifications, email, comments, editorial comments, usergroups, calendars, editorial calendar, story budget
-Requires at least: 6.0
+Requires at least: 6.4
 Requires PHP: 8.0
 Tested up to: 6.5
 Stable tag: 0.9.9


### PR DESCRIPTION
## Summary

Bumps the minimum required WordPress version to 6.4.

## Why

WordPress 6.4 provides a more modern baseline, with 85.1% of WordPress sites running 6.4 or later. WP 6.4 drops support for PHP 5.6, aligning with current PHP support policies.

## Testing

No functional changes - this only updates metadata and code standards configuration.