### PR TITLE
fix: guard against null return from get_edit_post_link() and get_permalink()

### DIFF
--- a/modules/notifications/notifications.php
+++ b/modules/notifications/notifications.php
@@ -732,12 +732,24 @@ if ( ! class_exists( 'EF_Notifications' ) ) {
 					$body .= sprintf( __( 'Author: %1$s (%2$s)', 'edit-flow' ), $post_author->display_name, $post_author->user_email ) . "\r\n";
 				}
 
-				$edit_link = htmlspecialchars_decode( get_edit_post_link( $post_id ) );
+				$edit_post_link = get_edit_post_link( $post_id );
+				if ( is_null( $edit_post_link ) ) {
+					return;
+				}
+
+				$edit_link = htmlspecialchars_decode( $edit_post_link );
+
 				if ( 'publish' != $new_status ) {
 					$view_link = add_query_arg( [ 'preview' => 'true' ], wp_get_shortlink( $post_id ) );
 				} else {
-					$view_link = htmlspecialchars_decode( get_permalink( $post_id ) );
+					$permalink = get_permalink( $post_id );
+					if ( is_null( $permalink ) ) {
+						return;
+					}
+
+					$view_link = htmlspecialchars_decode( $permalink );
 				}
+
 				$body .= "\r\n";
 				$body .= __( '== Actions ==', 'edit-flow' ) . "\r\n";
 				/* translators: 1: edit link */
@@ -830,8 +842,19 @@ if ( ! class_exists( 'EF_Notifications' ) ) {
 				$body .= esc_html__( 'Notified', 'edit-flow' ) . ': ' . esc_html( $notification_list ) . "\n";
 			}
 
-			$edit_link = htmlspecialchars_decode( get_edit_post_link( $post_id ) );
-			$view_link = htmlspecialchars_decode( get_permalink( $post_id ) );
+			$edit_post_link = get_edit_post_link( $post_id );
+			if ( is_null( $edit_post_link ) ) {
+				return;
+			}
+
+			$edit_link = htmlspecialchars_decode( $edit_post_link );
+
+			$permalink = get_permalink( $post_id );
+			if ( is_null( $permalink ) ) {
+				return;
+			}
+
+			$view_link = htmlspecialchars_decode( $permalink );
 
 			$body .= "\r\n";
 			$body .= __( '== Actions ==', 'edit-flow' ) . "\r\n";

--- a/tests/Integration/NotificationsTest.php
+++ b/tests/Integration/NotificationsTest.php
@@ -52,6 +52,8 @@ class NotificationsTest extends TestCase {
 	function test_send_post_notification_no_status() {
 		global $edit_flow;
 
+		wp_set_current_user( self::$admin_user_id );
+
 		$edit_flow->notifications->module->options->always_notify_admin = 'on';
 
 		$post = array(
@@ -74,6 +76,8 @@ class NotificationsTest extends TestCase {
 	 */
 	function test_send_post_notification_no_status_custom_status_disabled_for_post_type() {
 		global $edit_flow, $typenow;
+
+		wp_set_current_user( self::$admin_user_id );
 
 		/**
 		 * Prevent the registration of custom status to check if notification module will still


### PR DESCRIPTION
## Summary

Fixes the PHP 8.1+ deprecation notice caused by passing `null` to `htmlspecialchars_decode()`:

```
htmlspecialchars_decode(): Passing null to parameter #1 ($string) of type string is deprecated
```

This occurs in the notification callbacks when `get_edit_post_link()` or `get_permalink()` returns `null` (e.g., when the current user lacks permission to view edit links, or during unit tests without a logged-in user).

### Changes

- **`modules/notifications/notifications.php`**: Added null checks before calling `htmlspecialchars_decode()`. If the edit link or permalink is null, the notification callback returns early rather than sending an incomplete email.

- **`tests/Integration/NotificationsTest.php`**: Updated tests to call `wp_set_current_user()` before creating posts, ensuring `get_edit_post_link()` returns a valid URL.

Fixes #771

## Test plan

- [x] Notifications tests pass (2/2)
- [x] All other tests unaffected (pre-existing failures in CustomStatusTest are unrelated)
- [ ] Manual testing: Create a post with no logged-in user and verify no deprecation notice

🤖 Generated with [Claude Code](https://claude.com/claude-code)