### PR TITLE
fix: reduce readme tags to comply with WordPress.org limit

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === Edit Flow ===
 Contributors: batmoo, danielbachhuber, sbressler, automattic
 Donate link: http://editflow.org/contribute/
-Tags: edit flow, workflow, editorial, newsroom, management, journalism, post status, custom status, notifications, email, comments, editorial comments, usergroups, calendars, editorial calendar, story budget
+Tags: workflow, editorial, editorial calendar, custom status, newsroom
 Requires at least: 6.4
 Requires PHP: 8.0
 Tested up to: 6.5


### PR DESCRIPTION
## Problem

WordPress.org's plugin directory enforces a strict limit of 5 tags per plugin, but Edit Flow's readme.txt contained 16 tags. This excessive number of tags would cause validation failures when submitting updates to the WordPress.org plugin directory.

## Solution

This change reduces the tags to the 5 most relevant and descriptive terms for Edit Flow's core functionality:
- workflow
- editorial
- editorial calendar
- custom status
- newsroom

These tags were selected to represent the plugin's primary features whilst staying within the WordPress.org requirements, ensuring the plugin metadata remains compliant with directory guidelines.

Fixes #761