### PR TITLE
fix: correct Dependabot configuration for team reviewers

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,8 +14,7 @@ updates:
         patterns: ["*"]
     labels:
       - "dependencies"
-      - "github-actions"
-    assignees:
+    reviewers:
       - "Automattic/vip-plugins"
     commit-message:
       prefix: "Actions"
@@ -40,7 +39,7 @@ updates:
           - "yoast/*"
     labels:
       - "dependencies"
-    assignees:
+    reviewers:
       - "Automattic/vip-plugins"
     commit-message:
       prefix: "Composer"
@@ -63,8 +62,7 @@ updates:
           - "@types/*"
     labels:
       - "dependencies"
-      - "npm"
-    assignees:
+    reviewers:
       - "Automattic/vip-plugins"
     commit-message:
       prefix: "npm"


### PR DESCRIPTION
## Problem

Dependabot was generating warnings on pull requests (such as #808) due to configuration issues in `.github/dependabot.yml`. The configuration attempted to assign teams using the `assignees` field, which is not supported by GitHub—teams can only be added as reviewers, not assignees. Additionally, the configuration referenced labels that do not exist in this repository ("github-actions" and "npm"), which Dependabot flagged as errors.

## Solution

This change corrects the Dependabot configuration across all three package ecosystems (GitHub Actions, Composer, and npm):

- Changed `assignees` to `reviewers` for the `Automattic/vip-plugins` team assignment, allowing the team to be properly notified of dependency updates
- Removed non-existent labels ("github-actions" and "npm") whilst retaining the valid "dependencies" label that exists in the repository

These corrections ensure Dependabot operates without warnings and properly routes dependency update PRs to the appropriate team for review.