### PR TITLE
chore: rename workflow to match plugin standards

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,4 +1,4 @@
-name: PHP Tests
+name: Integration Tests
 
 on:
   pull_request:


### PR DESCRIPTION
## Summary

- Rename `php-tests.yml` → `integration.yml`
- Update workflow name from "PHP Tests" to "Integration Tests"

This aligns with the naming convention used across other Automattic plugins (e.g., Co-Authors Plus) where integration test workflows are named `integration.yml`.

## Test plan

- [x] Verify the workflow runs correctly under the new name

🤖 Generated with [Claude Code](https://claude.com/claude-code)