### PR TITLE
feat(notifications): add Post Author and Auto-subscribed badges

### DIFF
--- a/modules/notifications/lib/notifications.css
+++ b/modules/notifications/lib/notifications.css
@@ -40,12 +40,28 @@
 	margin-top: 5px;
 }
 
+/* Badge base styles */
+.ef-post_following_list li .ef-user-subscribe-actions span[class^="post_following_list-"] {
+	margin-right: 8px;
+	border: solid 2px;
+	padding: 2px 6px;
+	font-size: 11px;
+	border-radius: 3px;
+	white-space: nowrap;
+}
+
+/* Warning badges (red) */
 .ef-post_following_list li .ef-user-subscribe-actions .post_following_list-no_email,
 .ef-post_following_list li .ef-user-subscribe-actions .post_following_list-no_access {
-	margin-right: 10px;
-	border: solid 2px #DC3232;
+	border-color: #DC3232;
 	color: #DC3232;
-	padding: 4px;
+}
+
+/* Neutral badges (grey) */
+.ef-post_following_list li .ef-user-subscribe-actions .post_following_list-post_author,
+.ef-post_following_list li .ef-user-subscribe-actions .post_following_list-auto_subscribed {
+	border-color: #787c82;
+	color: #787c82;
 }
 
 #ef-post_following_box {

