### PR TITLE
test: add integration tests for User Groups, Editorial Comments, Notifications, and Calendar modules

### DIFF
--- a/tests/Integration/CalendarModuleTest.php
+++ b/tests/Integration/CalendarModuleTest.php
@@ -1,0 +1,427 @@
+<?php
+/**
+ * Calendar module integration tests.
+ *
+ * Tests date calculations, post retrieval, and permission checks.
+ *
+ * @package Automattic\EditFlow\Tests\Integration
+ */
+
+declare( strict_types=1 );
+
+namespace Automattic\EditFlow\Tests\Integration;
+
+use EF_Calendar;
+use Yoast\WPTestUtils\WPIntegration\TestCase;
+
+class CalendarModuleTest extends TestCase {
+
+	protected static $admin_user_id;
+	protected static $editor_user_id;
+	protected static $author_user_id;
+	protected static $contributor_user_id;
+
+	public static function wpSetUpBeforeClass( $factory ) {
+		self::$admin_user_id       = $factory->user->create( array( 'role' => 'administrator' ) );
+		self::$editor_user_id      = $factory->user->create( array( 'role' => 'editor' ) );
+		self::$author_user_id      = $factory->user->create( array( 'role' => 'author' ) );
+		self::$contributor_user_id = $factory->user->create( array( 'role' => 'contributor' ) );
+	}
+
+	public static function wpTearDownAfterClass() {
+		self::delete_user( self::$admin_user_id );
+		self::delete_user( self::$editor_user_id );
+		self::delete_user( self::$author_user_id );
+		self::delete_user( self::$contributor_user_id );
+	}
+
+	protected function setUp(): void {
+		parent::setUp();
+		wp_set_current_user( self::$admin_user_id );
+	}
+
+	/**
+	 * Test that the calendar module exists and is accessible.
+	 */
+	public function test_calendar_module_exists() {
+		global $edit_flow;
+
+		$this->assertNotNull( $edit_flow->calendar );
+		$this->assertInstanceOf( EF_Calendar::class, $edit_flow->calendar );
+	}
+
+	/**
+	 * Test get_beginning_of_week with Sunday as start.
+	 */
+	public function test_get_beginning_of_week_sunday_start() {
+		global $edit_flow;
+
+		// Set Sunday (0) as start of week
+		update_option( 'start_of_week', 0 );
+
+		// Wednesday, January 15, 2025
+		$date   = '2025-01-15';
+		$result = $edit_flow->calendar->get_beginning_of_week( $date );
+
+		// Should return Sunday, January 12, 2025
+		$this->assertEquals( '2025-01-12', $result );
+	}
+
+	/**
+	 * Test get_beginning_of_week with Monday as start.
+	 */
+	public function test_get_beginning_of_week_monday_start() {
+		global $edit_flow;
+
+		// Set Monday (1) as start of week
+		update_option( 'start_of_week', 1 );
+
+		// Wednesday, January 15, 2025
+		$date   = '2025-01-15';
+		$result = $edit_flow->calendar->get_beginning_of_week( $date );
+
+		// Should return Monday, January 13, 2025
+		$this->assertEquals( '2025-01-13', $result );
+	}
+
+	/**
+	 * Test get_beginning_of_week when date is already start of week.
+	 */
+	public function test_get_beginning_of_week_already_start() {
+		global $edit_flow;
+
+		// Set Monday (1) as start of week
+		update_option( 'start_of_week', 1 );
+
+		// Monday, January 13, 2025
+		$date   = '2025-01-13';
+		$result = $edit_flow->calendar->get_beginning_of_week( $date );
+
+		// Should return the same date
+		$this->assertEquals( '2025-01-13', $result );
+	}
+
+	/**
+	 * Test get_beginning_of_week with week offset.
+	 */
+	public function test_get_beginning_of_week_with_offset() {
+		global $edit_flow;
+
+		update_option( 'start_of_week', 1 );
+
+		// Wednesday, January 15, 2025
+		$date   = '2025-01-15';
+		$result = $edit_flow->calendar->get_beginning_of_week( $date, 'Y-m-d', 2 );
+
+		// Week 2 should be January 20, 2025
+		$this->assertEquals( '2025-01-20', $result );
+	}
+
+	/**
+	 * Test get_ending_of_week with Sunday as start.
+	 */
+	public function test_get_ending_of_week_sunday_start() {
+		global $edit_flow;
+
+		// Set Sunday (0) as start of week
+		update_option( 'start_of_week', 0 );
+
+		// Wednesday, January 15, 2025
+		$date   = '2025-01-15';
+		$result = $edit_flow->calendar->get_ending_of_week( $date );
+
+		// Should return Saturday, January 18, 2025
+		$this->assertEquals( '2025-01-18', $result );
+	}
+
+	/**
+	 * Test get_ending_of_week with Monday as start.
+	 */
+	public function test_get_ending_of_week_monday_start() {
+		global $edit_flow;
+
+		// Set Monday (1) as start of week
+		update_option( 'start_of_week', 1 );
+
+		// Wednesday, January 15, 2025
+		$date   = '2025-01-15';
+		$result = $edit_flow->calendar->get_ending_of_week( $date );
+
+		// Should return Sunday, January 19, 2025
+		$this->assertEquals( '2025-01-19', $result );
+	}
+
+	/**
+	 * Test get_ending_of_week when date is already end of week.
+	 */
+	public function test_get_ending_of_week_already_end() {
+		global $edit_flow;
+
+		// Set Monday (1) as start of week
+		update_option( 'start_of_week', 1 );
+
+		// Sunday, January 19, 2025
+		$date   = '2025-01-19';
+		$result = $edit_flow->calendar->get_ending_of_week( $date );
+
+		// Should return the same date
+		$this->assertEquals( '2025-01-19', $result );
+	}
+
+	/**
+	 * Test get_beginning_of_week with different format.
+	 */
+	public function test_get_beginning_of_week_custom_format() {
+		global $edit_flow;
+
+		update_option( 'start_of_week', 1 );
+
+		$date   = '2025-01-15';
+		$result = $edit_flow->calendar->get_beginning_of_week( $date, 'F j, Y' );
+
+		$this->assertEquals( 'January 13, 2025', $result );
+	}
+
+	/**
+	 * Test admin can modify any post.
+	 */
+	public function test_current_user_can_modify_post_admin() {
+		global $edit_flow;
+
+		wp_set_current_user( self::$admin_user_id );
+
+		$post = self::factory()->post->create_and_get(
+			array(
+				'post_author' => self::$author_user_id,
+				'post_status' => 'draft',
+			)
+		);
+
+		$result = $edit_flow->calendar->current_user_can_modify_post( $post );
+
+		$this->assertTrue( $result );
+	}
+
+	/**
+	 * Test editor can modify any post.
+	 */
+	public function test_current_user_can_modify_post_editor() {
+		global $edit_flow;
+
+		wp_set_current_user( self::$editor_user_id );
+
+		$post = self::factory()->post->create_and_get(
+			array(
+				'post_author' => self::$author_user_id,
+				'post_status' => 'draft',
+			)
+		);
+
+		$result = $edit_flow->calendar->current_user_can_modify_post( $post );
+
+		$this->assertTrue( $result );
+	}
+
+	/**
+	 * Test author can modify own unpublished post.
+	 */
+	public function test_current_user_can_modify_post_author_own_draft() {
+		global $edit_flow;
+
+		wp_set_current_user( self::$author_user_id );
+
+		$post = self::factory()->post->create_and_get(
+			array(
+				'post_author' => self::$author_user_id,
+				'post_status' => 'draft',
+			)
+		);
+
+		$result = $edit_flow->calendar->current_user_can_modify_post( $post );
+
+		$this->assertTrue( $result );
+	}
+
+	/**
+	 * Test author can modify own published post (they can publish).
+	 */
+	public function test_current_user_can_modify_post_author_own_published() {
+		global $edit_flow;
+
+		wp_set_current_user( self::$author_user_id );
+
+		$post = self::factory()->post->create_and_get(
+			array(
+				'post_author' => self::$author_user_id,
+				'post_status' => 'publish',
+			)
+		);
+
+		$result = $edit_flow->calendar->current_user_can_modify_post( $post );
+
+		$this->assertTrue( $result );
+	}
+
+	/**
+	 * Test author cannot modify others' posts.
+	 */
+	public function test_current_user_can_modify_post_author_others_post() {
+		global $edit_flow;
+
+		wp_set_current_user( self::$author_user_id );
+
+		$post = self::factory()->post->create_and_get(
+			array(
+				'post_author' => self::$admin_user_id,
+				'post_status' => 'draft',
+			)
+		);
+
+		$result = $edit_flow->calendar->current_user_can_modify_post( $post );
+
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * Test contributor can modify own draft post.
+	 */
+	public function test_current_user_can_modify_post_contributor_own_draft() {
+		global $edit_flow;
+
+		wp_set_current_user( self::$contributor_user_id );
+
+		$post = self::factory()->post->create_and_get(
+			array(
+				'post_author' => self::$contributor_user_id,
+				'post_status' => 'draft',
+			)
+		);
+
+		$result = $edit_flow->calendar->current_user_can_modify_post( $post );
+
+		$this->assertTrue( $result );
+	}
+
+	/**
+	 * Test contributor cannot modify own published post (they can't publish).
+	 */
+	public function test_current_user_can_modify_post_contributor_own_published() {
+		global $edit_flow;
+
+		wp_set_current_user( self::$contributor_user_id );
+
+		// Create as admin, then test contributor permissions
+		$post_id = self::factory()->post->create(
+			array(
+				'post_author' => self::$contributor_user_id,
+				'post_status' => 'publish',
+			)
+		);
+		$post = get_post( $post_id );
+
+		$result = $edit_flow->calendar->current_user_can_modify_post( $post );
+
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * Test current_user_can_modify_post with null post.
+	 */
+	public function test_current_user_can_modify_post_null() {
+		global $edit_flow;
+
+		$result = $edit_flow->calendar->current_user_can_modify_post( null );
+
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * Test week boundary calculations across month.
+	 */
+	public function test_week_boundaries_across_month() {
+		global $edit_flow;
+
+		update_option( 'start_of_week', 1 ); // Monday
+
+		// January 30, 2025 (Thursday)
+		$date           = '2025-01-30';
+		$beginning      = $edit_flow->calendar->get_beginning_of_week( $date );
+		$ending         = $edit_flow->calendar->get_ending_of_week( $date );
+
+		// Week should span January to February
+		$this->assertEquals( '2025-01-27', $beginning ); // Monday Jan 27
+		$this->assertEquals( '2025-02-02', $ending );    // Sunday Feb 2
+	}
+
+	/**
+	 * Test week boundary calculations across year.
+	 */
+	public function test_week_boundaries_across_year() {
+		global $edit_flow;
+
+		update_option( 'start_of_week', 1 ); // Monday
+
+		// January 1, 2025 (Wednesday)
+		$date           = '2025-01-01';
+		$beginning      = $edit_flow->calendar->get_beginning_of_week( $date );
+		$ending         = $edit_flow->calendar->get_ending_of_week( $date );
+
+		// Week should span December 2024 to January 2025
+		$this->assertEquals( '2024-12-30', $beginning ); // Monday Dec 30
+		$this->assertEquals( '2025-01-05', $ending );    // Sunday Jan 5
+	}
+
+	/**
+	 * Test get_time_period_header generates correct HTML.
+	 */
+	public function test_get_time_period_header() {
+		global $edit_flow;
+
+		$dates = array( '2025-01-13', '2025-01-14', '2025-01-15' );
+		$html  = $edit_flow->calendar->get_time_period_header( $dates );
+
+		$this->assertStringContainsString( '<th class="column-heading"', $html );
+		$this->assertStringContainsString( 'Monday', $html );
+		$this->assertStringContainsString( 'Tuesday', $html );
+		$this->assertStringContainsString( 'Wednesday', $html );
+	}
+
+	/**
+	 * Test multiple week offset calculation.
+	 */
+	public function test_get_beginning_of_week_multiple_weeks() {
+		global $edit_flow;
+
+		update_option( 'start_of_week', 1 );
+
+		$date = '2025-01-15';
+
+		$week1 = $edit_flow->calendar->get_beginning_of_week( $date, 'Y-m-d', 1 );
+		$week2 = $edit_flow->calendar->get_beginning_of_week( $date, 'Y-m-d', 2 );
+		$week3 = $edit_flow->calendar->get_beginning_of_week( $date, 'Y-m-d', 3 );
+
+		$this->assertEquals( '2025-01-13', $week1 );
+		$this->assertEquals( '2025-01-20', $week2 );
+		$this->assertEquals( '2025-01-27', $week3 );
+	}
+
+	/**
+	 * Test Saturday start of week.
+	 */
+	public function test_week_with_saturday_start() {
+		global $edit_flow;
+
+		// Set Saturday (6) as start of week
+		update_option( 'start_of_week', 6 );
+
+		// Wednesday, January 15, 2025
+		$date      = '2025-01-15';
+		$beginning = $edit_flow->calendar->get_beginning_of_week( $date );
+		$ending    = $edit_flow->calendar->get_ending_of_week( $date );
+
+		// Should return Saturday, January 11, 2025
+		$this->assertEquals( '2025-01-11', $beginning );
+		// Should return Friday, January 17, 2025
+		$this->assertEquals( '2025-01-17', $ending );
+	}
+}

--- a/tests/Integration/EditorialCommentsTest.php
+++ b/tests/Integration/EditorialCommentsTest.php
@@ -1,0 +1,481 @@
+<?php
+/**
+ * Editorial Comments integration tests.
+ *
+ * @package Automattic\EditFlow\Tests\Integration
+ */
+
+declare( strict_types=1 );
+
+namespace Automattic\EditFlow\Tests\Integration;
+
+use EF_Editorial_Comments;
+use Yoast\WPTestUtils\WPIntegration\TestCase;
+
+class EditorialCommentsTest extends TestCase {
+
+	protected static $admin_user_id;
+	protected static $editor_user_id;
+	protected static $contributor_user_id;
+
+	public static function wpSetUpBeforeClass( $factory ) {
+		self::$admin_user_id       = $factory->user->create( array( 'role' => 'administrator' ) );
+		self::$editor_user_id      = $factory->user->create( array( 'role' => 'editor' ) );
+		self::$contributor_user_id = $factory->user->create( array( 'role' => 'contributor' ) );
+	}
+
+	public static function wpTearDownAfterClass() {
+		self::delete_user( self::$admin_user_id );
+		self::delete_user( self::$editor_user_id );
+		self::delete_user( self::$contributor_user_id );
+	}
+
+	protected function setUp(): void {
+		parent::setUp();
+		wp_set_current_user( self::$admin_user_id );
+	}
+
+	/**
+	 * Test that the editorial_comments module exists and is accessible.
+	 */
+	public function test_editorial_comments_module_exists() {
+		global $edit_flow;
+
+		$this->assertNotNull( $edit_flow->editorial_comments );
+		$this->assertInstanceOf( EF_Editorial_Comments::class, $edit_flow->editorial_comments );
+	}
+
+	/**
+	 * Test that the editorial comment type constant is defined.
+	 */
+	public function test_comment_type_constant() {
+		$this->assertEquals( 'editorial-comment', EF_Editorial_Comments::comment_type );
+	}
+
+	/**
+	 * Test creating an editorial comment on a post.
+	 */
+	public function test_insert_editorial_comment() {
+		$post_id = self::factory()->post->create();
+		$user    = get_user_by( 'id', self::$admin_user_id );
+
+		$comment_data = array(
+			'comment_post_ID'      => $post_id,
+			'comment_author'       => $user->display_name,
+			'comment_author_email' => $user->user_email,
+			'comment_content'      => 'This is an editorial comment for testing.',
+			'comment_type'         => EF_Editorial_Comments::comment_type,
+			'comment_approved'     => EF_Editorial_Comments::comment_type,
+			'user_id'              => self::$admin_user_id,
+		);
+
+		$comment_id = wp_insert_comment( $comment_data );
+
+		$this->assertIsInt( $comment_id );
+		$this->assertGreaterThan( 0, $comment_id );
+
+		$comment = get_comment( $comment_id );
+		$this->assertEquals( EF_Editorial_Comments::comment_type, $comment->comment_type );
+		$this->assertEquals( 'This is an editorial comment for testing.', $comment->comment_content );
+	}
+
+	/**
+	 * Test retrieving editorial comments for a post.
+	 */
+	public function test_get_editorial_comments() {
+		$post_id = self::factory()->post->create();
+		$user    = get_user_by( 'id', self::$admin_user_id );
+
+		// Create multiple editorial comments
+		for ( $i = 1; $i <= 3; $i++ ) {
+			wp_insert_comment(
+				array(
+					'comment_post_ID'      => $post_id,
+					'comment_author'       => $user->display_name,
+					'comment_author_email' => $user->user_email,
+					'comment_content'      => "Editorial comment {$i}",
+					'comment_type'         => EF_Editorial_Comments::comment_type,
+					'comment_approved'     => EF_Editorial_Comments::comment_type,
+					'user_id'              => self::$admin_user_id,
+				)
+			);
+		}
+
+		$editorial_comments = get_comments(
+			array(
+				'post_id'      => $post_id,
+				'comment_type' => EF_Editorial_Comments::comment_type,
+				'status'       => EF_Editorial_Comments::comment_type,
+			)
+		);
+
+		$this->assertCount( 3, $editorial_comments );
+	}
+
+	/**
+	 * Test that editorial comments are separate from regular comments.
+	 */
+	public function test_editorial_comments_separate_from_regular_comments() {
+		$post_id = self::factory()->post->create();
+		$user    = get_user_by( 'id', self::$admin_user_id );
+
+		// Create a regular comment
+		wp_insert_comment(
+			array(
+				'comment_post_ID'      => $post_id,
+				'comment_author'       => 'Regular User',
+				'comment_author_email' => 'regular@example.com',
+				'comment_content'      => 'This is a regular comment.',
+				'comment_type'         => '',
+				'comment_approved'     => 1,
+			)
+		);
+
+		// Create an editorial comment
+		wp_insert_comment(
+			array(
+				'comment_post_ID'      => $post_id,
+				'comment_author'       => $user->display_name,
+				'comment_author_email' => $user->user_email,
+				'comment_content'      => 'This is an editorial comment.',
+				'comment_type'         => EF_Editorial_Comments::comment_type,
+				'comment_approved'     => EF_Editorial_Comments::comment_type,
+				'user_id'              => self::$admin_user_id,
+			)
+		);
+
+		// Get only editorial comments
+		$editorial_comments = get_comments(
+			array(
+				'post_id'      => $post_id,
+				'comment_type' => EF_Editorial_Comments::comment_type,
+				'status'       => EF_Editorial_Comments::comment_type,
+			)
+		);
+
+		// Get only regular comments
+		$regular_comments = get_comments(
+			array(
+				'post_id'      => $post_id,
+				'comment_type' => '',
+				'status'       => 'approve',
+			)
+		);
+
+		$this->assertCount( 1, $editorial_comments );
+		$this->assertCount( 1, $regular_comments );
+		$this->assertEquals( 'This is an editorial comment.', $editorial_comments[0]->comment_content );
+		$this->assertEquals( 'This is a regular comment.', $regular_comments[0]->comment_content );
+	}
+
+	/**
+	 * Test threaded/nested editorial comments.
+	 */
+	public function test_threaded_editorial_comments() {
+		$post_id = self::factory()->post->create();
+		$user    = get_user_by( 'id', self::$admin_user_id );
+
+		// Create parent comment
+		$parent_comment_id = wp_insert_comment(
+			array(
+				'comment_post_ID'      => $post_id,
+				'comment_author'       => $user->display_name,
+				'comment_author_email' => $user->user_email,
+				'comment_content'      => 'Parent editorial comment',
+				'comment_type'         => EF_Editorial_Comments::comment_type,
+				'comment_approved'     => EF_Editorial_Comments::comment_type,
+				'user_id'              => self::$admin_user_id,
+			)
+		);
+
+		// Create child comment
+		$child_comment_id = wp_insert_comment(
+			array(
+				'comment_post_ID'      => $post_id,
+				'comment_author'       => $user->display_name,
+				'comment_author_email' => $user->user_email,
+				'comment_content'      => 'Reply to parent comment',
+				'comment_type'         => EF_Editorial_Comments::comment_type,
+				'comment_approved'     => EF_Editorial_Comments::comment_type,
+				'comment_parent'       => $parent_comment_id,
+				'user_id'              => self::$admin_user_id,
+			)
+		);
+
+		$child_comment = get_comment( $child_comment_id );
+		$this->assertEquals( $parent_comment_id, $child_comment->comment_parent );
+	}
+
+	/**
+	 * Test storing notification list in comment meta.
+	 */
+	public function test_notification_list_meta() {
+		$post_id = self::factory()->post->create();
+		$user    = get_user_by( 'id', self::$admin_user_id );
+
+		$comment_id = wp_insert_comment(
+			array(
+				'comment_post_ID'      => $post_id,
+				'comment_author'       => $user->display_name,
+				'comment_author_email' => $user->user_email,
+				'comment_content'      => 'Comment with notification',
+				'comment_type'         => EF_Editorial_Comments::comment_type,
+				'comment_approved'     => EF_Editorial_Comments::comment_type,
+				'user_id'              => self::$admin_user_id,
+			)
+		);
+
+		// Add notification list meta (as the AJAX handler does)
+		$notification_list = 'John Doe, Jane Smith, and Editors group';
+		add_comment_meta( $comment_id, 'notification_list', $notification_list );
+
+		$retrieved = get_comment_meta( $comment_id, 'notification_list', true );
+		$this->assertEquals( $notification_list, $retrieved );
+	}
+
+	/**
+	 * Test that editorial comments are associated with correct user.
+	 */
+	public function test_editorial_comment_user_association() {
+		$post_id = self::factory()->post->create();
+		$user    = get_user_by( 'id', self::$editor_user_id );
+
+		wp_set_current_user( self::$editor_user_id );
+
+		$comment_id = wp_insert_comment(
+			array(
+				'comment_post_ID'      => $post_id,
+				'comment_author'       => $user->display_name,
+				'comment_author_email' => $user->user_email,
+				'comment_content'      => 'Comment from editor',
+				'comment_type'         => EF_Editorial_Comments::comment_type,
+				'comment_approved'     => EF_Editorial_Comments::comment_type,
+				'user_id'              => self::$editor_user_id,
+			)
+		);
+
+		$comment = get_comment( $comment_id );
+		$this->assertEquals( self::$editor_user_id, $comment->user_id );
+		$this->assertEquals( $user->user_email, $comment->comment_author_email );
+	}
+
+	/**
+	 * Test the allowed HTML in editorial comments.
+	 */
+	public function test_comment_content_allowed_html() {
+		$post_id = self::factory()->post->create();
+		$user    = get_user_by( 'id', self::$admin_user_id );
+
+		// Content with allowed HTML tags (as defined in ajax_insert_comment)
+		$allowed_html = array(
+			'a'          => array(
+				'href'  => array(),
+				'title' => array(),
+			),
+			'b'          => array(),
+			'i'          => array(),
+			'strong'     => array(),
+			'em'         => array(),
+			'u'          => array(),
+			'del'        => array(),
+			'blockquote' => array(),
+			'sub'        => array(),
+			'sup'        => array(),
+		);
+
+		$content_with_html = 'This has <strong>bold</strong> and <em>italic</em> and <a href="https://example.com">a link</a>.';
+		$sanitized_content = wp_kses( $content_with_html, $allowed_html );
+
+		$comment_id = wp_insert_comment(
+			array(
+				'comment_post_ID'      => $post_id,
+				'comment_author'       => $user->display_name,
+				'comment_author_email' => $user->user_email,
+				'comment_content'      => $sanitized_content,
+				'comment_type'         => EF_Editorial_Comments::comment_type,
+				'comment_approved'     => EF_Editorial_Comments::comment_type,
+				'user_id'              => self::$admin_user_id,
+			)
+		);
+
+		$comment = get_comment( $comment_id );
+		// The allowed tags should be preserved
+		$this->assertStringContainsString( '<strong>bold</strong>', $comment->comment_content );
+		$this->assertStringContainsString( '<em>italic</em>', $comment->comment_content );
+		$this->assertStringContainsString( '<a href="https://example.com">', $comment->comment_content );
+	}
+
+	/**
+	 * Test that disallowed HTML is stripped from comment content.
+	 */
+	public function test_comment_content_strips_disallowed_html() {
+		$allowed_html = array(
+			'a'          => array(
+				'href'  => array(),
+				'title' => array(),
+			),
+			'b'          => array(),
+			'i'          => array(),
+			'strong'     => array(),
+			'em'         => array(),
+			'u'          => array(),
+			'del'        => array(),
+			'blockquote' => array(),
+			'sub'        => array(),
+			'sup'        => array(),
+		);
+
+		// Content with disallowed tags
+		$content_with_script = 'Safe text <script>alert("xss")</script> more safe text';
+		$sanitized           = wp_kses( $content_with_script, $allowed_html );
+
+		$this->assertStringNotContainsString( '<script>', $sanitized );
+		$this->assertStringContainsString( 'Safe text', $sanitized );
+		$this->assertStringContainsString( 'more safe text', $sanitized );
+	}
+
+	/**
+	 * Test that post types setting is respected.
+	 */
+	public function test_module_post_types_setting() {
+		global $edit_flow;
+
+		$supported_post_types = $edit_flow->editorial_comments->get_post_types_for_module(
+			$edit_flow->editorial_comments->module
+		);
+
+		// By default, post and page should be supported
+		$this->assertContains( 'post', $supported_post_types );
+		$this->assertContains( 'page', $supported_post_types );
+	}
+
+	/**
+	 * Test that user capability check works correctly.
+	 */
+	public function test_edit_post_capability_for_comments() {
+		$post_id = self::factory()->post->create(
+			array(
+				'post_author' => self::$admin_user_id,
+			)
+		);
+
+		// Admin can edit the post
+		wp_set_current_user( self::$admin_user_id );
+		$this->assertTrue( current_user_can( 'edit_post', $post_id ) );
+
+		// Editor can edit others' posts
+		wp_set_current_user( self::$editor_user_id );
+		$this->assertTrue( current_user_can( 'edit_post', $post_id ) );
+
+		// Contributor cannot edit others' published posts
+		// First let's publish the post
+		wp_update_post(
+			array(
+				'ID'          => $post_id,
+				'post_status' => 'publish',
+			)
+		);
+		wp_set_current_user( self::$contributor_user_id );
+		$this->assertFalse( current_user_can( 'edit_post', $post_id ) );
+	}
+
+	/**
+	 * Test editorial comment on draft post.
+	 */
+	public function test_editorial_comment_on_draft_post() {
+		$post_id = self::factory()->post->create(
+			array(
+				'post_status' => 'draft',
+			)
+		);
+		$user = get_user_by( 'id', self::$admin_user_id );
+
+		$comment_id = wp_insert_comment(
+			array(
+				'comment_post_ID'      => $post_id,
+				'comment_author'       => $user->display_name,
+				'comment_author_email' => $user->user_email,
+				'comment_content'      => 'Comment on draft post',
+				'comment_type'         => EF_Editorial_Comments::comment_type,
+				'comment_approved'     => EF_Editorial_Comments::comment_type,
+				'user_id'              => self::$admin_user_id,
+			)
+		);
+
+		$this->assertIsInt( $comment_id );
+		$this->assertGreaterThan( 0, $comment_id );
+
+		$post = get_post( $post_id );
+		$this->assertEquals( 'draft', $post->post_status );
+	}
+
+	/**
+	 * Test editorial comment ordering.
+	 */
+	public function test_editorial_comments_ordering() {
+		$post_id = self::factory()->post->create();
+		$user    = get_user_by( 'id', self::$admin_user_id );
+
+		// Create comments with slight time differences
+		$comment_ids = array();
+		for ( $i = 1; $i <= 3; $i++ ) {
+			$comment_ids[] = wp_insert_comment(
+				array(
+					'comment_post_ID'      => $post_id,
+					'comment_author'       => $user->display_name,
+					'comment_author_email' => $user->user_email,
+					'comment_content'      => "Comment number {$i}",
+					'comment_type'         => EF_Editorial_Comments::comment_type,
+					'comment_approved'     => EF_Editorial_Comments::comment_type,
+					'comment_date'         => date( 'Y-m-d H:i:s', strtotime( "+{$i} minutes" ) ),
+					'user_id'              => self::$admin_user_id,
+				)
+			);
+		}
+
+		// Get comments in ASC order (oldest first, as module does)
+		$comments = get_comments(
+			array(
+				'post_id'      => $post_id,
+				'comment_type' => EF_Editorial_Comments::comment_type,
+				'status'       => EF_Editorial_Comments::comment_type,
+				'orderby'      => 'comment_date',
+				'order'        => 'ASC',
+			)
+		);
+
+		$this->assertCount( 3, $comments );
+		$this->assertStringContainsString( 'Comment number 1', $comments[0]->comment_content );
+		$this->assertStringContainsString( 'Comment number 3', $comments[2]->comment_content );
+	}
+
+	/**
+	 * Test deleting editorial comments.
+	 */
+	public function test_delete_editorial_comment() {
+		$post_id = self::factory()->post->create();
+		$user    = get_user_by( 'id', self::$admin_user_id );
+
+		$comment_id = wp_insert_comment(
+			array(
+				'comment_post_ID'      => $post_id,
+				'comment_author'       => $user->display_name,
+				'comment_author_email' => $user->user_email,
+				'comment_content'      => 'Comment to be deleted',
+				'comment_type'         => EF_Editorial_Comments::comment_type,
+				'comment_approved'     => EF_Editorial_Comments::comment_type,
+				'user_id'              => self::$admin_user_id,
+			)
+		);
+
+		$this->assertIsInt( $comment_id );
+
+		// Delete the comment
+		$result = wp_delete_comment( $comment_id, true );
+		$this->assertTrue( $result );
+
+		// Verify it's gone
+		$comment = get_comment( $comment_id );
+		$this->assertNull( $comment );
+	}
+}

--- a/tests/Integration/NotificationsSubscriptionTest.php
+++ b/tests/Integration/NotificationsSubscriptionTest.php
@@ -1,0 +1,542 @@
+<?php
+/**
+ * Notifications subscription and permission integration tests.
+ *
+ * @package Automattic\EditFlow\Tests\Integration
+ */
+
+declare( strict_types=1 );
+
+namespace Automattic\EditFlow\Tests\Integration;
+
+use EF_Notifications;
+use Yoast\WPTestUtils\WPIntegration\TestCase;
+
+class NotificationsSubscriptionTest extends TestCase {
+
+	protected static $admin_user_id;
+	protected static $editor_user_id;
+	protected static $author_user_id;
+	protected static $contributor_user_id;
+	protected static $subscriber_user_id;
+
+	public static function wpSetUpBeforeClass( $factory ) {
+		self::$admin_user_id       = $factory->user->create( array( 'role' => 'administrator' ) );
+		self::$editor_user_id      = $factory->user->create( array( 'role' => 'editor' ) );
+		self::$author_user_id      = $factory->user->create( array( 'role' => 'author' ) );
+		self::$contributor_user_id = $factory->user->create( array( 'role' => 'contributor' ) );
+		self::$subscriber_user_id  = $factory->user->create( array( 'role' => 'subscriber' ) );
+	}
+
+	public static function wpTearDownAfterClass() {
+		self::delete_user( self::$admin_user_id );
+		self::delete_user( self::$editor_user_id );
+		self::delete_user( self::$author_user_id );
+		self::delete_user( self::$contributor_user_id );
+		self::delete_user( self::$subscriber_user_id );
+	}
+
+	protected function setUp(): void {
+		parent::setUp();
+		wp_set_current_user( self::$admin_user_id );
+	}
+
+	/**
+	 * Test that the notifications module exists and is accessible.
+	 */
+	public function test_notifications_module_exists() {
+		global $edit_flow;
+
+		$this->assertNotNull( $edit_flow->notifications );
+		$this->assertInstanceOf( EF_Notifications::class, $edit_flow->notifications );
+	}
+
+	/**
+	 * Test user_can_be_notified returns true for admin on any post.
+	 */
+	public function test_user_can_be_notified_admin() {
+		global $edit_flow;
+
+		$post_id = self::factory()->post->create();
+		$user    = get_user_by( 'id', self::$admin_user_id );
+
+		$result = $edit_flow->notifications->user_can_be_notified( $user, $post_id );
+
+		$this->assertTrue( $result );
+	}
+
+	/**
+	 * Test user_can_be_notified returns true for editor on any post.
+	 */
+	public function test_user_can_be_notified_editor() {
+		global $edit_flow;
+
+		$post_id = self::factory()->post->create(
+			array( 'post_author' => self::$admin_user_id )
+		);
+		$user = get_user_by( 'id', self::$editor_user_id );
+
+		$result = $edit_flow->notifications->user_can_be_notified( $user, $post_id );
+
+		$this->assertTrue( $result );
+	}
+
+	/**
+	 * Test user_can_be_notified returns true for author on their own post.
+	 */
+	public function test_user_can_be_notified_author_own_post() {
+		global $edit_flow;
+
+		$post_id = self::factory()->post->create(
+			array( 'post_author' => self::$author_user_id )
+		);
+		$user = get_user_by( 'id', self::$author_user_id );
+
+		$result = $edit_flow->notifications->user_can_be_notified( $user, $post_id );
+
+		$this->assertTrue( $result );
+	}
+
+	/**
+	 * Test user_can_be_notified returns false for author on others' post.
+	 */
+	public function test_user_can_be_notified_author_others_post() {
+		global $edit_flow;
+
+		$post_id = self::factory()->post->create(
+			array(
+				'post_author' => self::$admin_user_id,
+				'post_status' => 'publish',
+			)
+		);
+		$user = get_user_by( 'id', self::$author_user_id );
+
+		$result = $edit_flow->notifications->user_can_be_notified( $user, $post_id );
+
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * Test user_can_be_notified returns false for subscriber.
+	 */
+	public function test_user_can_be_notified_subscriber() {
+		global $edit_flow;
+
+		$post_id = self::factory()->post->create();
+		$user    = get_user_by( 'id', self::$subscriber_user_id );
+
+		$result = $edit_flow->notifications->user_can_be_notified( $user, $post_id );
+
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * Test user_can_be_notified returns false for invalid user.
+	 */
+	public function test_user_can_be_notified_invalid_user() {
+		global $edit_flow;
+
+		$post_id = self::factory()->post->create();
+
+		$result = $edit_flow->notifications->user_can_be_notified( false, $post_id );
+
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * Test following a post by user ID.
+	 */
+	public function test_follow_post_user_by_id() {
+		global $edit_flow;
+
+		$post_id = self::factory()->post->create();
+
+		$result = $edit_flow->notifications->follow_post_user( $post_id, self::$admin_user_id );
+
+		$this->assertTrue( $result );
+
+		$followers = $edit_flow->notifications->get_following_users( $post_id );
+		$admin     = get_user_by( 'id', self::$admin_user_id );
+
+		$this->assertContains( $admin->user_login, $followers );
+	}
+
+	/**
+	 * Test following a post by user login.
+	 */
+	public function test_follow_post_user_by_login() {
+		global $edit_flow;
+
+		$post_id = self::factory()->post->create();
+		$user    = get_user_by( 'id', self::$editor_user_id );
+
+		$result = $edit_flow->notifications->follow_post_user( $post_id, $user->user_login );
+
+		$this->assertTrue( $result );
+
+		$followers = $edit_flow->notifications->get_following_users( $post_id );
+
+		$this->assertContains( $user->user_login, $followers );
+	}
+
+	/**
+	 * Test following a post with multiple users.
+	 */
+	public function test_follow_post_multiple_users() {
+		global $edit_flow;
+
+		$post_id = self::factory()->post->create();
+		$users   = array( self::$admin_user_id, self::$editor_user_id, self::$author_user_id );
+
+		$result = $edit_flow->notifications->follow_post_user( $post_id, $users );
+
+		$this->assertTrue( $result );
+
+		$followers = $edit_flow->notifications->get_following_users( $post_id );
+
+		$this->assertCount( 3, $followers );
+	}
+
+	/**
+	 * Test appending followers to existing list.
+	 */
+	public function test_follow_post_user_append() {
+		global $edit_flow;
+
+		$post_id = self::factory()->post->create();
+
+		// Add first user
+		$edit_flow->notifications->follow_post_user( $post_id, self::$admin_user_id );
+
+		// Append second user
+		$edit_flow->notifications->follow_post_user( $post_id, self::$editor_user_id, true );
+
+		$followers = $edit_flow->notifications->get_following_users( $post_id );
+
+		$this->assertCount( 2, $followers );
+	}
+
+	/**
+	 * Test replacing followers list (no append).
+	 */
+	public function test_follow_post_user_replace() {
+		global $edit_flow;
+
+		$post_id = self::factory()->post->create();
+
+		// Add first user
+		$edit_flow->notifications->follow_post_user( $post_id, self::$admin_user_id );
+
+		// Replace with second user
+		$edit_flow->notifications->follow_post_user( $post_id, self::$editor_user_id, false );
+
+		$followers = $edit_flow->notifications->get_following_users( $post_id );
+
+		$this->assertCount( 1, $followers );
+
+		$editor = get_user_by( 'id', self::$editor_user_id );
+		$this->assertContains( $editor->user_login, $followers );
+	}
+
+	/**
+	 * Test unfollowing a post.
+	 *
+	 * Note: The unfollow_post_user method has a known issue where it compares
+	 * user_login against term slugs. When user_login differs from the sanitized
+	 * slug (e.g., uppercase letters), unfollow may not work correctly.
+	 * This test verifies the method returns success and documents the behavior.
+	 */
+	public function test_unfollow_post_user() {
+		global $edit_flow;
+
+		$post_id = self::factory()->post->create();
+
+		// Create a simple user with lowercase login to ensure slug matches
+		$test_user_id = self::factory()->user->create(
+			array(
+				'user_login' => 'testunfollowuser',
+				'role'       => 'editor',
+			)
+		);
+
+		// Follow with test user
+		$edit_flow->notifications->follow_post_user( $post_id, $test_user_id );
+
+		// Verify following
+		$followers = $edit_flow->notifications->get_following_users( $post_id );
+		$this->assertContains( 'testunfollowuser', $followers );
+
+		// Unfollow
+		$result = $edit_flow->notifications->unfollow_post_user( $post_id, $test_user_id );
+
+		$this->assertTrue( $result );
+
+		// Verify unfollowed
+		$followers_after = $edit_flow->notifications->get_following_users( $post_id );
+		$this->assertNotContains( 'testunfollowuser', $followers_after );
+
+		// Clean up
+		wp_delete_user( $test_user_id );
+	}
+
+	/**
+	 * Test follow_post_user with invalid post returns WP_Error.
+	 */
+	public function test_follow_post_user_invalid_post() {
+		global $edit_flow;
+
+		$result = $edit_flow->notifications->follow_post_user( 999999, self::$admin_user_id );
+
+		$this->assertInstanceOf( 'WP_Error', $result );
+	}
+
+	/**
+	 * Test getting following users returns empty array for post with no followers.
+	 */
+	public function test_get_following_users_empty() {
+		global $edit_flow;
+
+		$post_id = self::factory()->post->create();
+
+		$followers = $edit_flow->notifications->get_following_users( $post_id );
+
+		$this->assertIsArray( $followers );
+		$this->assertEmpty( $followers );
+	}
+
+	/**
+	 * Test getting following users by ID.
+	 */
+	public function test_get_following_users_by_id() {
+		global $edit_flow;
+
+		$post_id = self::factory()->post->create();
+
+		$edit_flow->notifications->follow_post_user( $post_id, self::$admin_user_id );
+
+		$followers = $edit_flow->notifications->get_following_users( $post_id, 'id' );
+
+		$this->assertContains( self::$admin_user_id, $followers );
+	}
+
+	/**
+	 * Test getting following users by email.
+	 */
+	public function test_get_following_users_by_email() {
+		global $edit_flow;
+
+		$post_id = self::factory()->post->create();
+		$user    = get_user_by( 'id', self::$admin_user_id );
+
+		$edit_flow->notifications->follow_post_user( $post_id, self::$admin_user_id );
+
+		$followers = $edit_flow->notifications->get_following_users( $post_id, 'user_email' );
+
+		$this->assertContains( $user->user_email, $followers );
+	}
+
+	/**
+	 * Test following a post with usergroups.
+	 */
+	public function test_follow_post_usergroups() {
+		global $edit_flow;
+
+		// Skip if user_groups module is not enabled
+		if ( ! $edit_flow->notifications->module_enabled( 'user_groups' ) ) {
+			$this->markTestSkipped( 'User Groups module is not enabled.' );
+		}
+
+		$post_id = self::factory()->post->create();
+
+		// Create a usergroup
+		$usergroup = $edit_flow->user_groups->add_usergroup(
+			array( 'name' => 'Notification Test Group' )
+		);
+
+		$edit_flow->notifications->follow_post_usergroups( $post_id, $usergroup->term_id );
+
+		$following_groups = $edit_flow->notifications->get_following_usergroups( $post_id, 'ids' );
+
+		$this->assertContains( $usergroup->term_id, $following_groups );
+
+		// Clean up
+		$edit_flow->user_groups->delete_usergroup( $usergroup->term_id );
+	}
+
+	/**
+	 * Test getting posts that a user follows.
+	 */
+	public function test_get_user_following_posts() {
+		global $edit_flow;
+
+		// Create posts and have user follow them
+		$post_ids = self::factory()->post->create_many( 3 );
+
+		foreach ( $post_ids as $post_id ) {
+			$edit_flow->notifications->follow_post_user( $post_id, self::$admin_user_id );
+		}
+
+		$following_posts = $edit_flow->notifications->get_user_following_posts( self::$admin_user_id );
+
+		$this->assertCount( 3, $following_posts );
+	}
+
+	/**
+	 * Test that deleting a user removes them from following taxonomy.
+	 */
+	public function test_delete_user_removes_from_following() {
+		global $edit_flow;
+
+		// Create a temporary user
+		$temp_user_id = self::factory()->user->create( array( 'role' => 'editor' ) );
+		$temp_user    = get_user_by( 'id', $temp_user_id );
+
+		$post_id = self::factory()->post->create();
+
+		// Have user follow the post
+		$edit_flow->notifications->follow_post_user( $post_id, $temp_user_id );
+
+		// Verify they're following
+		$followers = $edit_flow->notifications->get_following_users( $post_id );
+		$this->assertContains( $temp_user->user_login, $followers );
+
+		// Trigger the delete action
+		$edit_flow->notifications->delete_user_action( $temp_user_id );
+
+		// Verify the term is deleted
+		$term = get_term_by( 'name', $temp_user->user_login, $edit_flow->notifications->following_users_taxonomy );
+		$this->assertFalse( $term );
+
+		// Clean up
+		wp_delete_user( $temp_user_id );
+	}
+
+	/**
+	 * Test add_term_if_not_exists creates term.
+	 */
+	public function test_add_term_if_not_exists() {
+		global $edit_flow;
+
+		$term_name = 'unique_test_term_' . time();
+		$taxonomy  = $edit_flow->notifications->following_users_taxonomy;
+
+		$result = $edit_flow->notifications->add_term_if_not_exists( $term_name, $taxonomy );
+
+		$this->assertNotInstanceOf( 'WP_Error', $result );
+
+		// Verify term exists
+		$term = get_term_by( 'name', $term_name, $taxonomy );
+		$this->assertNotFalse( $term );
+
+		// Clean up
+		wp_delete_term( $term->term_id, $taxonomy );
+	}
+
+	/**
+	 * Test add_term_if_not_exists returns true for existing term.
+	 */
+	public function test_add_term_if_not_exists_already_exists() {
+		global $edit_flow;
+
+		$term_name = 'existing_test_term_' . time();
+		$taxonomy  = $edit_flow->notifications->following_users_taxonomy;
+
+		// Create term first
+		wp_insert_term( $term_name, $taxonomy );
+
+		// Try to add again
+		$result = $edit_flow->notifications->add_term_if_not_exists( $term_name, $taxonomy );
+
+		$this->assertTrue( $result );
+
+		// Clean up
+		$term = get_term_by( 'name', $term_name, $taxonomy );
+		wp_delete_term( $term->term_id, $taxonomy );
+	}
+
+	/**
+	 * Test that capability for editing subscriptions is defined.
+	 */
+	public function test_edit_post_subscriptions_cap() {
+		global $edit_flow;
+
+		// Verify the capability property is set correctly
+		$this->assertEquals( 'edit_post_subscriptions', $edit_flow->notifications->edit_post_subscriptions_cap );
+
+		// Run install to ensure capabilities are added to roles
+		$edit_flow->notifications->install();
+
+		// Create fresh users after install() so they pick up the new capabilities
+		// (existing user objects have cached capabilities)
+		$admin_id       = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		$editor_id      = self::factory()->user->create( array( 'role' => 'editor' ) );
+		$author_id      = self::factory()->user->create( array( 'role' => 'author' ) );
+		$contributor_id = self::factory()->user->create( array( 'role' => 'contributor' ) );
+
+		// Admin should have this cap
+		wp_set_current_user( $admin_id );
+		$this->assertTrue( current_user_can( 'edit_post_subscriptions' ), 'Administrator should have edit_post_subscriptions cap' );
+
+		// Editor should have this cap
+		wp_set_current_user( $editor_id );
+		$this->assertTrue( current_user_can( 'edit_post_subscriptions' ), 'Editor should have edit_post_subscriptions cap' );
+
+		// Author should have this cap
+		wp_set_current_user( $author_id );
+		$this->assertTrue( current_user_can( 'edit_post_subscriptions' ), 'Author should have edit_post_subscriptions cap' );
+
+		// Contributor should NOT have this cap by default
+		wp_set_current_user( $contributor_id );
+		$this->assertFalse( current_user_can( 'edit_post_subscriptions' ), 'Contributor should NOT have edit_post_subscriptions cap' );
+	}
+
+	/**
+	 * Test user_can_be_notified filter.
+	 */
+	public function test_user_can_be_notified_filter() {
+		global $edit_flow;
+
+		$post_id = self::factory()->post->create();
+		$user    = get_user_by( 'id', self::$subscriber_user_id );
+
+		// Subscriber normally can't be notified
+		$this->assertFalse( $edit_flow->notifications->user_can_be_notified( $user, $post_id ) );
+
+		// Add filter to allow subscriber
+		add_filter(
+			'ef_notification_user_can_be_notified',
+			function ( $can_be_notified, $filter_user, $filter_post_id ) use ( $user, $post_id ) {
+				if ( $filter_user->ID === $user->ID && $filter_post_id === $post_id ) {
+					return true;
+				}
+				return $can_be_notified;
+			},
+			10,
+			3
+		);
+
+		// Now subscriber can be notified
+		$this->assertTrue( $edit_flow->notifications->user_can_be_notified( $user, $post_id ) );
+
+		// Clean up filter
+		remove_all_filters( 'ef_notification_user_can_be_notified' );
+	}
+
+	/**
+	 * Test following with user object.
+	 */
+	public function test_follow_post_user_with_object() {
+		global $edit_flow;
+
+		$post_id = self::factory()->post->create();
+		$user    = get_user_by( 'id', self::$admin_user_id );
+
+		$result = $edit_flow->notifications->follow_post_user( $post_id, $user );
+
+		$this->assertTrue( $result );
+
+		$followers = $edit_flow->notifications->get_following_users( $post_id );
+
+		$this->assertContains( $user->user_login, $followers );
+	}
+}

--- a/tests/Integration/UserGroupsTest.php
+++ b/tests/Integration/UserGroupsTest.php
@@ -1,0 +1,497 @@
+<?php
+/**
+ * User Groups integration tests.
+ *
+ * @package Automattic\EditFlow\Tests\Integration
+ */
+
+declare( strict_types=1 );
+
+namespace Automattic\EditFlow\Tests\Integration;
+
+use Yoast\WPTestUtils\WPIntegration\TestCase;
+
+class UserGroupsTest extends TestCase {
+
+	protected static $admin_user_id;
+	protected static $editor_user_id;
+
+	public static function wpSetUpBeforeClass( $factory ) {
+		self::$admin_user_id  = $factory->user->create( array( 'role' => 'administrator' ) );
+		self::$editor_user_id = $factory->user->create( array( 'role' => 'editor' ) );
+	}
+
+	public static function wpTearDownAfterClass() {
+		self::delete_user( self::$admin_user_id );
+		self::delete_user( self::$editor_user_id );
+	}
+
+	protected function setUp(): void {
+		parent::setUp();
+		wp_set_current_user( self::$admin_user_id );
+	}
+
+	/**
+	 * Test that the user_groups module exists and is accessible.
+	 */
+	public function test_user_groups_module_exists() {
+		global $edit_flow;
+
+		$this->assertNotNull( $edit_flow->user_groups );
+		$this->assertInstanceOf( 'EF_User_Groups', $edit_flow->user_groups );
+	}
+
+	/**
+	 * Test creating a usergroup with valid data.
+	 */
+	public function test_add_usergroup_with_valid_data() {
+		global $edit_flow;
+
+		$args = array(
+			'name'        => 'Test Group',
+			'description' => 'A test user group',
+		);
+
+		$usergroup = $edit_flow->user_groups->add_usergroup( $args );
+
+		$this->assertNotInstanceOf( 'WP_Error', $usergroup );
+		$this->assertIsObject( $usergroup );
+		$this->assertEquals( 'Test Group', $usergroup->name );
+		$this->assertEquals( 'A test user group', $usergroup->description );
+		$this->assertIsArray( $usergroup->user_ids );
+		$this->assertEmpty( $usergroup->user_ids );
+
+		// Clean up
+		$edit_flow->user_groups->delete_usergroup( $usergroup->term_id );
+	}
+
+	/**
+	 * Test creating a usergroup without a name returns WP_Error.
+	 */
+	public function test_add_usergroup_without_name_returns_error() {
+		global $edit_flow;
+
+		$args = array(
+			'description' => 'A test user group without name',
+		);
+
+		$result = $edit_flow->user_groups->add_usergroup( $args );
+
+		$this->assertInstanceOf( 'WP_Error', $result );
+		$this->assertEquals( 'invalid', $result->get_error_code() );
+	}
+
+	/**
+	 * Test creating a usergroup with users.
+	 */
+	public function test_add_usergroup_with_users() {
+		global $edit_flow;
+
+		$args = array(
+			'name'        => 'Group With Users',
+			'description' => 'A group with initial users',
+		);
+
+		$user_ids  = array( self::$admin_user_id, self::$editor_user_id );
+		$usergroup = $edit_flow->user_groups->add_usergroup( $args, $user_ids );
+
+		$this->assertNotInstanceOf( 'WP_Error', $usergroup );
+		$this->assertCount( 2, $usergroup->user_ids );
+		$this->assertContains( self::$admin_user_id, $usergroup->user_ids );
+		$this->assertContains( self::$editor_user_id, $usergroup->user_ids );
+
+		// Clean up
+		$edit_flow->user_groups->delete_usergroup( $usergroup->term_id );
+	}
+
+	/**
+	 * Test retrieving a usergroup by ID.
+	 */
+	public function test_get_usergroup_by_id() {
+		global $edit_flow;
+
+		$args = array(
+			'name'        => 'Retrievable Group',
+			'description' => 'For retrieval testing',
+		);
+
+		$created   = $edit_flow->user_groups->add_usergroup( $args );
+		$retrieved = $edit_flow->user_groups->get_usergroup_by( 'id', $created->term_id );
+
+		$this->assertIsObject( $retrieved );
+		$this->assertEquals( $created->term_id, $retrieved->term_id );
+		$this->assertEquals( 'Retrievable Group', $retrieved->name );
+
+		// Clean up
+		$edit_flow->user_groups->delete_usergroup( $created->term_id );
+	}
+
+	/**
+	 * Test retrieving a usergroup by name.
+	 */
+	public function test_get_usergroup_by_name() {
+		global $edit_flow;
+
+		$args = array(
+			'name'        => 'Named Group',
+			'description' => 'For name retrieval testing',
+		);
+
+		$created   = $edit_flow->user_groups->add_usergroup( $args );
+		$retrieved = $edit_flow->user_groups->get_usergroup_by( 'name', 'Named Group' );
+
+		$this->assertIsObject( $retrieved );
+		$this->assertEquals( $created->term_id, $retrieved->term_id );
+
+		// Clean up
+		$edit_flow->user_groups->delete_usergroup( $created->term_id );
+	}
+
+	/**
+	 * Test retrieving a non-existent usergroup returns false.
+	 */
+	public function test_get_nonexistent_usergroup_returns_false() {
+		global $edit_flow;
+
+		$result = $edit_flow->user_groups->get_usergroup_by( 'id', 999999 );
+
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * Test updating a usergroup name.
+	 */
+	public function test_update_usergroup_name() {
+		global $edit_flow;
+
+		$args = array(
+			'name'        => 'Original Name',
+			'description' => 'Original description',
+		);
+
+		$usergroup = $edit_flow->user_groups->add_usergroup( $args );
+
+		$update_args = array(
+			'name' => 'Updated Name',
+		);
+
+		$updated = $edit_flow->user_groups->update_usergroup( $usergroup->term_id, $update_args );
+
+		$this->assertNotInstanceOf( 'WP_Error', $updated );
+		$this->assertEquals( 'Updated Name', $updated->name );
+		// Description should remain unchanged
+		$this->assertEquals( 'Original description', $updated->description );
+
+		// Clean up
+		$edit_flow->user_groups->delete_usergroup( $usergroup->term_id );
+	}
+
+	/**
+	 * Test updating a usergroup description.
+	 */
+	public function test_update_usergroup_description() {
+		global $edit_flow;
+
+		$args = array(
+			'name'        => 'Desc Test Group',
+			'description' => 'Original description',
+		);
+
+		$usergroup = $edit_flow->user_groups->add_usergroup( $args );
+
+		$update_args = array(
+			'description' => 'Updated description',
+		);
+
+		$updated = $edit_flow->user_groups->update_usergroup( $usergroup->term_id, $update_args );
+
+		$this->assertNotInstanceOf( 'WP_Error', $updated );
+		$this->assertEquals( 'Updated description', $updated->description );
+
+		// Clean up
+		$edit_flow->user_groups->delete_usergroup( $usergroup->term_id );
+	}
+
+	/**
+	 * Test updating usergroup users replaces existing users.
+	 */
+	public function test_update_usergroup_users() {
+		global $edit_flow;
+
+		$args = array(
+			'name' => 'Users Update Group',
+		);
+
+		$usergroup = $edit_flow->user_groups->add_usergroup( $args, array( self::$admin_user_id ) );
+		$this->assertCount( 1, $usergroup->user_ids );
+
+		// Update with different user
+		$updated = $edit_flow->user_groups->update_usergroup(
+			$usergroup->term_id,
+			array(),
+			array( self::$editor_user_id )
+		);
+
+		$this->assertCount( 1, $updated->user_ids );
+		$this->assertContains( self::$editor_user_id, $updated->user_ids );
+		$this->assertNotContains( self::$admin_user_id, $updated->user_ids );
+
+		// Clean up
+		$edit_flow->user_groups->delete_usergroup( $usergroup->term_id );
+	}
+
+	/**
+	 * Test deleting a usergroup.
+	 */
+	public function test_delete_usergroup() {
+		global $edit_flow;
+
+		$args = array(
+			'name' => 'Deletable Group',
+		);
+
+		$usergroup = $edit_flow->user_groups->add_usergroup( $args );
+		$term_id   = $usergroup->term_id;
+
+		$result = $edit_flow->user_groups->delete_usergroup( $term_id );
+
+		$this->assertTrue( $result );
+
+		// Verify it's gone
+		$retrieved = $edit_flow->user_groups->get_usergroup_by( 'id', $term_id );
+		$this->assertFalse( $retrieved );
+	}
+
+	/**
+	 * Test adding a user to a usergroup.
+	 */
+	public function test_add_user_to_usergroup() {
+		global $edit_flow;
+
+		$args = array(
+			'name' => 'Add User Test Group',
+		);
+
+		$usergroup = $edit_flow->user_groups->add_usergroup( $args );
+		$this->assertEmpty( $usergroup->user_ids );
+
+		$result = $edit_flow->user_groups->add_user_to_usergroup( self::$admin_user_id, $usergroup->term_id );
+
+		$this->assertTrue( $result );
+
+		// Verify user was added
+		$updated = $edit_flow->user_groups->get_usergroup_by( 'id', $usergroup->term_id );
+		$this->assertContains( self::$admin_user_id, $updated->user_ids );
+
+		// Clean up
+		$edit_flow->user_groups->delete_usergroup( $usergroup->term_id );
+	}
+
+	/**
+	 * Test adding a user to multiple usergroups at once.
+	 */
+	public function test_add_user_to_multiple_usergroups() {
+		global $edit_flow;
+
+		$group1 = $edit_flow->user_groups->add_usergroup( array( 'name' => 'Multi Group 1' ) );
+		$group2 = $edit_flow->user_groups->add_usergroup( array( 'name' => 'Multi Group 2' ) );
+
+		$result = $edit_flow->user_groups->add_user_to_usergroup(
+			self::$admin_user_id,
+			array( $group1->term_id, $group2->term_id )
+		);
+
+		$this->assertTrue( $result );
+
+		// Verify user was added to both
+		$updated1 = $edit_flow->user_groups->get_usergroup_by( 'id', $group1->term_id );
+		$updated2 = $edit_flow->user_groups->get_usergroup_by( 'id', $group2->term_id );
+
+		$this->assertContains( self::$admin_user_id, $updated1->user_ids );
+		$this->assertContains( self::$admin_user_id, $updated2->user_ids );
+
+		// Clean up
+		$edit_flow->user_groups->delete_usergroup( $group1->term_id );
+		$edit_flow->user_groups->delete_usergroup( $group2->term_id );
+	}
+
+	/**
+	 * Test removing a user from a usergroup.
+	 */
+	public function test_remove_user_from_usergroup() {
+		global $edit_flow;
+
+		$args = array(
+			'name' => 'Remove User Test Group',
+		);
+
+		$usergroup = $edit_flow->user_groups->add_usergroup( $args, array( self::$admin_user_id, self::$editor_user_id ) );
+		$this->assertCount( 2, $usergroup->user_ids );
+
+		$result = $edit_flow->user_groups->remove_user_from_usergroup( self::$admin_user_id, $usergroup->term_id );
+
+		$this->assertTrue( $result );
+
+		// Verify user was removed but other user remains
+		$updated = $edit_flow->user_groups->get_usergroup_by( 'id', $usergroup->term_id );
+		$this->assertNotContains( self::$admin_user_id, $updated->user_ids );
+		$this->assertContains( self::$editor_user_id, $updated->user_ids );
+
+		// Clean up
+		$edit_flow->user_groups->delete_usergroup( $usergroup->term_id );
+	}
+
+	/**
+	 * Test getting all usergroups for a specific user.
+	 */
+	public function test_get_usergroups_for_user() {
+		global $edit_flow;
+
+		$group1 = $edit_flow->user_groups->add_usergroup(
+			array( 'name' => 'User Groups Test 1' ),
+			array( self::$admin_user_id )
+		);
+		$group2 = $edit_flow->user_groups->add_usergroup(
+			array( 'name' => 'User Groups Test 2' ),
+			array( self::$admin_user_id )
+		);
+		$group3 = $edit_flow->user_groups->add_usergroup(
+			array( 'name' => 'User Groups Test 3' ),
+			array( self::$editor_user_id ) // Different user
+		);
+
+		$admin_groups = $edit_flow->user_groups->get_usergroups_for_user( self::$admin_user_id, 'ids' );
+
+		$this->assertIsArray( $admin_groups );
+		$this->assertContains( $group1->term_id, $admin_groups );
+		$this->assertContains( $group2->term_id, $admin_groups );
+		$this->assertNotContains( $group3->term_id, $admin_groups );
+
+		// Clean up
+		$edit_flow->user_groups->delete_usergroup( $group1->term_id );
+		$edit_flow->user_groups->delete_usergroup( $group2->term_id );
+		$edit_flow->user_groups->delete_usergroup( $group3->term_id );
+	}
+
+	/**
+	 * Test getting usergroups for user returns objects when requested.
+	 */
+	public function test_get_usergroups_for_user_returns_objects() {
+		global $edit_flow;
+
+		$group = $edit_flow->user_groups->add_usergroup(
+			array( 'name' => 'Object Return Test' ),
+			array( self::$admin_user_id )
+		);
+
+		$groups = $edit_flow->user_groups->get_usergroups_for_user( self::$admin_user_id, 'objects' );
+
+		$this->assertIsArray( $groups );
+		$this->assertNotEmpty( $groups );
+		$this->assertIsObject( $groups[0] );
+		$this->assertObjectHasProperty( 'name', $groups[0] );
+
+		// Clean up
+		$edit_flow->user_groups->delete_usergroup( $group->term_id );
+	}
+
+	/**
+	 * Test that user IDs are stored uniquely (no duplicates).
+	 */
+	public function test_usergroup_user_ids_are_unique() {
+		global $edit_flow;
+
+		$args = array(
+			'name' => 'Unique Users Test',
+		);
+
+		// Add same user twice
+		$usergroup = $edit_flow->user_groups->add_usergroup(
+			$args,
+			array( self::$admin_user_id, self::$admin_user_id, self::$admin_user_id )
+		);
+
+		$this->assertCount( 1, $usergroup->user_ids );
+
+		// Clean up
+		$edit_flow->user_groups->delete_usergroup( $usergroup->term_id );
+	}
+
+	/**
+	 * Test getting all usergroups.
+	 */
+	public function test_get_usergroups() {
+		global $edit_flow;
+
+		// Create some test groups
+		$group1 = $edit_flow->user_groups->add_usergroup( array( 'name' => 'All Groups Test 1' ) );
+		$group2 = $edit_flow->user_groups->add_usergroup( array( 'name' => 'All Groups Test 2' ) );
+
+		$all_groups = $edit_flow->user_groups->get_usergroups();
+
+		$this->assertIsArray( $all_groups );
+		$this->assertGreaterThanOrEqual( 2, count( $all_groups ) );
+
+		// Clean up
+		$edit_flow->user_groups->delete_usergroup( $group1->term_id );
+		$edit_flow->user_groups->delete_usergroup( $group2->term_id );
+	}
+
+	/**
+	 * Test that usergroup slug is properly prefixed.
+	 */
+	public function test_usergroup_slug_is_prefixed() {
+		global $edit_flow;
+
+		$usergroup = $edit_flow->user_groups->add_usergroup( array( 'name' => 'Slug Prefix Test' ) );
+
+		$this->assertStringStartsWith( 'ef-usergroup-', $usergroup->slug );
+
+		// Clean up
+		$edit_flow->user_groups->delete_usergroup( $usergroup->term_id );
+	}
+
+	/**
+	 * Test adding users to usergroup by login name.
+	 */
+	public function test_add_user_to_usergroup_by_login() {
+		global $edit_flow;
+
+		$user      = get_user_by( 'id', self::$admin_user_id );
+		$usergroup = $edit_flow->user_groups->add_usergroup( array( 'name' => 'Login Test Group' ) );
+
+		$result = $edit_flow->user_groups->add_user_to_usergroup( $user->user_login, $usergroup->term_id );
+
+		$this->assertTrue( $result );
+
+		$updated = $edit_flow->user_groups->get_usergroup_by( 'id', $usergroup->term_id );
+		$this->assertContains( self::$admin_user_id, $updated->user_ids );
+
+		// Clean up
+		$edit_flow->user_groups->delete_usergroup( $usergroup->term_id );
+	}
+
+	/**
+	 * Test that description can contain special characters.
+	 */
+	public function test_usergroup_description_with_special_characters() {
+		global $edit_flow;
+
+		$description = "Test with special chars: <>&\"' and unicode: éàü";
+
+		$usergroup = $edit_flow->user_groups->add_usergroup(
+			array(
+				'name'        => 'Special Chars Group',
+				'description' => $description,
+			)
+		);
+
+		$retrieved = $edit_flow->user_groups->get_usergroup_by( 'id', $usergroup->term_id );
+
+		// The description should be stored and retrieved (may be sanitized)
+		$this->assertNotEmpty( $retrieved->description );
+
+		// Clean up
+		$edit_flow->user_groups->delete_usergroup( $usergroup->term_id );
+	}
+}


### PR DESCRIPTION
## Summary

Adds comprehensive integration tests for four previously untested or minimally tested modules, increasing test coverage from 59 to 142 tests (a 140% increase).

### New Test Files

| Module | Tests | Key Coverage Areas |
|--------|-------|-------------------|
| **User Groups** | 21 | CRUD operations, user membership, data integrity |
| **Editorial Comments** | 15 | Comment creation, threading, HTML sanitization, permissions |
| **Notifications** | 25 | Subscription management, follow/unfollow, permission checks |
| **Calendar** | 22 | Date calculations, week boundaries, modify permissions |

### Test Details

**User Groups (`UserGroupsTest.php`)**
- Create, read, update, delete usergroups
- Add/remove users from groups
- Get usergroups for a specific user
- Validation (name required, unique user IDs, slug prefixing)

**Editorial Comments (`EditorialCommentsTest.php`)**
- Insert and retrieve editorial comments
- Separation from regular WordPress comments
- Threaded/nested comment support
- HTML content sanitization (allowed vs stripped tags)
- Notification list meta storage

**Notifications (`NotificationsSubscriptionTest.php`)**
- `user_can_be_notified()` permission checks for all roles
- Follow/unfollow posts by user ID, login, or object
- Usergroup subscription integration
- User deletion cleanup from following taxonomy
- Custom filter hook for notification permissions

**Calendar (`CalendarModuleTest.php`)**
- `get_beginning_of_week()` / `get_ending_of_week()` calculations
- Various start-of-week options (Sunday, Monday, Saturday)
- Week boundaries across month and year transitions
- `current_user_can_modify_post()` permission checks

## Known Limitation

AJAX handlers in these modules use `die()` instead of `wp_die()`, which prevents proper test isolation. This will be addressed in a follow-up PR to enable AJAX handler testing.

## Test plan

- [x] All 142 tests pass locally
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)