### PR TITLE
ci: improve CI visibility and reliability for dependency PRs

### DIFF
--- a/.github/workflows/e2e-and-js-tests.yml
+++ b/.github/workflows/e2e-and-js-tests.yml
@@ -15,15 +15,11 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  test:
-    name: E2E and JS tests
+  build:
+    name: Build and Lint
     runs-on: ubuntu-latest
-    continue-on-error: false
     permissions:
       contents: read
-
-    strategy:
-      fail-fast: true
 
     steps:
       - name: Checkout code
@@ -37,17 +33,80 @@ jobs:
           node-version: '20'
           cache: npm
 
-      - name: Build Edit Flow
-        run: |
-          npm ci
-          npx playwright install --with-deps chromium
-          npm run build
+      - name: Install dependencies
+        run: npm ci
 
-      - name: Install WordPress with wp-env
-        run: npm run wp-env start
+      - name: Build assets
+        run: npm run build
+
+      - name: Verify built assets exist
+        run: |
+          echo "Checking custom-status assets..."
+          test -f dist/custom-status.build.js || (echo "Missing: dist/custom-status.build.js" && exit 1)
+          test -f dist/custom-status.editor.build.css || (echo "Missing: dist/custom-status.editor.build.css" && exit 1)
+          test -f dist/custom-status.style.build.css || (echo "Missing: dist/custom-status.style.build.css" && exit 1)
+
+          echo "Checking calendar assets..."
+          test -f modules/calendar/lib/dist/calendar.react.build.js || (echo "Missing: modules/calendar/lib/dist/calendar.react.build.js" && exit 1)
+          test -f modules/calendar/lib/dist/calendar.react.editor.build.css || (echo "Missing: modules/calendar/lib/dist/calendar.react.editor.build.css" && exit 1)
+          test -f modules/calendar/lib/dist/calendar.react.style.build.css || (echo "Missing: modules/calendar/lib/dist/calendar.react.style.build.css" && exit 1)
+
+          echo "All expected assets present!"
+
+      - name: Report asset sizes
+        run: |
+          echo "### Asset Sizes" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| File | Size |" >> $GITHUB_STEP_SUMMARY
+          echo "|------|------|" >> $GITHUB_STEP_SUMMARY
+          echo "| custom-status.build.js | $(du -h dist/custom-status.build.js | cut -f1) |" >> $GITHUB_STEP_SUMMARY
+          echo "| calendar.react.build.js | $(du -h modules/calendar/lib/dist/calendar.react.build.js | cut -f1) |" >> $GITHUB_STEP_SUMMARY
 
       - name: Run Lint JS
         run: npm run lint-js
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: build-artifacts
+          path: |
+            dist/
+            modules/calendar/lib/dist/
+          retention-days: 1
+
+  test:
+    name: E2E and Jest tests
+    runs-on: ubuntu-latest
+    needs: build
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
+        with:
+          persist-credentials: false
+
+      - name: Set up NodeJS 20
+        uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
+        with:
+          node-version: '20'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: build-artifacts
+          path: .
+
+      - name: Install Playwright
+        run: npx playwright install --with-deps chromium
+
+      - name: Install WordPress with wp-env
+        run: npm run wp-env start
 
       - name: Run tests
         run: npm run test


### PR DESCRIPTION
## Problem

When Dependabot creates pull requests with dependency updates, the current CI workflow provides limited visibility into what's happening during the build and test process. The workflow runs everything in a single monolithic job, making it difficult to quickly identify whether issues stem from the build phase, linting, or the actual tests. Additionally, there's no verification that the build process produces all expected assets, which could mask subtle build failures that don't cause the build command itself to fail.

This lack of granularity means maintainers reviewing Dependabot PRs must dig through combined logs to diagnose issues, and there's no easy way to see at a glance whether a dependency update affects the size of built assets.

## Solution

This change restructures the E2E and JS tests workflow into two distinct jobs with clearer responsibilities and better observability:

**Build and Lint Job:**
- Installs dependencies and builds all assets
- Verifies that all expected build outputs exist (both custom-status and calendar assets)
- Reports asset sizes directly in the GitHub job summary for easy comparison across PRs
- Uploads build artifacts for use by the test job

**E2E and Jest Tests Job:**
- Downloads the pre-built artifacts from the build job
- Installs Playwright and sets up WordPress
- Runs the actual test suite

This separation provides several benefits:
- Build failures are immediately visible as a separate job failure
- Asset verification catches incomplete builds that might otherwise pass
- Asset size reporting helps identify unexpected bloat from dependency updates
- More descriptive step names make logs easier to navigate
- Build artifacts are shared efficiently between jobs rather than rebuilding