--- a/modules/notifications/lib/notifications.js
+++ b/modules/notifications/lib/notifications.js
@@ -6,30 +6,51 @@ jQuery( document ).ready( function ( $ ) {
 		post_id: $( '#post_ID' ).val(),
 	};
 
-	const toggle_warning_badges = function ( container, response ) {
-		// Remove any existing badges
-		if ( $( container ).siblings( 'span' ).length ) {
-			$( container ).siblings( 'span' ).remove();
+	const localization =
+		typeof ef_notifications_localization !== 'undefined' ? ef_notifications_localization : {};
+
+	/**
+	 * Disable the post author checkbox if auto-subscribe is enabled.
+	 * The checkbox is disabled because unchecking it would have no effect -
+	 * the post author will be re-subscribed automatically on save.
+	 */
+	const maybe_disable_post_author_checkbox = function () {
+		if ( ! localization.post_author_id || ! localization.post_author_auto_subscribe ) {
+			return;
 		}
 
-		// "No Access" If this user was flagged as not having access
-		const user_has_no_access = response.data.subscribers_with_no_access.includes(
-			parseInt( $( container ).val() )
-		);
+		const $checkbox = $( '#ef-selected-users-' + localization.post_author_id );
+		if ( $checkbox.length ) {
+			$checkbox.prop( 'disabled', true );
+			$checkbox.attr( 'title', localization.auto_subscribed );
+		}
+	};
+
+	// Initialize: disable post author checkbox if needed.
+	maybe_disable_post_author_checkbox();
+
+	const toggle_warning_badges = function ( container, response ) {
+		const userId = parseInt( $( container ).val(), 10 );
+		const $actionsDiv = $( container ).parent();
+
+		// Remove existing warning badges (but keep Post Author and Auto-subscribed badges).
+		$actionsDiv.find( '.post_following_list-no_access, .post_following_list-no_email' ).remove();
+
+		// "No Access" If this user was flagged as not having access.
+		const user_has_no_access = response.data.subscribers_with_no_access.includes( userId );
 		if ( user_has_no_access ) {
-			var span = $( '<span />' ).addClass( 'post_following_list-no_access' );
-			span.text( ef_notifications_localization.no_access );
-			$( container ).parent().prepend( span );
+			const span = $( '<span />' ).addClass( 'post_following_list-no_access' );
+			span.text( localization.no_access );
+			$actionsDiv.prepend( span );
 			warning_background = true;
 		}
-		// "No Email" If this user was flagged as not having an email
-		const user_has_no_email = response.data.subscribers_with_no_email.includes(
-			parseInt( $( container ).val() )
-		);
+
+		// "No Email" If this user was flagged as not having an email.
+		const user_has_no_email = response.data.subscribers_with_no_email.includes( userId );
 		if ( user_has_no_email ) {
-			var span = $( '<span />' ).addClass( 'post_following_list-no_email' );
-			span.text( ef_notifications_localization.no_email );
-			$( container ).parent().prepend( span );
+			const span = $( '<span />' ).addClass( 'post_following_list-no_email' );
+			span.text( localization.no_email );
+			$actionsDiv.prepend( span );
 			warning_background = true;
 		}
 	};

--- a/modules/notifications/notifications.php
+++ b/modules/notifications/notifications.php
@@ -192,17 +192,33 @@ if ( ! class_exists( 'EF_Notifications' ) ) {
 		 * @uses wp_enqueue_script()
 		 */
 		public function enqueue_admin_scripts() {
+			global $post;
 
 			if ( $this->is_whitelisted_functional_view() ) {
 				wp_enqueue_script( 'jquery-listfilterizer' );
 				wp_enqueue_script( 'edit-flow-notifications-js', $this->module_url . 'lib/notifications.js', [ 'jquery', 'jquery-listfilterizer' ], EDIT_FLOW_VERSION, true );
+
+				$localization_data = [
+					'no_access'       => esc_html__( 'No Access', 'edit-flow' ),
+					'no_email'        => esc_html__( 'No Email', 'edit-flow' ),
+					'post_author'     => esc_html__( 'Post Author', 'edit-flow' ),
+					'auto_subscribed' => esc_html__( 'Auto-subscribed', 'edit-flow' ),
+				];
+
+				// Add post author info if we're on a post edit screen.
+				if ( $post ) {
+					$localization_data['post_author_id']            = (int) $post->post_author;
+					$localization_data['post_author_auto_subscribe'] = apply_filters( 'ef_notification_auto_subscribe_post_author', true, 'subscription_action' );
+
+					// Check if post author is currently a follower.
+					$followers                                       = $this->get_following_users( $post->ID, 'id' );
+					$localization_data['post_author_is_following']   = in_array( (int) $post->post_author, $followers, true );
+				}
+
 				wp_localize_script(
 					'edit-flow-notifications-js',
 					'ef_notifications_localization',
-					[
-						'no_access' => esc_html__( 'No Access', 'edit-flow' ),
-						'no_email'  => esc_html__( 'No Email', 'edit-flow' ),
-					]
+					$localization_data
 				);
 			}
 		}
@@ -375,31 +391,49 @@ if ( ! class_exists( 'EF_Notifications' ) ) {
 		}
 
 		/**
-		 * Show warning badges next to a subscriber's name if they won't receive notifications
+		 * Show badges next to a subscriber's name for status information
 		 *
-		 * Applies on initial loading of list via. PHP. JS will set these spans based on AJAX response when box is ticked/unticked.
+		 * Applies on initial loading of list via PHP. JS will set these spans based on AJAX response when box is ticked/unticked.
 		 *
-		 * @param int $user_id
+		 * @param int  $user_id The user ID.
 		 * @param bool $checked True if the user is subscribed already, false otherwise.
 		 * @return void
 		 */
 		public function display_subscriber_warning_badges( $user_id, $checked ) {
 			global $post;
 
-			if ( ! isset( $post ) || ! $checked ) {
+			if ( ! isset( $post ) ) {
 				return;
 			}
 
-			// Add No Access span if they won't be notified
+			$is_post_author    = ( (int) $post->post_author === (int) $user_id );
+			$auto_subscribe_on = apply_filters( 'ef_notification_auto_subscribe_post_author', true, 'subscription_action' );
+
+			// Show "Post Author" badge for the post author.
+			if ( $is_post_author ) {
+				echo '<span class="post_following_list-post_author">' . esc_html__( 'Post Author', 'edit-flow' ) . '</span>';
+			}
+
+			// Show "Auto-subscribed" badge if post author is auto-subscribed.
+			if ( $is_post_author && $auto_subscribe_on && $checked ) {
+				echo '<span class="post_following_list-auto_subscribed">' . esc_html__( 'Auto-subscribed', 'edit-flow' ) . '</span>';
+			}
+
+			// Only show warning badges if user is subscribed.
+			if ( ! $checked ) {
+				return;
+			}
+
+			// Add No Access span if they won't be notified.
 			if ( ! $this->user_can_be_notified( get_user_by( 'id', $user_id ), $post->ID ) ) {
-				// span.post_following_list-no_access is also added in notifications.js after AJAX that ticks/unticks a user
+				// span.post_following_list-no_access is also added in notifications.js after AJAX that ticks/unticks a user.
 				echo '<span class="post_following_list-no_access">' . esc_html__( 'No Access', 'edit-flow' ) . '</span>';
 			}
 
-			// Add No Email span if they have no email
+			// Add No Email span if they have no email.
 			$user_object = get_user_by( 'id', $user_id );
 			if ( ! is_a( $user_object, 'WP_User' ) || empty( $user_object->user_email ) ) {
-				// span.post_following_list-no_email is also added in notifications.js after AJAX that ticks/unticks a user
+				// span.post_following_list-no_email is also added in notifications.js after AJAX that ticks/unticks a user.
 				echo '<span class="post_following_list-no_email">' . esc_html__( 'No Email', 'edit-flow' ) . '</span>';
 			}
 		}

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -4,6 +4,7 @@ const baseConfig = require('@wordpress/scripts/config/playwright.config');
 module.exports = defineConfig({
 	...baseConfig,
 	testDir: './tests/e2e',
+	globalSetup: require.resolve('./tests/e2e/global-setup.js'),
 	use: {
 		...baseConfig.use,
 		baseURL: process.env.WP_BASE_URL || 'http://localhost:8889',

--- a/tests/Integration/NotificationsBadgesTest.php
+++ b/tests/Integration/NotificationsBadgesTest.php
@@ -1,0 +1,539 @@
+<?php
+/**
+ * Tests for notification subscriber warning badges feature.
+ *
+ * @package Automattic\EditFlow\Tests\Integration
+ */
+
+declare( strict_types=1 );
+
+namespace Automattic\EditFlow\Tests\Integration;
+
+use EF_Notifications;
+use Yoast\WPTestUtils\WPIntegration\TestCase;
+
+/**
+ * Tests for the display_subscriber_warning_badges method in EF_Notifications.
+ */
+class NotificationsBadgesTest extends TestCase {
+
+	protected static $admin_user_id;
+	protected static $editor_user_id;
+	protected static $author_user_id;
+	protected static $subscriber_user_id;
+	protected static $no_email_user_id;
+
+	public static function wpSetUpBeforeClass( $factory ) {
+		global $edit_flow;
+
+		// Ensure notifications module is initialized.
+		$edit_flow->notifications->install();
+		$edit_flow->notifications->init();
+
+		self::$admin_user_id = $factory->user->create(
+			array(
+				'role'       => 'administrator',
+				'user_email' => 'admin@example.com',
+			)
+		);
+
+		self::$editor_user_id = $factory->user->create(
+			array(
+				'role'       => 'editor',
+				'user_email' => 'editor@example.com',
+			)
+		);
+
+		self::$author_user_id = $factory->user->create(
+			array(
+				'role'       => 'author',
+				'user_email' => 'author@example.com',
+			)
+		);
+
+		self::$subscriber_user_id = $factory->user->create(
+			array(
+				'role'       => 'subscriber',
+				'user_email' => 'subscriber@example.com',
+			)
+		);
+
+		// Create a user without an email address.
+		self::$no_email_user_id = $factory->user->create(
+			array(
+				'role'       => 'editor',
+				'user_email' => '',
+			)
+		);
+	}
+
+	public static function wpTearDownAfterClass() {
+		self::delete_user( self::$admin_user_id );
+		self::delete_user( self::$editor_user_id );
+		self::delete_user( self::$author_user_id );
+		self::delete_user( self::$subscriber_user_id );
+		self::delete_user( self::$no_email_user_id );
+	}
+
+	protected function setUp(): void {
+		parent::setUp();
+		wp_set_current_user( self::$admin_user_id );
+	}
+
+	protected function tearDown(): void {
+		// Clean up any filters we may have added.
+		remove_all_filters( 'ef_notification_auto_subscribe_post_author' );
+		parent::tearDown();
+	}
+
+	/**
+	 * Test that post author gets "Post Author" badge.
+	 */
+	public function test_post_author_gets_post_author_badge() {
+		global $edit_flow, $post;
+
+		// Create a post with a specific author.
+		$post_id = self::factory()->post->create(
+			array( 'post_author' => self::$author_user_id )
+		);
+
+		// Set the global $post variable as the method relies on it.
+		$post = get_post( $post_id );
+
+		// Capture the output.
+		ob_start();
+		$edit_flow->notifications->display_subscriber_warning_badges( self::$author_user_id, false );
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'post_following_list-post_author', $output );
+		$this->assertStringContainsString( 'Post Author', $output );
+	}
+
+	/**
+	 * Test that post author gets "Auto-subscribed" badge when auto-subscribe is enabled and they're subscribed.
+	 */
+	public function test_post_author_gets_auto_subscribed_badge_when_subscribed() {
+		global $edit_flow, $post;
+
+		// Create a post with a specific author.
+		$post_id = self::factory()->post->create(
+			array( 'post_author' => self::$author_user_id )
+		);
+
+		// Set the global $post variable.
+		$post = get_post( $post_id );
+
+		// Ensure auto-subscribe filter returns true (default behavior).
+		add_filter( 'ef_notification_auto_subscribe_post_author', '__return_true' );
+
+		// Capture the output when user IS subscribed (checked = true).
+		ob_start();
+		$edit_flow->notifications->display_subscriber_warning_badges( self::$author_user_id, true );
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'post_following_list-auto_subscribed', $output );
+		$this->assertStringContainsString( 'Auto-subscribed', $output );
+	}
+
+	/**
+	 * Test that post author does NOT get "Auto-subscribed" badge when not subscribed.
+	 */
+	public function test_post_author_no_auto_subscribed_badge_when_not_subscribed() {
+		global $edit_flow, $post;
+
+		// Create a post with a specific author.
+		$post_id = self::factory()->post->create(
+			array( 'post_author' => self::$author_user_id )
+		);
+
+		// Set the global $post variable.
+		$post = get_post( $post_id );
+
+		// Ensure auto-subscribe filter returns true.
+		add_filter( 'ef_notification_auto_subscribe_post_author', '__return_true' );
+
+		// Capture the output when user is NOT subscribed (checked = false).
+		ob_start();
+		$edit_flow->notifications->display_subscriber_warning_badges( self::$author_user_id, false );
+		$output = ob_get_clean();
+
+		// Should have "Post Author" badge but NOT "Auto-subscribed" badge.
+		$this->assertStringContainsString( 'post_following_list-post_author', $output );
+		$this->assertStringNotContainsString( 'post_following_list-auto_subscribed', $output );
+	}
+
+	/**
+	 * Test that post author does NOT get "Auto-subscribed" badge when auto-subscribe is disabled.
+	 */
+	public function test_post_author_no_auto_subscribed_badge_when_filter_disabled() {
+		global $edit_flow, $post;
+
+		// Create a post with a specific author.
+		$post_id = self::factory()->post->create(
+			array( 'post_author' => self::$author_user_id )
+		);
+
+		// Set the global $post variable.
+		$post = get_post( $post_id );
+
+		// Disable auto-subscribe via filter.
+		add_filter( 'ef_notification_auto_subscribe_post_author', '__return_false' );
+
+		// Capture the output when user IS subscribed (checked = true).
+		ob_start();
+		$edit_flow->notifications->display_subscriber_warning_badges( self::$author_user_id, true );
+		$output = ob_get_clean();
+
+		// Should have "Post Author" badge but NOT "Auto-subscribed" badge.
+		$this->assertStringContainsString( 'post_following_list-post_author', $output );
+		$this->assertStringNotContainsString( 'post_following_list-auto_subscribed', $output );
+	}
+
+	/**
+	 * Test that non-author users don't get "Post Author" badge.
+	 */
+	public function test_non_author_does_not_get_post_author_badge() {
+		global $edit_flow, $post;
+
+		// Create a post with admin as the author.
+		$post_id = self::factory()->post->create(
+			array( 'post_author' => self::$admin_user_id )
+		);
+
+		// Set the global $post variable.
+		$post = get_post( $post_id );
+
+		// Capture the output for a different user (editor, not the post author).
+		ob_start();
+		$edit_flow->notifications->display_subscriber_warning_badges( self::$editor_user_id, true );
+		$output = ob_get_clean();
+
+		$this->assertStringNotContainsString( 'post_following_list-post_author', $output );
+		$this->assertStringNotContainsString( 'Post Author', $output );
+	}
+
+	/**
+	 * Test that subscriber user gets "No Access" badge when subscribed.
+	 */
+	public function test_subscriber_gets_no_access_badge_when_subscribed() {
+		global $edit_flow, $post;
+
+		// Create a post.
+		$post_id = self::factory()->post->create(
+			array( 'post_author' => self::$admin_user_id )
+		);
+
+		// Set the global $post variable.
+		$post = get_post( $post_id );
+
+		// Capture the output for a subscriber (who can't edit the post).
+		ob_start();
+		$edit_flow->notifications->display_subscriber_warning_badges( self::$subscriber_user_id, true );
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'post_following_list-no_access', $output );
+		$this->assertStringContainsString( 'No Access', $output );
+	}
+
+	/**
+	 * Test that subscriber user does NOT get "No Access" badge when not subscribed.
+	 */
+	public function test_subscriber_no_access_badge_only_when_subscribed() {
+		global $edit_flow, $post;
+
+		// Create a post.
+		$post_id = self::factory()->post->create(
+			array( 'post_author' => self::$admin_user_id )
+		);
+
+		// Set the global $post variable.
+		$post = get_post( $post_id );
+
+		// Capture the output for a subscriber when NOT subscribed.
+		ob_start();
+		$edit_flow->notifications->display_subscriber_warning_badges( self::$subscriber_user_id, false );
+		$output = ob_get_clean();
+
+		// No Access badge should NOT appear when not subscribed.
+		$this->assertStringNotContainsString( 'post_following_list-no_access', $output );
+	}
+
+	/**
+	 * Test that user with no email gets "No Email" badge when subscribed.
+	 */
+	public function test_user_without_email_gets_no_email_badge_when_subscribed() {
+		global $edit_flow, $post;
+
+		// Create a post.
+		$post_id = self::factory()->post->create(
+			array( 'post_author' => self::$admin_user_id )
+		);
+
+		// Set the global $post variable.
+		$post = get_post( $post_id );
+
+		// Capture the output for user without email.
+		ob_start();
+		$edit_flow->notifications->display_subscriber_warning_badges( self::$no_email_user_id, true );
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'post_following_list-no_email', $output );
+		$this->assertStringContainsString( 'No Email', $output );
+	}
+
+	/**
+	 * Test that user with no email does NOT get "No Email" badge when not subscribed.
+	 */
+	public function test_user_without_email_no_email_badge_only_when_subscribed() {
+		global $edit_flow, $post;
+
+		// Create a post.
+		$post_id = self::factory()->post->create(
+			array( 'post_author' => self::$admin_user_id )
+		);
+
+		// Set the global $post variable.
+		$post = get_post( $post_id );
+
+		// Capture the output for user without email when NOT subscribed.
+		ob_start();
+		$edit_flow->notifications->display_subscriber_warning_badges( self::$no_email_user_id, false );
+		$output = ob_get_clean();
+
+		// No Email badge should NOT appear when not subscribed.
+		$this->assertStringNotContainsString( 'post_following_list-no_email', $output );
+	}
+
+	/**
+	 * Test that method returns early when global $post is not set.
+	 */
+	public function test_returns_early_when_no_post() {
+		global $edit_flow, $post;
+
+		// Unset the global $post variable.
+		$post = null;
+
+		// Capture the output.
+		ob_start();
+		$edit_flow->notifications->display_subscriber_warning_badges( self::$author_user_id, true );
+		$output = ob_get_clean();
+
+		// Should output nothing when $post is not set.
+		$this->assertEmpty( $output );
+	}
+
+	/**
+	 * Test that invalid user_id returns "No Email" badge (since get_user_by returns false).
+	 */
+	public function test_invalid_user_id_gets_no_email_badge_when_subscribed() {
+		global $edit_flow, $post;
+
+		// Create a post.
+		$post_id = self::factory()->post->create(
+			array( 'post_author' => self::$admin_user_id )
+		);
+
+		// Set the global $post variable.
+		$post = get_post( $post_id );
+
+		// Use an invalid user ID.
+		$invalid_user_id = 999999;
+
+		// Capture the output.
+		ob_start();
+		$edit_flow->notifications->display_subscriber_warning_badges( $invalid_user_id, true );
+		$output = ob_get_clean();
+
+		// Should have "No Email" badge since get_user_by will return false.
+		$this->assertStringContainsString( 'post_following_list-no_email', $output );
+	}
+
+	/**
+	 * Test that localization data includes post_author_id when on a post edit screen.
+	 *
+	 * The enqueue_admin_scripts method adds post_author_id, post_author_auto_subscribe,
+	 * and post_author_is_following to the localization data when $post is set.
+	 */
+	public function test_localization_includes_post_author_id_on_post_edit_screen() {
+		global $edit_flow, $post, $pagenow, $typenow;
+
+		// Set up the admin context for a post edit screen.
+		$original_pagenow  = $pagenow;
+		$original_typenow  = $typenow;
+		$pagenow           = 'post.php';
+		$typenow           = 'post';
+
+		// Create a post with a specific author.
+		$post_id = self::factory()->post->create(
+			array( 'post_author' => self::$author_user_id )
+		);
+
+		// Set the global $post variable.
+		$post = get_post( $post_id );
+
+		// Set current screen to simulate the post edit screen.
+		set_current_screen( 'post' );
+
+		// Dequeue any previously registered script to ensure fresh state.
+		wp_deregister_script( 'edit-flow-notifications-js' );
+
+		// Call enqueue_admin_scripts.
+		$edit_flow->notifications->enqueue_admin_scripts();
+
+		// Get the localized data for the script.
+		$wp_scripts     = wp_scripts();
+		$localized_data = $wp_scripts->get_data( 'edit-flow-notifications-js', 'data' );
+
+		// Restore original globals.
+		$pagenow  = $original_pagenow;
+		$typenow  = $original_typenow;
+		set_current_screen( 'front' );
+
+		// Verify the script was registered and has localization data.
+		$this->assertNotEmpty( $localized_data, 'Script should have localization data' );
+
+		// The localization data is a JavaScript string, so check for the expected values.
+		$this->assertStringContainsString( 'post_author_id', $localized_data );
+		$this->assertStringContainsString( (string) self::$author_user_id, $localized_data );
+		$this->assertStringContainsString( 'post_author_auto_subscribe', $localized_data );
+		$this->assertStringContainsString( 'post_author_is_following', $localized_data );
+	}
+
+	/**
+	 * Test that localization data includes correct badge labels for JavaScript.
+	 */
+	public function test_localization_includes_badge_labels() {
+		global $edit_flow, $post, $pagenow, $typenow;
+
+		// Set up the admin context for a post edit screen.
+		$original_pagenow  = $pagenow;
+		$original_typenow  = $typenow;
+		$pagenow           = 'post.php';
+		$typenow           = 'post';
+
+		// Create a post.
+		$post_id = self::factory()->post->create(
+			array( 'post_author' => self::$admin_user_id )
+		);
+
+		// Set the global $post variable.
+		$post = get_post( $post_id );
+
+		// Set current screen to simulate the post edit screen.
+		set_current_screen( 'post' );
+
+		// Dequeue any previously registered script to ensure fresh state.
+		wp_deregister_script( 'edit-flow-notifications-js' );
+
+		// Call enqueue_admin_scripts.
+		$edit_flow->notifications->enqueue_admin_scripts();
+
+		// Get the localized data for the script.
+		$wp_scripts     = wp_scripts();
+		$localized_data = $wp_scripts->get_data( 'edit-flow-notifications-js', 'data' );
+
+		// Restore original globals.
+		$pagenow  = $original_pagenow;
+		$typenow  = $original_typenow;
+		set_current_screen( 'front' );
+
+		// Verify all badge labels are included in the localization data.
+		$this->assertStringContainsString( 'no_access', $localized_data );
+		$this->assertStringContainsString( 'No Access', $localized_data );
+		$this->assertStringContainsString( 'no_email', $localized_data );
+		$this->assertStringContainsString( 'No Email', $localized_data );
+		$this->assertStringContainsString( 'post_author', $localized_data );
+		$this->assertStringContainsString( 'Post Author', $localized_data );
+		$this->assertStringContainsString( 'auto_subscribed', $localized_data );
+		$this->assertStringContainsString( 'Auto-subscribed', $localized_data );
+	}
+
+	/**
+	 * Test that post author with no followers shows post_author_is_following as false.
+	 */
+	public function test_localization_post_author_is_following_false_when_not_subscribed() {
+		global $edit_flow, $post, $pagenow, $typenow;
+
+		// Set up the admin context for a post edit screen.
+		$original_pagenow  = $pagenow;
+		$original_typenow  = $typenow;
+		$pagenow           = 'post.php';
+		$typenow           = 'post';
+
+		// Create a post with a specific author but don't add any followers.
+		$post_id = self::factory()->post->create(
+			array( 'post_author' => self::$author_user_id )
+		);
+
+		// Set the global $post variable.
+		$post = get_post( $post_id );
+
+		// Set current screen to simulate the post edit screen.
+		set_current_screen( 'post' );
+
+		// Dequeue any previously registered script to ensure fresh state.
+		wp_deregister_script( 'edit-flow-notifications-js' );
+
+		// Call enqueue_admin_scripts.
+		$edit_flow->notifications->enqueue_admin_scripts();
+
+		// Get the localized data for the script.
+		$wp_scripts     = wp_scripts();
+		$localized_data = $wp_scripts->get_data( 'edit-flow-notifications-js', 'data' );
+
+		// Restore original globals.
+		$pagenow  = $original_pagenow;
+		$typenow  = $original_typenow;
+		set_current_screen( 'front' );
+
+		// Verify post_author_is_following is false (represented as empty string "" in the JS output).
+		$this->assertStringContainsString( 'post_author_is_following', $localized_data );
+		// When false, wp_localize_script outputs an empty string.
+		$this->assertStringContainsString( '"post_author_is_following":""', $localized_data );
+	}
+
+	/**
+	 * Test that post author who is subscribed shows post_author_is_following as true.
+	 */
+	public function test_localization_post_author_is_following_true_when_subscribed() {
+		global $edit_flow, $post, $pagenow, $typenow;
+
+		// Set up the admin context for a post edit screen.
+		$original_pagenow  = $pagenow;
+		$original_typenow  = $typenow;
+		$pagenow           = 'post.php';
+		$typenow           = 'post';
+
+		// Create a post with a specific author.
+		$post_id = self::factory()->post->create(
+			array( 'post_author' => self::$author_user_id )
+		);
+
+		// Add the author as a follower.
+		$edit_flow->notifications->follow_post_user( $post_id, self::$author_user_id );
+
+		// Set the global $post variable.
+		$post = get_post( $post_id );
+
+		// Set current screen to simulate the post edit screen.
+		set_current_screen( 'post' );
+
+		// Dequeue any previously registered script to ensure fresh state.
+		wp_deregister_script( 'edit-flow-notifications-js' );
+
+		// Call enqueue_admin_scripts.
+		$edit_flow->notifications->enqueue_admin_scripts();
+
+		// Get the localized data for the script.
+		$wp_scripts     = wp_scripts();
+		$localized_data = $wp_scripts->get_data( 'edit-flow-notifications-js', 'data' );
+
+		// Restore original globals.
+		$pagenow  = $original_pagenow;
+		$typenow  = $original_typenow;
+		set_current_screen( 'front' );
+
+		// Verify post_author_is_following is true (wp_localize_script outputs "1" for true).
+		$this->assertStringContainsString( '"post_author_is_following":"1"', $localized_data );
+	}
+}

--- a/tests/e2e/global-setup.js
+++ b/tests/e2e/global-setup.js
@@ -1,0 +1,40 @@
+/**
+ * Playwright global setup for Edit Flow E2E tests.
+ *
+ * This is the E2E equivalent of PHPUnit's bootstrap.php - it ensures
+ * the test environment is properly configured before any tests run.
+ *
+ * @see https://playwright.dev/docs/test-global-setup-teardown
+ * @see https://github.com/WordPress/gutenberg/blob/trunk/test/e2e/config/global-setup.ts
+ */
+
+const { request } = require('@playwright/test');
+const { RequestUtils } = require('@wordpress/e2e-test-utils-playwright');
+
+/**
+ * Global setup function - runs once before all tests.
+ *
+ * @param {import('@playwright/test').FullConfig} config Playwright config.
+ */
+async function globalSetup(config) {
+	const { storageState, baseURL } = config.projects[0].use;
+	const storageStatePath = typeof storageState === 'string' ? storageState : undefined;
+
+	const requestContext = await request.newContext({
+		baseURL,
+	});
+
+	const requestUtils = new RequestUtils(requestContext, {
+		storageStatePath,
+	});
+
+	// Authenticate and save the storageState to disk.
+	await requestUtils.setupRest();
+
+	// Activate the Edit Flow plugin - mirrors PHPUnit's bootstrap.php.
+	await requestUtils.activatePlugin('edit-flow');
+
+	await requestContext.dispose();
+}
+
+module.exports = globalSetup;

--- a/tests/e2e/notification-badges.spec.js
+++ b/tests/e2e/notification-badges.spec.js
@@ -1,0 +1,166 @@
+/**
+ * WordPress dependencies
+ */
+const { test, expect } = require('./utils');
+
+/**
+ * Helper function to expand meta boxes in the block editor
+ */
+async function expandMetaBoxes(page) {
+	// Scroll to bottom to see the Meta Boxes toggle
+	await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
+	await page.waitForTimeout(500);
+
+	// Try clicking directly via JavaScript to expand meta boxes
+	await page.evaluate(() => {
+		// Find the meta boxes toggle button (it has aria-expanded attribute)
+		const buttons = document.querySelectorAll('button[aria-expanded]');
+		for (const btn of buttons) {
+			if (btn.textContent.includes('Meta Boxes') || btn.closest('[class*="meta-boxes"]')) {
+				if (btn.getAttribute('aria-expanded') === 'false') {
+					btn.click();
+					return true;
+				}
+			}
+		}
+		// Alternative: find by class name pattern
+		const toggle = document.querySelector('.edit-post-meta-boxes-main button[aria-expanded="false"]');
+		if (toggle) {
+			toggle.click();
+			return true;
+		}
+		return false;
+	});
+
+	await page.waitForTimeout(1500);
+}
+
+/**
+ * Helper function to expand a specific metabox if collapsed
+ */
+async function expandMetabox(page, metabox) {
+	const isClosed = await metabox.evaluate((el) => el.classList.contains('closed'));
+	if (isClosed) {
+		const toggleButton = metabox.locator('button.handlediv, .handlediv');
+		await toggleButton.click();
+		await page.waitForTimeout(300);
+	}
+}
+
+test.describe('Notification Badges', () => {
+	test('post author has Post Author badge and disabled checkbox', async ({ admin, editor, page }) => {
+		await admin.createNewPost({ title: 'Notification Badge Test' });
+
+		// Dismiss the welcome guide if it appears
+		const welcomeGuide = page.locator('.edit-post-welcome-guide, [aria-label="Welcome to the block editor"]');
+		if (await welcomeGuide.isVisible({ timeout: 2000 }).catch(() => false)) {
+			await page.keyboard.press('Escape');
+			await page.waitForTimeout(300);
+		}
+
+		// Save the post as draft
+		await editor.saveDraft();
+
+		// Wait for save to complete
+		await expect(page.locator('.editor-post-saved-state')).toContainText('Saved');
+
+		// Reload page to ensure notifications UI is loaded
+		await page.reload({ waitUntil: 'load' });
+
+		// Wait a moment for the block editor to initialize
+		await page.waitForTimeout(2000);
+
+		// Expand meta boxes
+		await expandMetaBoxes(page);
+
+		// Find the notifications metabox
+		const metabox = page.locator('#edit-flow-notifications');
+		await metabox.waitFor({ state: 'visible', timeout: 15000 });
+
+		// Scroll to the metabox
+		await metabox.evaluate((el) => el.scrollIntoView({ behavior: 'instant', block: 'center' }));
+		await page.waitForTimeout(500);
+
+		// Expand the metabox if it's collapsed
+		await expandMetabox(page, metabox);
+
+		// Get the current user's ID from the page
+		const currentUserId = await page.evaluate(() => {
+			return typeof ef_notifications_localization !== 'undefined'
+				? ef_notifications_localization.post_author_id
+				: null;
+		});
+
+		expect(currentUserId).not.toBeNull();
+
+		// Find the post author's list item
+		const authorCheckbox = page.locator(`#ef-selected-users-${currentUserId}`);
+		await authorCheckbox.waitFor({ state: 'attached', timeout: 5000 });
+
+		// Verify the checkbox is disabled (auto-subscribed - JS disables it)
+		await expect(authorCheckbox).toBeDisabled();
+
+		// Verify the "Post Author" badge is present
+		const postAuthorBadge = page.locator('.post_following_list-post_author');
+		await expect(postAuthorBadge).toBeVisible();
+		await expect(postAuthorBadge).toHaveText('Post Author');
+
+		// Note: "Auto-subscribed" badge only shows when the author is already subscribed.
+		// For a new post, the author may not yet be auto-subscribed until a status transition.
+		// The PHP unit tests cover the auto-subscribed badge logic.
+	});
+
+	test('non-author users do not have Post Author badge', async ({ admin, editor, page }) => {
+		await admin.createNewPost({ title: 'Non-Author Badge Test' });
+
+		// Dismiss the welcome guide if it appears
+		const welcomeGuide = page.locator('.edit-post-welcome-guide, [aria-label="Welcome to the block editor"]');
+		if (await welcomeGuide.isVisible({ timeout: 2000 }).catch(() => false)) {
+			await page.keyboard.press('Escape');
+			await page.waitForTimeout(300);
+		}
+
+		// Save the post as draft
+		await editor.saveDraft();
+
+		// Wait for save to complete
+		await expect(page.locator('.editor-post-saved-state')).toContainText('Saved');
+
+		// Reload page to ensure notifications UI is loaded
+		await page.reload({ waitUntil: 'load' });
+		await page.waitForTimeout(2000);
+
+		// Expand meta boxes
+		await expandMetaBoxes(page);
+
+		// Find the notifications metabox
+		const metabox = page.locator('#edit-flow-notifications');
+		await metabox.waitFor({ state: 'visible', timeout: 15000 });
+
+		// Scroll to the metabox
+		await metabox.evaluate((el) => el.scrollIntoView({ behavior: 'instant', block: 'center' }));
+		await page.waitForTimeout(500);
+
+		// Expand the metabox if it's collapsed
+		await expandMetabox(page, metabox);
+
+		// Get all Post Author badges - should only be one (for the actual post author)
+		const postAuthorBadges = page.locator('.post_following_list-post_author');
+		const badgeCount = await postAuthorBadges.count();
+
+		// There should be exactly one Post Author badge
+		expect(badgeCount).toBe(1);
+
+		// Get the current user's ID
+		const currentUserId = await page.evaluate(() => {
+			return typeof ef_notifications_localization !== 'undefined'
+				? ef_notifications_localization.post_author_id
+				: null;
+		});
+
+		// Verify the badge is associated with the post author's checkbox
+		const authorListItem = page.locator(`label[for="ef-selected-users-${currentUserId}"]`);
+		const badgeInAuthorItem = authorListItem.locator('.post_following_list-post_author');
+		await expect(badgeInAuthorItem).toBeVisible();
+	});
+});


### PR DESCRIPTION
## Summary

- Add "Post Author" badge next to the post author in the notifications subscriber list
- Add "Auto-subscribed" badge when the post author is auto-subscribed to the post
- Disable the post author's checkbox when auto-subscribe is enabled (prevents confusing UX where unticking appears to work but doesn't actually unsubscribe them)
- Add badge styling: neutral grey for informational badges, red for warning badges

## Context

This is a fresh reimplementation addressing issue #508. The original PR #563 was closed as stale after 5+ years, and the codebase has changed significantly since then.

Implements the "Alternate UX: Disable checkbox" approach from the issue discussion - this prevents the scenario where a user unticks the post author, sees a green "success" flash, but the author is immediately re-subscribed on save.

## Test plan

- [x] PHP integration tests added (15 tests, 34 assertions)
- [x] E2E tests added for badge UI behaviour
- [x] Added Playwright `globalSetup` to ensure plugin is activated before E2E tests (mirrors PHPUnit's `bootstrap.php` pattern, follows Gutenberg's approach)
- [x] Manual testing: create a post, check that the post author shows "Post Author" badge and disabled checkbox

Closes #508

🤖 Generated with [Claude Code](https://claude.com/claude-code)