### PR TITLE
fix: correct i18n function usage in calendar module

### DIFF
--- a/modules/calendar/calendar.php
+++ b/modules/calendar/calendar.php
@@ -863,7 +863,7 @@ if ( ! class_exists( 'EF_Calendar' ) ) {
 						?>
 					</ul>
 						<?php if ( $this->hidden ) : ?>
-						<a class="show-more" href="#"><?php /* translators: %d = number of posts to show */ esc_html_e( sprintf( __( 'Show %d more', 'edit-flow' ), $this->hidden ) ); ?></a>
+						<a class="show-more" href="#"><?php /* translators: %d = number of posts to show */ printf( esc_html__( 'Show %d more', 'edit-flow' ), $this->hidden ); ?></a>
 					<?php endif; ?>
 
 						<?php
@@ -873,7 +873,7 @@ if ( ! class_exists( 'EF_Calendar' ) ) {
 
 						<form method="POST" class="post-insert-dialog">
 							<?php /* translators: %1$s = post type name, %2$s = date */ ?>
-							<h1><?php esc_html_e( sprintf( __( 'Schedule a %1$s for %2$s', 'edit-flow' ), $this->get_quick_create_post_type_name(), $date_formatted ) ); ?></h1>
+							<h1><?php printf( esc_html__( 'Schedule a %1$s for %2$s', 'edit-flow' ), $this->get_quick_create_post_type_name(), $date_formatted ); ?></h1>
 							<?php /* translators: %s = post type name */ ?>
 							<input type="text" class="post-insert-dialog-post-title" name="post-insert-dialog-post-title" placeholder="<?php echo esc_attr( sprintf( _x( '%s Title', 'post type name', 'edit-flow' ), $this->get_quick_create_post_type_name() ) ); ?>">
 							<input type="hidden" class="post-insert-dialog-post-date" name="post-insert-dialog-post-title" value="<?php echo esc_attr( $week_single_date ); ?>">
@@ -1478,7 +1478,7 @@ if ( ! class_exists( 'EF_Calendar' ) ) {
 
 			$regenerate_url = add_query_arg( 'action', 'ef_calendar_regenerate_calendar_feed_secret', admin_url( 'index.php' ) );
 			$regenerate_url = wp_nonce_url( $regenerate_url, 'ef-regenerate-ics-key' );
-			echo '&nbsp;&nbsp;&nbsp;<a href="' . esc_url( $regenerate_url ) . '">' . esc_html_e( 'Regenerate calendar feed secret', 'edit-flow' ) . '</a>';
+			echo '&nbsp;&nbsp;&nbsp;<a href="' . esc_url( $regenerate_url ) . '">' . esc_html__( 'Regenerate calendar feed secret', 'edit-flow' ) . '</a>';
 
 			// If our secret key doesn't exist, create a new one
 			if ( empty( $this->module->options->ics_secret_key ) ) {


### PR DESCRIPTION
This PR addresses incorrect usage of WordPress internationalisation functions in the calendar module that prevented proper translation of user-facing strings.

## Problem

The calendar module contained three instances where i18n functions were misused:

1. `esc_html_e()` was incorrectly wrapping `sprintf()` output, which attempts to echo an already-formatted string
2. In two cases, translated strings with placeholders were being echoed rather than formatted with `printf()`
3. `esc_html_e()` was used in string concatenation context where `esc_html__()` (which returns rather than echoes) was required

These patterns prevented the strings from being properly translated and displayed, as the functions were either echoing when they should return, or returning when they should echo and format.

## Solution

The changes correct the function usage patterns:

- Line 866: Changed from `esc_html_e( sprintf( __( ... ) ) )` to `printf( esc_html__( ... ) )` to properly format and echo the translated string
- Line 876: Applied the same correction for the schedule dialog heading
- Line 1481: Changed from `esc_html_e()` to `esc_html__()` in string concatenation context to return the translated string rather than echo it

These corrections follow WordPress i18n best practises and ensure the strings are properly translated and displayed to users.

## Credit

Original fix by @DAnn2012.

Supersedes #759