### PR TITLE
Fix case-sensitive plugin path in composer scripts

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,8 +23,8 @@
   "scripts": {
     "cs": "@php ./vendor/bin/phpcs",
     "cs-fix": "@php ./vendor/bin/phpcbf",
-    "integration": "wp-env run tests-cli --env-cwd=wp-content/plugins/Edit-Flow ./vendor/bin/phpunit",
-    "integration-ms": "wp-env run tests-cli --env-cwd=wp-content/plugins/Edit-Flow /bin/bash -c 'WP_MULTISITE=1 ./vendor/bin/phpunit'"
+    "integration": "wp-env run tests-cli --env-cwd=wp-content/plugins/edit-flow ./vendor/bin/phpunit",
+    "integration-ms": "wp-env run tests-cli --env-cwd=wp-content/plugins/edit-flow /bin/bash -c 'WP_MULTISITE=1 ./vendor/bin/phpunit'"
   },
   "config": {
     "allow-plugins": {


### PR DESCRIPTION
## Summary

Updates plugin directory path from `Edit-Flow` to `edit-flow` in composer.json scripts.

## Why

The repository was recently renamed from Edit-Flow to edit-flow. The case-sensitive paths in the integration test scripts were causing CI failures:

```
chdir to cwd ("/var/www/html/wp-content/plugins/Edit-Flow") failed: no such file or directory
```

## Testing

CI tests should now pass successfully.