### PR TITLE
test: resolve E2E visibility issues and add WP 6.9 support

### DIFF
--- a/.github/workflows/php-tests.yml
+++ b/.github/workflows/php-tests.yml
@@ -31,10 +31,14 @@ jobs:
           - php: '8.0'
             wp: '6.4'
             allowed_failure: false
-          # Check latest WP with the highest supported PHP.
+          # Check current stable WP (6.9) with latest PHP.
+          - php: 'latest'
+            wp: '6.9'
+            allowed_failure: false
+          # Check upcoming WP with latest PHP.
           - php: 'latest'
             wp: 'master'
-            allowed_failure: false
+            allowed_failure: true
 
     steps:
       - name: Checkout code

--- a/.wp-env.json
+++ b/.wp-env.json
@@ -14,7 +14,7 @@
   "env": {
     "tests": {
       "phpVersion": "8.4",
-      "core": "WordPress/WordPress#6.8"
+      "core": "WordPress/WordPress#6.9"
     }
   }
 }

--- a/tests/e2e/editorial-comments.spec.js
+++ b/tests/e2e/editorial-comments.spec.js
@@ -7,6 +7,13 @@ test.describe('Editorial Comments', () => {
 	test('expects a user can create an editorial comment on a post', async ({ admin, editor, page }) => {
 		await admin.createNewPost({ title: 'Title' });
 
+		// Dismiss the welcome guide if it appears
+		const welcomeGuide = page.locator('.edit-post-welcome-guide, [aria-label="Welcome to the block editor"]');
+		if (await welcomeGuide.isVisible({ timeout: 2000 }).catch(() => false)) {
+			await page.keyboard.press('Escape');
+			await page.waitForTimeout(300);
+		}
+
 		// Save the post as draft
 		await editor.saveDraft();
 
@@ -14,16 +21,66 @@ test.describe('Editorial Comments', () => {
 		await expect(page.locator('.editor-post-saved-state')).toContainText('Saved');
 
 		// Reload page to ensure editorial comments UI is loaded
-		// TODO: Eventually show "Respond to post" button without reload
-		await page.reload({ waitUntil: 'domcontentloaded' });
+		await page.reload({ waitUntil: 'load' });
 
-		// Wait for editorial comments section to be ready
-		await page.locator('#ef-comment_respond').waitFor();
+		// Wait a moment for the block editor to initialize
+		await page.waitForTimeout(2000);
+
+		// In WordPress 6.9, metaboxes are in a collapsible panel at the bottom of the editor
+		// Scroll to bottom to see the Meta Boxes toggle
+		await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
+		await page.waitForTimeout(500);
+
+		// The Meta Boxes toggle has a specific structure - find and click the chevron/toggle
+		// Look for the button with the chevron SVG or the panel header
+		const metaBoxesRow = page.locator('.edit-post-meta-boxes-main__presenter, [class*="meta-boxes"]').first();
+
+		// Try clicking directly via JavaScript to expand meta boxes
+		await page.evaluate(() => {
+			// Find the meta boxes toggle button (it has aria-expanded attribute)
+			const buttons = document.querySelectorAll('button[aria-expanded]');
+			for (const btn of buttons) {
+				if (btn.textContent.includes('Meta Boxes') || btn.closest('[class*="meta-boxes"]')) {
+					if (btn.getAttribute('aria-expanded') === 'false') {
+						btn.click();
+						return true;
+					}
+				}
+			}
+			// Alternative: find by class name pattern
+			const toggle = document.querySelector('.edit-post-meta-boxes-main button[aria-expanded="false"]');
+			if (toggle) {
+				toggle.click();
+				return true;
+			}
+			return false;
+		});
+
+		await page.waitForTimeout(1500);
+
+		// Now the metabox should be in the DOM and visible
+		const metabox = page.locator('#edit-flow-editorial-comments');
+		await metabox.waitFor({ state: 'visible', timeout: 15000 });
+
+		// Scroll to the metabox
+		await metabox.evaluate((el) => el.scrollIntoView({ behavior: 'instant', block: 'center' }));
+		await page.waitForTimeout(500);
+
+		// Expand the metabox if it's collapsed
+		if (await metabox.evaluate((el) => el.classList.contains('closed'))) {
+			const toggleButton = metabox.locator('button.handlediv');
+			await toggleButton.click();
+			await page.waitForTimeout(300);
+		}
+
+		// The respond button should now be visible
+		const respondButton = page.locator('#ef-comment_respond');
+		await respondButton.waitFor({ state: 'visible', timeout: 10000 });
 
 		const COMMENT_TEXT = 'Hello';
 
 		// Click the respond button
-		await page.locator('#ef-comment_respond').click();
+		await respondButton.click();
 
 		// Type the comment
 		await page.locator('#ef-replycontent').fill(COMMENT_TEXT);


### PR DESCRIPTION
## Summary

- Fixed E2E test flakiness in editorial-comments.spec.js that has been failing since the Playwright migration (24th November)
- Updated CI matrix and wp-env to test against WordPress 6.9 (released this week)

## Problem

The editorial comments E2E test was failing because the `#ef-comment_respond` button was being found in the DOM but was hidden. This occurred due to:

1. **Welcome guide modal** - blocks interaction on fresh installs
2. **Collapsed Meta Boxes panel** - in WordPress 6.9, metaboxes are in a collapsible panel at the bottom of the block editor that needs to be expanded
3. **Hidden elements** - the metabox and respond button needed scrolling into view

The CI logs showed: `locator resolved to hidden <a href="#" id="ef-comment_respond"...>`

## Solution

1. **E2E Test Fix**: Updated the test to:
   - Dismiss the welcome guide if it appears
   - Scroll to the bottom of the block editor
   - Expand the Meta Boxes panel using JavaScript click (bypasses overlay issues)
   - Scroll to and expand the Editorial Comments metabox
   - Wait for elements to be visible before interacting

2. **WordPress 6.9 Support**: Updated:
   - `php-tests.yml`: Added WP 6.9 as the stable version, moved master branch to `allowed_failure: true`
   - `.wp-env.json`: Updated test environment from 6.8 to 6.9

## Test plan

- [x] All 11 E2E tests pass locally
- [ ] CI E2E tests pass
- [ ] PHP tests pass on WP 6.4, 6.9, and master

🤖 Generated with [Claude Code](https://claude.com/claude-code)