### PR TITLE
Replace die() with wp_die() in AJAX handlers for testability

### DIFF
--- a/modules/calendar/calendar.php
+++ b/modules/calendar/calendar.php
@@ -395,12 +395,12 @@ if ( ! class_exists( 'EF_Calendar' ) ) {
 
 			// Only do .ics subscriptions when the option is active
 			if ( 'on' != $this->module->options->ics_subscription ) {
-				die(); // @todo return accepted response value.
+				wp_die(); // @todo return accepted response value.
 			}
 
 			// Confirm all of the arguments are present
 			if ( ! isset( $_GET['user'], $_GET['user_key'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-				die(); // @todo return an error response
+				wp_die(); // @todo return an error response
 			}
 
 			// Confirm this is a valid request
@@ -408,7 +408,7 @@ if ( ! class_exists( 'EF_Calendar' ) ) {
 			$user_key = sanitize_user( $_GET['user_key'] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			$ics_secret_key = $this->module->options->ics_secret_key;
 			if ( ! $ics_secret_key || md5( $user . $ics_secret_key ) !== $user_key ) {
-				die( esc_html( $this->module->messages['nonce-failed'] ) );
+				wp_die( esc_html( $this->module->messages['nonce-failed'] ) );
 			}
 
 			// Set up the post data to be printed
@@ -497,7 +497,7 @@ if ( ! class_exists( 'EF_Calendar' ) ) {
 					}
 				}
 			}
-			die();
+			wp_die();
 		}
 
 		/**

--- a/modules/custom-status/custom-status.php
+++ b/modules/custom-status/custom-status.php
@@ -1092,11 +1092,11 @@ if ( ! class_exists( 'EF_Custom_Status' ) ) {
 			global $edit_flow;
 
 			if ( ! isset( $_POST['inline_edit'] ) || ! wp_verify_nonce( $_POST['inline_edit'], 'custom-status-inline-edit-nonce' ) ) {
-				die( esc_html( $this->module->messages['nonce-failed'] ) );
+				wp_die( esc_html( $this->module->messages['nonce-failed'] ) );
 			}
 
 			if ( ! current_user_can( 'manage_options' ) ) {
-				die( esc_html( $this->module->messages['invalid-permissions'] ) );
+				wp_die( esc_html( $this->module->messages['invalid-permissions'] ) );
 			}
 
 			$term_id            = isset( $_POST['status_id'] ) ? (int) $_POST['status_id'] : 0;
@@ -1107,38 +1107,38 @@ if ( ! class_exists( 'EF_Custom_Status' ) ) {
 			// Check if name field was filled in
 			if ( empty( $status_name ) ) {
 				$change_error = new WP_Error( 'invalid', esc_html__( 'Please enter a name for the status.', 'edit-flow' ) );
-				die( esc_html( $change_error->get_error_message() ) );
+				wp_die( esc_html( $change_error->get_error_message() ) );
 			}
 
 			// Check that the name isn't numeric
 			if ( is_numeric( $status_name ) ) {
 				$change_error = new WP_Error( 'invalid', esc_html__( 'Please enter a valid, non-numeric name for the status.', 'edit-flow' ) );
-				die( esc_html( $change_error->get_error_message() ) );
+				wp_die( esc_html( $change_error->get_error_message() ) );
 			}
 
 			// Check that the status name doesn't exceed 20 chars
 			if ( strlen( $status_name ) > 20 ) {
 				$change_error = new WP_Error( 'invalid', esc_html__( 'Status name cannot exceed 20 characters. Please try a shorter name.', 'edit-flow' ) );
-				die( esc_html( $change_error->get_error_message() ) );
+				wp_die( esc_html( $change_error->get_error_message() ) );
 			}
 
 			// Check to make sure the name is not restricted
 			if ( $edit_flow->custom_status->is_restricted_status( strtolower( $status_name ) ) ) {
 				$change_error = new WP_Error( 'invalid', esc_html__( 'Status name is restricted. Please chose another name.', 'edit-flow' ) );
-				die( esc_html( $change_error->get_error_message() ) );
+				wp_die( esc_html( $change_error->get_error_message() ) );
 			}
 
 			// Check to make sure the status doesn't already exist
 			if ( $this->get_custom_status_by( 'slug', $status_slug ) && ( $this->get_custom_status_by( 'id', $term_id )->slug != $status_slug ) ) {
 				$change_error = new WP_Error( 'invalid', esc_html__( 'Status already exists. Please choose another name.', 'edit-flow' ) );
-				die( esc_html( $change_error->get_error_message() ) );
+				wp_die( esc_html( $change_error->get_error_message() ) );
 			}
 
 			// Check to make sure the status doesn't already exist as another term because otherwise we'd get a fatal error
 			$term_exists = term_exists( sanitize_title( $status_name ), self::taxonomy_key );
 			if ( $term_exists && isset( $term_exists['term_id'] ) && $term_exists['term_id'] != $term_id ) {
 				$change_error = new WP_Error( 'invalid', esc_html__( 'Status name conflicts with existing term. Please choose another.', 'edit-flow' ) );
-				die( esc_html( $change_error->get_error_message() ) );
+				wp_die( esc_html( $change_error->get_error_message() ) );
 			}
 
 			// get status_name & status_description
@@ -1153,11 +1153,11 @@ if ( ! class_exists( 'EF_Custom_Status' ) ) {
 				$wp_list_table = new EF_Custom_Status_List_Table();
 				$wp_list_table->prepare_items();
 				echo wp_kses_post( $wp_list_table->single_row( $return ) );
-				die();
+				wp_die();
 			} else {
 				/* translators: 1: the status's name */
 				$change_error = new WP_Error( 'invalid', sprintf( __( 'Could not update the status: <strong>%s</strong>', 'edit-flow' ), $status_name ) );
-				die( wp_kses( $change_error->get_error_message(), 'strong' ) );
+				wp_die( wp_kses( $change_error->get_error_message(), 'strong' ) );
 			}
 		}
 

