### PR TITLE
Optimize workflow triggers to avoid redundant CI runs

### DIFF
--- a/.github/workflows/e2e-and-js-tests.yml
+++ b/.github/workflows/e2e-and-js-tests.yml
@@ -1,6 +1,11 @@
 name: E2E and JS tests
 
-on: push
+on:
+  pull_request:
+  push:
+    branches-ignore:
+      - develop
+      - main
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/php-tests.yml
+++ b/.github/workflows/php-tests.yml
@@ -1,6 +1,11 @@
 name: PHP Tests
 
-on: push
+on:
+  pull_request:
+  push:
+    branches-ignore:
+      - develop
+      - main
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Summary

Prevents E2E and PHP tests from running on pushes to develop and main branches.

## Why

Since develop and main are protected branches that only receive changes through pull requests (where tests already run and must pass), running tests again after merge is redundant and wastes CI resources.

## Changes

Updated workflow triggers to:
- Run on all pull requests
- Run on pushes to feature branches
- Skip on pushes to develop and main

## Testing

Tests will still run on all PRs. After PR merge, tests won't re-run on the protected branches.