### PR TITLE
fix: add Private option to bulk edit status dropdown

### DIFF
--- a/modules/custom-status/custom-status.php
+++ b/modules/custom-status/custom-status.php
@@ -314,6 +314,7 @@ if ( ! class_exists( 'EF_Custom_Status' ) ) {
 				wp_localize_script('edit_flow-custom_status', '__ef_localize_custom_status', [
 					'no_change' => esc_html__( '&mdash; No Change &mdash;', 'edit-flow' ),
 					'published' => esc_html__( 'Published', 'edit-flow' ),
+					'private'   => esc_html__( 'Private', 'edit-flow' ),
 					'save_as'   => esc_html__( 'Save as', 'edit-flow' ),
 					'save'      => esc_html__( 'Save', 'edit-flow' ),
 					'edit'      => esc_html__( 'Edit', 'edit-flow' ),

--- a/modules/custom-status/lib/custom-status.js
+++ b/modules/custom-status/lib/custom-status.js
@@ -126,7 +126,16 @@ jQuery( document ).ready( function () {
 			);
 		}
 
-		// Add remaining statuses to dropdown. 'private' is always handled by a checkbox, and 'future' already exists if we need it
+		// Add "Private" status to bulk/quick-edit for users that can publish
+		// On the post editor, private is handled by the Visibility checkbox, but bulk edit has no such control
+		if ( id == 'select[name="_status"]' && current_user_can_publish_posts ) {
+			jQuery( id ).append(
+				jQuery( '<option></option' ).attr( 'value', 'private' ).text( i18n.private )
+			);
+		}
+
+		// Add remaining statuses to dropdown. 'future' already exists if we need it.
+		// 'private' is handled above for bulk/quick edit, or via Visibility checkbox on post editor.
 		jQuery.each( custom_statuses, function () {
 			if ( this.slug == 'private' || this.slug == 'future' ) {
 				return;


### PR DESCRIPTION
## Summary

Adds 'Private' to the bulk/quick edit status dropdown, matching WordPress core behavior.

**The issue:** WordPress core includes Private as a status option in bulk edit, but Edit Flow was excluding it because 'private' is handled by a Visibility checkbox in the single post editor. However, bulk edit has no such checkbox, so users couldn't set posts to private via bulk actions.

## Changes

- Added 'Private' option to the bulk/quick edit status dropdown (for users with publish permissions)
- Added localized string for 'Private' label

## Test plan

1. Go to Posts → All Posts
2. Select multiple posts
3. Click "Bulk actions" → "Edit" → "Apply"
4. Verify the Status dropdown now includes "Private" option
5. Select "Private" and click "Update"
6. Verify selected posts are now private

Fixes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)