--- a/modules/editorial-comments/editorial-comments.php
+++ b/modules/editorial-comments/editorial-comments.php
@@ -300,7 +300,7 @@ if ( ! class_exists( 'EF_Editorial_Comments' ) ) {
 
 			// Verify nonce
 			if ( ! isset( $_POST['_nonce'] ) || ! wp_verify_nonce( $_POST['_nonce'], 'comment' ) ) {
-				die( esc_html__( "Nonce check failed. Please ensure you're supposed to be adding editorial comments.", 'edit-flow' ) );
+				wp_die( esc_html__( "Nonce check failed. Please ensure you're supposed to be adding editorial comments.", 'edit-flow' ) );
 			}
 
 			// Get user info
@@ -315,13 +315,13 @@ if ( ! class_exists( 'EF_Editorial_Comments' ) ) {
 			// Only allow the comment if user can edit post
 			// @TODO: allow contributers to add comments as well (?)
 			if ( ! current_user_can( 'edit_post', $post_id ) ) {
-				die( esc_html__( 'Sorry, you don\'t have the privileges to add editorial comments. Please talk to your Administrator.', 'edit-flow' ) );
+				wp_die( esc_html__( 'Sorry, you don\'t have the privileges to add editorial comments. Please talk to your Administrator.', 'edit-flow' ) );
 			}
 
 			// Verify that comment was actually entered
 			$comment_content = isset( $_POST['content'] ) ? trim( $_POST['content'] ) : '';
 			if ( ! $comment_content ) {
-				die( esc_html__( 'Please enter a comment.', 'edit-flow' ) );
+				wp_die( esc_html__( 'Please enter a comment.', 'edit-flow' ) );
 			}
 
 			// Check that we have a post_id and user logged in
@@ -405,7 +405,7 @@ if ( ! class_exists( 'EF_Editorial_Comments' ) ) {
 				$response->send();
 
 			} else {
-				die( esc_html__( 'There was a problem of some sort. Try again or contact your administrator.', 'edit-flow' ) );
+				wp_die( esc_html__( 'There was a problem of some sort. Try again or contact your administrator.', 'edit-flow' ) );
 			}
 		}
 

--- a/modules/editorial-metadata/editorial-metadata.php
+++ b/modules/editorial-metadata/editorial-metadata.php
@@ -1275,16 +1275,16 @@ if ( ! class_exists( 'EF_Editorial_Metadata' ) ) {
 		public function handle_ajax_inline_save_term() {
 
 			if ( ! isset( $_POST['inline_edit'] ) || ! wp_verify_nonce( $_POST['inline_edit'], 'editorial-metadata-inline-edit-nonce' ) ) {
-				die( esc_html( $this->module->messages['nonce-failed'] ) );
+				wp_die( esc_html( $this->module->messages['nonce-failed'] ) );
 			}
 
 			if ( ! current_user_can( 'manage_options' ) ) {
-				die( esc_html( $this->module->messages['invalid-permissions'] ) );
+				wp_die( esc_html( $this->module->messages['invalid-permissions'] ) );
 			}
 
 			$term_id = isset( $_POST['term_id'] ) ? (int) $_POST['term_id'] : 0;
 			if ( ! $existing_term = $this->get_editorial_metadata_term_by( 'id', $term_id ) ) {
-				die( esc_html( $this->module->messages['term-missing'] ) );
+				wp_die( esc_html( $this->module->messages['term-missing'] ) );
 			}
 
 			$metadata_name = isset( $_POST['name'] ) ? sanitize_text_field( trim( $_POST['name'] ) ) : '';
@@ -1296,40 +1296,40 @@ if ( ! class_exists( 'EF_Editorial_Metadata' ) ) {
 			// Check if name field was filled in
 			if ( empty( $metadata_name ) ) {
 				$change_error = new WP_Error( 'invalid', _esc_html__( 'Please enter a name for the editorial metadata', 'edit-flow' ) );
-				die( esc_html( $change_error->get_error_message() ) );
+				wp_die( esc_html( $change_error->get_error_message() ) );
 			}
 
 			// Check that the name isn't numeric
 			if ( is_numeric( $metadata_name ) ) {
 				$change_error = new WP_Error( 'invalid', esc_html__( 'Please enter a valid, non-numeric name for the editorial metadata.', 'edit-flow' ) );
-				die( esc_html( $change_error->get_error_message() ) );
+				wp_die( esc_html( $change_error->get_error_message() ) );
 			}
 
 			// Check that the term name doesn't exceed 200 chars
 			if ( strlen( $metadata_name ) > 200 ) {
 				$change_error = new WP_Error( 'invalid', esc_html__( 'Name cannot exceed 200 characters. Please try a shorter name.' ) );
-				die( esc_html( $change_error->get_error_message() ) );
+				wp_die( esc_html( $change_error->get_error_message() ) );
 			}
 
 			// Check to make sure the status doesn't already exist as another term because otherwise we'd get a fatal error
 			$term_exists = term_exists( sanitize_title( $metadata_name ) );
 			if ( $term_exists && $term_exists != $term_id ) {
 				$change_error = new WP_Error( 'invalid', esc_html____( 'Metadata name conflicts with existing term. Please choose another.', 'edit-flow' ) );
-				die( esc_html( $change_error->get_error_message() ) );
+				wp_die( esc_html( $change_error->get_error_message() ) );
 			}
 
 			// Check to ensure a term with the same name doesn't exist,
 			$search_term = $this->get_editorial_metadata_term_by( 'name', $metadata_name );
 			if ( is_object( $search_term ) && $search_term->term_id != $existing_term->term_id ) {
 				$change_error = new WP_Error( 'invalid', esc_html__( 'Name already in use. Please choose another.', 'edit-flow' ) );
-				die( esc_html( $change_error->get_error_message() ) );
+				wp_die( esc_html( $change_error->get_error_message() ) );
 			}
 
 			// or that the term name doesn't map to an existing term's slug
 			$search_term = $this->get_editorial_metadata_term_by( 'slug', sanitize_title( $metadata_name ) );
 			if ( is_object( $search_term ) && $search_term->term_id != $existing_term->term_id ) {
 				$change_error = new WP_Error( 'invalid', esc_html__( 'Name conflicts with slug for another term. Please choose again.', 'edit-flow' ) );
-				die( esc_html( $change_error->get_error_message() ) );
+				wp_die( esc_html( $change_error->get_error_message() ) );
 			}
 
 			// Prepare the term name and description for saving
@@ -1343,11 +1343,11 @@ if ( ! class_exists( 'EF_Editorial_Metadata' ) ) {
 				$wp_list_table = new EF_Editorial_Metadata_List_Table();
 				$wp_list_table->prepare_items();
 				echo wp_kses_post( $wp_list_table->single_row( $return ) );
-				die();
+				wp_die();
 			} else {
 				/* Translators: 1: the name of the term that could not be found */
 				$change_error = new WP_Error( 'invalid', sprintf( __( 'Could not update the term: <strong>%s</strong>', 'edit-flow' ), $metadata_name ) );
-				die( wp_kses( $change_error->get_error_message() ) );
+				wp_die( wp_kses( $change_error->get_error_message() ) );
 			}
 		}
 

--- a/modules/notifications/notifications.php
+++ b/modules/notifications/notifications.php
@@ -412,7 +412,7 @@ if ( ! class_exists( 'EF_Notifications' ) ) {
 
 			// Verify nonce.
 			if ( ! isset( $_POST['_nonce'] ) || ! wp_verify_nonce( $_POST['_nonce'], 'save_user_usergroups' ) ) {
-				die( esc_html__( 'Nonce check failed. Please ensure you can add users or user groups to a post.', 'edit-flow' ) );
+				wp_die( esc_html__( 'Nonce check failed. Please ensure you can add users or user groups to a post.', 'edit-flow' ) );
 			}
 
 			$post_id = isset( $_POST['post_id'] ) ? (int) $_POST['post_id'] : 0;
@@ -420,7 +420,7 @@ if ( ! class_exists( 'EF_Notifications' ) ) {
 
 			$valid_post = ! is_null( $post ) && ! wp_is_post_revision( $post_id ) && ! wp_is_post_autosave( $post_id );
 			if ( ! isset( $_POST['ef_notifications_name'] ) || ! $valid_post || ! current_user_can( $this->edit_post_subscriptions_cap ) ) {
-				die();
+				wp_die();
 			}
 
 			$user_group_ids = [];
@@ -469,7 +469,7 @@ if ( ! class_exists( 'EF_Notifications' ) ) {
 				$this->save_post_following_usergroups( $post, $user_group_ids );
 			}
 
-			die();
+			wp_die();
 		}
 
 		/**

--- a/modules/settings/settings.php
+++ b/modules/settings/settings.php
@@ -99,7 +99,7 @@ if ( ! class_exists( 'EF_Settings' ) ) {
 			}
 
 			if ( ! isset( $_POST['module_action'], $_POST['slug'] ) ) {
-				die( '-1' );
+				wp_die( '-1' );
 			}
 
 			$module_action = sanitize_key( $_POST['module_action'] );
@@ -108,7 +108,7 @@ if ( ! class_exists( 'EF_Settings' ) ) {
 			$module = $edit_flow->get_module_by( 'slug', $slug );
 
 			if ( ! $module ) {
-				die( '-1' );
+				wp_die( '-1' );
 			}
 
 			if ( 'enable' == $module_action ) {
@@ -118,9 +118,9 @@ if ( ! class_exists( 'EF_Settings' ) ) {
 			}
 
 			if ( $return ) {
-				die( '1' );
+				wp_die( '1' );
 			} else {
-				die( '-1' );
+				wp_die( '-1' );
 			}
 		}
 

--- a/modules/user-groups/user-groups.php
+++ b/modules/user-groups/user-groups.php
@@ -458,16 +458,16 @@ if ( ! class_exists( 'EF_User_Groups' ) ) {
 		public function handle_ajax_inline_save_usergroup() {
 
 			if ( ! isset( $_POST['inline_edit'] ) || ! wp_verify_nonce( $_POST['inline_edit'], 'usergroups-inline-edit-nonce' ) ) {
-				die( esc_html( $this->module->messages['nonce-failed'] ) );
+				wp_die( esc_html( $this->module->messages['nonce-failed'] ) );
 			}
 
 			if ( ! current_user_can( $this->manage_usergroups_cap ) ) {
-				die( esc_html( $this->module->messages['invalid-permissions'] ) );
+				wp_die( esc_html( $this->module->messages['invalid-permissions'] ) );
 			}
 
 			$usergroup_id = isset( $_POST['usergroup_id'] ) ? (int) $_POST['usergroup_id'] : 0;
 			if ( ! $existing_term = $this->get_usergroup_by( 'id', $usergroup_id ) ) {
-				die( esc_html( $this->module->messages['usergroup-missing'] ) );
+				wp_die( esc_html( $this->module->messages['usergroup-missing'] ) );
 			}
 
 			$name = isset( $_POST['name'] ) ? sanitize_text_field( trim( $_POST['name'] ) ) : '';
@@ -479,24 +479,24 @@ if ( ! class_exists( 'EF_User_Groups' ) ) {
 			// Check if name field was filled in
 			if ( empty( $name ) ) {
 				$change_error = new WP_Error( 'invalid', esc_html__( 'Please enter a name for the user group.', 'edit-flow' ) );
-				die( esc_html( $change_error->get_error_message() ) );
+				wp_die( esc_html( $change_error->get_error_message() ) );
 			}
 			// Check that the name doesn't exceed 40 chars
 			if ( strlen( $name ) > 40 ) {
 				$change_error = new WP_Error( 'invalid', esc_html__( 'User group name cannot exceed 40 characters. Please try a shorter name.' ) );
-				die( esc_html( $change_error->get_error_message() ) );
+				wp_die( esc_html( $change_error->get_error_message() ) );
 			}
 			// Check to ensure a term with the same name doesn't exist
 			$search_term = $this->get_usergroup_by( 'name', $name );
 			if ( is_object( $search_term ) && $search_term->term_id != $existing_term->term_id ) {
 				$change_error = new WP_Error( 'invalid', esc_html__( 'Name already in use. Please choose another.', 'edit-flow' ) );
-				die( esc_html( $change_error->get_error_message() ) );
+				wp_die( esc_html( $change_error->get_error_message() ) );
 			}
 			// Check to ensure a term with the same slug doesn't exist
 			$search_term = $this->get_usergroup_by( 'slug', sanitize_title( $name ) );
 			if ( is_object( $search_term ) && $search_term->term_id != $existing_term->term_id ) {
 				$change_error = new WP_Error( 'invalid', esc_html__( 'Name conflicts with slug for another term. Please choose again.', 'edit-flow' ) );
-				die( esc_html( $change_error->get_error_message() ) );
+				wp_die( esc_html( $change_error->get_error_message() ) );
 			}
 
 			// Prepare the term name and description for saving
@@ -510,11 +510,11 @@ if ( ! class_exists( 'EF_User_Groups' ) ) {
 				$wp_list_table = new EF_Usergroups_List_Table();
 				$wp_list_table->prepare_items();
 				echo wp_kses_post( $wp_list_table->single_row( $return ) );
-				die();
+				wp_die();
 			} else {
 				// translators: %s is the name of the user group
 				$change_error = new WP_Error( 'invalid', sprintf( __( 'Could not update the user group: <strong>%s</strong>', 'edit-flow' ), $name ) );
-				die( wp_kses( $change_error->get_error_message(), 'strong' ) );
+				wp_die( wp_kses( $change_error->get_error_message(), 'strong' ) );
 			}
 		}
 


### PR DESCRIPTION
## Summary

This refactoring systematically replaces all `die()` calls with `wp_die()` in AJAX handlers across seven modules:

- **calendar** (4 replacements)
- **custom-status** (10 replacements)
- **editorial-comments** (4 replacements)
- **editorial-metadata** (11 replacements)
- **notifications** (3 replacements)
- **settings** (4 replacements)
- **user-groups** (9 replacements)

**Total: 45 die() calls replaced with wp_die()**

## Why This Change Matters

Using `die()` directly terminates the PHP process immediately, making AJAX handlers completely untestable with PHPUnit. When `die()` is called during a test, the entire test process terminates, preventing proper test isolation and making it impossible to assert on response behaviour.

The `wp_die()` function is WordPress's recommended alternative for AJAX endpoints. In production, it behaves identically to `die()`, but in test environments it throws a catchable `WPDieException` instead of terminating the process. This allows tests to:

1. Catch the exception and assert on the exit behaviour
2. Verify the correct response messages were sent
3. Continue running subsequent tests without process termination
4. Properly isolate and test error handling paths

This change is foundational work that unlocks the ability to write comprehensive AJAX integration tests for the plugin, significantly improving test coverage for user interactions in the WordPress admin.

## Test Plan

- ✅ All existing integration tests pass
- ✅ Manual testing of AJAX functionality in WordPress admin:
  - Calendar ICS subscriptions
  - Custom status inline editing
  - Editorial comments creation
  - Editorial metadata management
  - Notification user/usergroup assignments
  - Settings module enable/disable
  - User groups management

The behaviour in production remains identical—only the testability in PHPUnit environments improves.