### PR TITLE
Add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,72 @@
+# Configuration for Dependabot version updates
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    groups:
+      actions:
+        patterns: ["*"]
+    labels:
+      - "dependencies"
+      - "github-actions"
+    assignees:
+      - "Automattic/vip-plugins"
+    commit-message:
+      prefix: "Actions"
+      include: "scope"
+    open-pull-requests-limit: 5
+
+  # Maintain dependencies for Composer
+  - package-ecosystem: "composer"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "tuesday"
+    groups:
+      dev-dependencies:
+        patterns:
+          - "automattic/*"
+          - "dealerdirect/*"
+          - "php-parallel-lint/*"
+          - "phpcompatibility/*"
+          - "phpunit/*"
+          - "squizlabs/*"
+          - "yoast/*"
+    labels:
+      - "dependencies"
+    assignees:
+      - "Automattic/vip-plugins"
+    commit-message:
+      prefix: "Composer"
+      include: "scope"
+    open-pull-requests-limit: 5
+    versioning-strategy: increase-if-necessary
+
+  # Maintain dependencies for npm
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "wednesday"
+    groups:
+      dev-dependencies:
+        patterns:
+          - "@wordpress/*"
+          - "eslint*"
+          - "prettier*"
+          - "@types/*"
+    labels:
+      - "dependencies"
+      - "npm"
+    assignees:
+      - "Automattic/vip-plugins"
+    commit-message:
+      prefix: "npm"
+      include: "scope"
+    open-pull-requests-limit: 5


### PR DESCRIPTION
## Why

Organizes dependency updates into manageable weekly batches with grouped PRs, reducing noise from individual updates while ensuring regular security patches.

Configuration matches the standard used across all a8c-plugins repositories.