### PR TITLE
fix: allow text selection in calendar overlay without triggering drag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Fixed
 
+* fix: allow text selection in calendar overlay without triggering drag by @GaryJones in [#857](https://github.com/Automattic/Edit-Flow/pull/857)
 * fix: update post date to current time when publishing from custom status by @GaryJones in [#856](https://github.com/Automattic/Edit-Flow/pull/856)
 * fix: resolve calendar drag-and-drop not persisting post date changes by @GaryJones in [#854](https://github.com/Automattic/Edit-Flow/pull/854)
 * fix: guard against null return from get_edit_post_link() and get_permalink() by @GaryJones in [#853](https://github.com/Automattic/Edit-Flow/pull/853)

--- a/modules/calendar/lib/calendar.js
+++ b/modules/calendar/lib/calendar.js
@@ -210,6 +210,7 @@ jQuery( document ).ready( function ( $ ) {
 		items: 'li.day-item.sortable',
 		connectWith: 'td.day-unit ul',
 		placeholder: 'ui-state-highlight',
+		cancel: '.item-overlay, .item-overlay *, .post-insert-overlay, .post-insert-overlay *',
 		start( event, ui ) {
 			$( this ).disableSelection();
 			edit_flow_calendar_close_overlays();


### PR DESCRIPTION
## Summary

On the calendar view, when a user opens an overlay to view post details or editorial metadata, they couldn't select text without inadvertently triggering a drag operation that would move the post to another date.

## Changes

Added the `cancel` option to jQuery UI sortable configuration:
```js
cancel: '.item-overlay, .item-overlay *, .post-insert-overlay, .post-insert-overlay *',
```

This excludes overlay elements from initiating drag operations, allowing users to:
- Select and copy text within the expanded post overlay
- Interact with the quick publish dialog without triggering drags
- Click on links and buttons inside overlays normally

## Test plan

1. Go to Edit Flow → Calendar
2. Click on a post to open the overlay
3. Try to select text within the overlay (post title, editorial metadata, etc.)
4. Verify text can be selected without the post being dragged
5. Verify drag-and-drop still works when clicking on the post item itself (outside the overlay)

Fixes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)