### PR TITLE
fix: add type guard to prevent PHP warning in preview link filter

### DIFF
--- a/modules/custom-status/custom-status.php
+++ b/modules/custom-status/custom-status.php
@@ -1477,6 +1477,11 @@ if ( ! class_exists( 'EF_Custom_Status' ) ) {
 				$post = get_post( $post );
 			}
 
+			// Bail if $post is not a valid post object.
+			if ( ! $post instanceof WP_Post ) {
+				return $permalink;
+			}
+
 			//Should we be doing anything at all?
 			if ( ! in_array( $post->post_type, $this->get_post_types_for_module( $this->module ) ) ) {
 				return $permalink;


### PR DESCRIPTION
## Summary
- Adds guard clause to `fix_preview_link_part_two()` to prevent PHP warning when `$post` is not a valid WP_Post object
- Uses `instanceof WP_Post` for stricter type checking (rather than `is_object()` which would accept any object)
- Fixes indentation to use tabs matching surrounding code

## Problem
The `fix_preview_link_part_two()` filter callback could receive a string URL instead of a WP_Post object when `get_post()` returns null, causing a PHP warning:
```
Attempt to read property 'post_type' on string
```

## Attribution
Based on PR #747 by @dev4starter, rebased onto develop with improvements.

## Test plan
- [ ] Verify no PHP warnings when previewing posts with custom statuses
- [ ] Verify preview links still work correctly for valid posts
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)