### PR TITLE
chore: harden GitHub Actions workflows with SHA pinning and minimal permissions

### DIFF
--- a/.github/workflows/e2e-and-js-tests.yml
+++ b/.github/workflows/e2e-and-js-tests.yml
@@ -21,10 +21,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
 
       - name: Set up NodeJS 20
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
         with:
           node-version: '20'
           cache: npm

--- a/.github/workflows/e2e-and-js-tests.yml
+++ b/.github/workflows/e2e-and-js-tests.yml
@@ -7,14 +7,20 @@ on:
       - develop
       - main
 
+# Disable all permissions by default; grant minimal permissions per job
+permissions: {}
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
   test:
+    name: E2E and JS tests
     runs-on: ubuntu-latest
     continue-on-error: false
+    permissions:
+      contents: read
 
     strategy:
       fail-fast: true
@@ -22,6 +28,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
+        with:
+          persist-credentials: false
 
       - name: Set up NodeJS 20
         uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0

--- a/.github/workflows/php-tests.yml
+++ b/.github/workflows/php-tests.yml
@@ -7,6 +7,9 @@ on:
       - develop
       - main
 
+# Disable all permissions by default; grant minimal permissions per job
+permissions: {}
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -17,6 +20,8 @@ jobs:
     name: WP ${{ matrix.wp == 'master' && 'latest' || matrix.wp }} and PHP ${{ matrix.php }}
     runs-on: ubuntu-latest
     continue-on-error: ${{ matrix.allowed_failure }}
+    permissions:
+      contents: read
 
     strategy:
       fail-fast: false
@@ -34,6 +39,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
+        with:
+          persist-credentials: false
 
       - name: Install wordpress environment
         run: npm -g install @wordpress/env

--- a/.github/workflows/php-tests.yml
+++ b/.github/workflows/php-tests.yml
@@ -33,19 +33,19 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
 
       - name: Install wordpress environment
         run: npm -g install @wordpress/env
 
       - name: Setup PHP ${{ matrix.php }}
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@bf6b4fbd49ca58e4608c9c89fba0b8d90bd2a39f # 2.35.5
         with:
           php-version: ${{ matrix.php }}
           tools: composer
 
       - name: Install Composer dependencies
-        uses: ramsey/composer-install@v3
+        uses: ramsey/composer-install@3cf229dc2919194e9e36783941438d17239e8520 # 3.1.1
         with:
           composer-options: --prefer-dist --no-progress
 


### PR DESCRIPTION
## Problem

GitHub Actions workflows present two significant security risks when not properly hardened:

1. **Supply chain attacks**: Using mutable version tags (e.g., `@v4`) for third-party actions allows attackers to compromise repositories and inject malicious code into existing tags, potentially affecting all workflows using those tags.

2. **Excessive permissions**: GitHub's default workflow permissions grant write access to repository contents and other resources, violating the principle of least privilege and creating unnecessary attack surface.

A security audit using zizmor identified 7 specific findings across our workflows requiring remediation.

## Solution

This PR implements two complementary security hardening measures:

**SHA pinning for supply chain security**: All third-party GitHub Actions are now pinned to their full commit SHA hashes rather than mutable version tags. Each pinned SHA includes a comment with the corresponding version tag for maintainability:
- `actions/checkout@v4` → `@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0`
- `actions/setup-node@v4` → `@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0`
- `shivammathur/setup-php@v2` → `@bf6b4fbd49ca58e4608c9c89fba0b8d90bd2a39f # 2.35.5`
- `ramsey/composer-install@v3` → `@3cf229dc2919194e9e36783941438d17239e8520 # 3.1.1`

This prevents attackers from injecting malicious code through compromised version tags whilst maintaining readability through version comments.

**Minimal permissions following principle of least privilege**: Workflows now implement a defence-in-depth permissions model addressing all 7 zizmor findings:
- Added `permissions: {}` at workflow level to disable all default permissions
- Granted explicit `contents: read` at job level (minimum required for checkout)
- Added `persist-credentials: false` to all checkout actions to prevent credential leakage
- Added explicit `name` to E2E test job for improved auditability

A post-implementation zizmor scan confirms zero remaining security findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)