### PR TITLE
fix: resolve stale cache causing incorrect display in custom status Quick Edit

### DIFF
--- a/modules/custom-status/custom-status.php
+++ b/modules/custom-status/custom-status.php
@@ -537,9 +537,6 @@ if ( ! class_exists( 'EF_Custom_Status' ) ) {
 				return new WP_Error( 'invalid', __( "Custom status doesn't exist.", 'edit-flow' ) );
 			}
 
-			// Reset our internal object cache
-			$this->custom_statuses_cache = [];
-
 			// Prevent user from changing draft name or slug
 			if ( 'draft' === $old_status->slug
 			&& (
@@ -573,7 +570,12 @@ if ( ! class_exists( 'EF_Custom_Status' ) ) {
 			$args['description']           = $encoded_description;
 
 			$updated_status_array = wp_update_term( $status_id, self::taxonomy_key, $args );
-			$updated_status       = $this->get_custom_status_by( 'id', $updated_status_array['term_id'] );
+
+			// Reset our internal object cache after the update, not before.
+			// This ensures get_custom_status_by() returns fresh data.
+			$this->custom_statuses_cache = [];
+
+			$updated_status = $this->get_custom_status_by( 'id', $updated_status_array['term_id'] );
 
 			return $updated_status;
 		}


### PR DESCRIPTION
This change addresses a visual update bug in the Custom Status Quick Edit functionality where the status row would display stale data after updates, requiring a manual page refresh to see the correct name.

## The Problem

When editing a custom status name through Quick Edit, the update operation would save correctly to the database (verified by page refresh), but the table row rendered from the AJAX response would display the old name rather than the newly updated one. This created a confusing user experience where changes appeared not to take effect until the page was manually refreshed.

The underlying issue was a timing problem in the cache management within `update_custom_status()`. The function cleared the internal `custom_statuses_cache` at the start of its execution. However, during the update logic—specifically when the slug needed to be updated as part of a name change—calls to `get_default_custom_status()` would repopulate this cache with stale data from the database. This repopulation occurred before `wp_update_term()` had written the new values. Consequently, when the function returned the updated status via `get_custom_status_by()`, it was serving cached data that reflected the pre-update state.

## The Solution

The fix moves the cache reset to occur after `wp_update_term()` has completed but before fetching the updated term data. This ensures that when `get_custom_status_by()` retrieves the status object to return in the AJAX response, it's working with fresh data that reflects the update that was just written to the database.

This approach mirrors the pattern already successfully employed in the Editorial Metadata module, which handles similar update operations without cache-related issues.

## Testing

To verify the fix:

1. Navigate to Edit Flow → Custom Statuses
2. Click "Quick Edit" on any custom status (except Draft, which has special handling)
3. Change the status name and click "Update Status"
4. Observe that the table row immediately displays the updated name without requiring a page refresh

Fixes #657