### PR TITLE
chore: widen composer/installers version constraint to support v2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     "source": "https://github.com/Automattic/edit-flow"
   },
   "require": {
-    "composer/installers": "~1.0",
+    "composer/installers": "^1 || ^2",
     "php": ">=8.0"
   },
   "require-dev": {


### PR DESCRIPTION
## Problem

The project currently constrains `composer/installers` to version `~1.0`, which only permits 1.x releases. This prevents Composer from updating to the 2.x series, which has been available since 2020 and offers improved performance and compatibility with modern Composer workflows. Dependabot has identified this constraint as outdated in PR #788, but cannot automatically resolve it due to the overly restrictive version specification.

## Solution

This change widens the version constraint from `~1.0` to `^1 || ^2`, explicitly allowing both the 1.x and 2.x release series whilst maintaining semantic versioning guarantees. Both versions provide the same core functionality for installing WordPress plugins to the correct directory structure, and the 2.x series maintains backwards compatibility with projects using Composer Installers 1.x.

This enables Dependabot to successfully update the dependency whilst ensuring the project remains compatible with environments that may not yet have migrated to Composer Installers 2.x.

Closes #788

🤖 Generated with [Claude Code](https://claude.com/claude-code)