### PR TITLE
ci: pin E2E tests to Ubuntu 22.04 for Playwright compatibility

### DIFF
--- a/.github/workflows/e2e-and-js-tests.yml
+++ b/.github/workflows/e2e-and-js-tests.yml
@@ -76,7 +76,9 @@ jobs:
 
   test:
     name: E2E and Jest tests
-    runs-on: ubuntu-latest
+    # Pin to ubuntu-22.04 for Playwright compatibility
+    # ubuntu-latest (24.04) has library version mismatches with Playwright's WebKit dependencies
+    runs-on: ubuntu-22.04
     needs: build
     permissions:
       contents: read
@@ -102,7 +104,7 @@ jobs:
           name: build-artifacts
           path: .
 
-      - name: Install Playwright
+      - name: Install Playwright browsers and system dependencies
         run: npx playwright install --with-deps chromium
 
       - name: Install WordPress with wp-env


### PR DESCRIPTION
## Summary

Pins the E2E test job to Ubuntu 22.04 instead of `ubuntu-latest` to resolve Playwright browser dependency warnings.

## Problem

`ubuntu-latest` now resolves to Ubuntu 24.04, which has library version mismatches with Playwright's WebKit dependencies. This causes warnings like:

```
Host system is missing dependencies to run browsers.
Missing libraries:
    libgtk-4.so.1
    libgraphene-1.0.so.0
    libwoff2dec.so.1.0.2
    ... (many more)
```

While these are warnings (not errors) and only affect WebKit (not Chromium which we use), they add noise to the CI logs and indicate a fragile setup.

## Solution

- Pin the test job to `ubuntu-22.04` which has better Playwright compatibility
- Added comment explaining why the pin exists
- Clarified the Playwright installation step name

## Reference

- [Playwright Issue #32546](https://github.com/microsoft/playwright/issues/32546) - GitHub action fails with missing dependencies on Ubuntu 24.04

## Test plan

- [ ] CI passes on this PR (proving the fix works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)