### PR TITLE
fix: scope module asset loading to post management pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Fixed
 
+* fix: scope module asset loading to relevant pages only by @GaryJones in [#858](https://github.com/Automattic/Edit-Flow/pull/858)
 * fix: allow text selection in calendar overlay without triggering drag by @GaryJones in [#857](https://github.com/Automattic/Edit-Flow/pull/857)
 * fix: update post date to current time when publishing from custom status by @GaryJones in [#856](https://github.com/Automattic/Edit-Flow/pull/856)
 * fix: resolve calendar drag-and-drop not persisting post date changes by @GaryJones in [#854](https://github.com/Automattic/Edit-Flow/pull/854)

--- a/common/php/class-module.php
+++ b/common/php/class-module.php
@@ -372,16 +372,44 @@ if ( ! class_exists( 'EF_Module' ) ) {
 		}
 
 		/**
-		 * Whether or not the current page is a user-facing Edit Flow View
-		 * @todo Think of a creative way to make this work
+		 * Whether or not the current page is a post management page.
+		 *
+		 * A post management page is where the module's functionality is actually
+		 * needed, such as post editing pages (post.php, post-new.php) or post listing
+		 * pages (edit.php) for supported post types.
 		 *
 		 * @since 0.7
+		 * @since 0.10.0 Actually implemented instead of returning true. Renamed from
+		 *               is_whitelisted_functional_view().
 		 *
-		 * @param string $module_name (Optional) Module name to check against
+		 * @see https://github.com/Automattic/Edit-Flow/issues/351
+		 *
+		 * @param string $module_name (Optional) Module name to check against.
+		 * @return bool Whether the current page is a post management page for the module.
 		 */
-		public function is_whitelisted_functional_view( $module_name = null ) {
+		public function is_post_management_page( $module_name = null ) {
+			global $pagenow, $edit_flow;
 
-			// @todo complete this method
+			// Only load on post editing and listing pages.
+			$functional_pages = [ 'post.php', 'post-new.php', 'edit.php' ];
+			if ( ! in_array( $pagenow, $functional_pages, true ) ) {
+				return false;
+			}
+
+			// Get the current post type.
+			$current_post_type = $this->get_current_post_type();
+			if ( ! $current_post_type ) {
+				return false;
+			}
+
+			// If a module name is specified, check if this post type is supported by that module.
+			if ( $module_name && isset( $edit_flow->modules->$module_name ) ) {
+				$module = $edit_flow->modules->$module_name;
+				$supported_post_types = $this->get_post_types_for_module( $module );
+				if ( ! in_array( $current_post_type, $supported_post_types, true ) ) {
+					return false;
+				}
+			}
 
 			return true;
 		}

--- a/modules/notifications/notifications.php
+++ b/modules/notifications/notifications.php
@@ -194,7 +194,7 @@ if ( ! class_exists( 'EF_Notifications' ) ) {
 		public function enqueue_admin_scripts() {
 			global $post;
 
-			if ( $this->is_whitelisted_functional_view() ) {
+			if ( $this->is_post_management_page( $this->module->name ) ) {
 				wp_enqueue_script( 'jquery-listfilterizer' );
 				wp_enqueue_script( 'edit-flow-notifications-js', $this->module_url . 'lib/notifications.js', [ 'jquery', 'jquery-listfilterizer' ], EDIT_FLOW_VERSION, true );
 
@@ -232,7 +232,7 @@ if ( ! class_exists( 'EF_Notifications' ) ) {
 		 */
 		public function enqueue_admin_styles() {
 
-			if ( $this->is_whitelisted_functional_view() || $this->is_whitelisted_settings_view() ) {
+			if ( $this->is_post_management_page( $this->module->name ) || $this->is_whitelisted_settings_view( $this->module->name ) ) {
 				wp_enqueue_style( 'jquery-listfilterizer' );
 				wp_enqueue_style( 'edit-flow-notifications-css', $this->module->module_url . 'lib/notifications.css', false, EDIT_FLOW_VERSION );
 			}

--- a/modules/user-groups/user-groups.php
+++ b/modules/user-groups/user-groups.php
@@ -229,7 +229,7 @@ if ( ! class_exists( 'EF_User_Groups' ) ) {
 		 */
 		public function enqueue_admin_scripts() {
 
-			if ( $this->is_whitelisted_functional_view() || $this->is_whitelisted_settings_view( $this->module->name ) ) {
+			if ( $this->is_post_management_page( $this->module->name ) || $this->is_whitelisted_settings_view( $this->module->name ) ) {
 				wp_enqueue_script( 'jquery-listfilterizer' );
 				wp_enqueue_script( 'edit-flow-user-groups-js', $this->module_url . 'lib/user-groups.js', array( 'jquery', 'jquery-listfilterizer' ), EDIT_FLOW_VERSION, true );
 			}
@@ -249,7 +249,7 @@ if ( ! class_exists( 'EF_User_Groups' ) ) {
 		public function enqueue_admin_styles() {
 
 
-			if ( $this->is_whitelisted_functional_view() || $this->is_whitelisted_settings_view() ) {
+			if ( $this->is_post_management_page( $this->module->name ) || $this->is_whitelisted_settings_view( $this->module->name ) ) {
 				wp_enqueue_style( 'jquery-listfilterizer' );
 				wp_enqueue_style( 'edit-flow-user-groups-css', $this->module_url . 'lib/user-groups.css', false, EDIT_FLOW_VERSION );
 			}

--- a/tests/Integration/ModuleAssetScopingTest.php
+++ b/tests/Integration/ModuleAssetScopingTest.php
@@ -1,0 +1,208 @@
+<?php
+/**
+ * Tests for scoped module asset loading.
+ *
+ * @package Automattic\EditFlow\Tests\Integration
+ * @see https://github.com/Automattic/edit-flow/issues/351
+ */
+
+declare( strict_types=1 );
+
+namespace Automattic\EditFlow\Tests\Integration;
+
+use EF_Module;
+use Yoast\WPTestUtils\WPIntegration\TestCase;
+
+/**
+ * Test that is_post_management_page() properly scopes asset loading.
+ *
+ * Module assets should only load on pages where the module functionality is needed,
+ * not on every admin page.
+ */
+class ModuleAssetScopingTest extends TestCase {
+
+	protected static $admin_user_id;
+
+	public static function wpSetUpBeforeClass( $factory ) {
+		self::$admin_user_id = $factory->user->create( array( 'role' => 'administrator' ) );
+	}
+
+	public static function wpTearDownAfterClass() {
+		self::delete_user( self::$admin_user_id );
+	}
+
+	protected function setUp(): void {
+		parent::setUp();
+		wp_set_current_user( self::$admin_user_id );
+	}
+
+	/**
+	 * Get a module instance for testing.
+	 *
+	 * @return EF_Module
+	 */
+	protected function get_test_module() {
+		global $edit_flow;
+		// Use notifications module as test subject since it uses is_post_management_page().
+		return $edit_flow->notifications;
+	}
+
+	/**
+	 * Test that is_post_management_page returns false on dashboard.
+	 */
+	public function test_is_post_management_page_returns_false_on_dashboard() {
+		global $pagenow;
+		$pagenow = 'index.php';
+
+		$module = $this->get_test_module();
+		$this->assertFalse(
+			$module->is_post_management_page(),
+			'is_post_management_page() should return false on dashboard'
+		);
+	}
+
+	/**
+	 * Test that is_post_management_page returns false on options page.
+	 */
+	public function test_is_post_management_page_returns_false_on_options() {
+		global $pagenow;
+		$pagenow = 'options-general.php';
+
+		$module = $this->get_test_module();
+		$this->assertFalse(
+			$module->is_post_management_page(),
+			'is_post_management_page() should return false on options page'
+		);
+	}
+
+	/**
+	 * Test that is_post_management_page returns false on plugins page.
+	 */
+	public function test_is_post_management_page_returns_false_on_plugins() {
+		global $pagenow;
+		$pagenow = 'plugins.php';
+
+		$module = $this->get_test_module();
+		$this->assertFalse(
+			$module->is_post_management_page(),
+			'is_post_management_page() should return false on plugins page'
+		);
+	}
+
+	/**
+	 * Test that is_post_management_page returns false on users page.
+	 */
+	public function test_is_post_management_page_returns_false_on_users() {
+		global $pagenow;
+		$pagenow = 'users.php';
+
+		$module = $this->get_test_module();
+		$this->assertFalse(
+			$module->is_post_management_page(),
+			'is_post_management_page() should return false on users page'
+		);
+	}
+
+	/**
+	 * Test that is_post_management_page returns true on post edit page.
+	 */
+	public function test_is_post_management_page_returns_true_on_post_edit() {
+		global $pagenow, $typenow;
+		$pagenow = 'post.php';
+		$typenow = 'post';
+
+		$module = $this->get_test_module();
+		$this->assertTrue(
+			$module->is_post_management_page(),
+			'is_post_management_page() should return true on post.php'
+		);
+	}
+
+	/**
+	 * Test that is_post_management_page returns true on new post page.
+	 */
+	public function test_is_post_management_page_returns_true_on_post_new() {
+		global $pagenow, $typenow;
+		$pagenow = 'post-new.php';
+		$typenow = 'post';
+
+		$module = $this->get_test_module();
+		$this->assertTrue(
+			$module->is_post_management_page(),
+			'is_post_management_page() should return true on post-new.php'
+		);
+	}
+
+	/**
+	 * Test that is_post_management_page returns true on posts list page.
+	 */
+	public function test_is_post_management_page_returns_true_on_edit() {
+		global $pagenow, $typenow;
+		$pagenow = 'edit.php';
+		$typenow = 'post';
+
+		$module = $this->get_test_module();
+		$this->assertTrue(
+			$module->is_post_management_page(),
+			'is_post_management_page() should return true on edit.php'
+		);
+	}
+
+	/**
+	 * Test that is_post_management_page returns true on page edit page.
+	 */
+	public function test_is_post_management_page_returns_true_on_page_edit() {
+		global $pagenow, $typenow;
+		$pagenow = 'post.php';
+		$typenow = 'page';
+
+		$module = $this->get_test_module();
+		$this->assertTrue(
+			$module->is_post_management_page(),
+			'is_post_management_page() should return true on post.php for pages'
+		);
+	}
+
+	/**
+	 * Test that is_post_management_page respects module-specific post types.
+	 */
+	public function test_is_post_management_page_respects_module_post_types() {
+		global $pagenow, $typenow, $edit_flow;
+
+		// Register a custom post type that's NOT supported by the module.
+		register_post_type( 'unsupported_cpt', array( 'public' => true ) );
+
+		$pagenow = 'post.php';
+		$typenow = 'unsupported_cpt';
+
+		$module = $this->get_test_module();
+
+		// When passing module name, it should check if post type is supported.
+		$result = $module->is_post_management_page( $module->module->name );
+
+		// Clean up.
+		unregister_post_type( 'unsupported_cpt' );
+
+		$this->assertFalse(
+			$result,
+			'is_post_management_page() should return false for unsupported post types when module name is passed'
+		);
+	}
+
+	/**
+	 * Test that is_post_management_page without module name still works on supported post types.
+	 */
+	public function test_is_post_management_page_without_module_name() {
+		global $pagenow, $typenow;
+		$pagenow = 'post.php';
+		$typenow = 'post';
+
+		$module = $this->get_test_module();
+
+		// Without module name, it should just check the page type.
+		$this->assertTrue(
+			$module->is_post_management_page(),
+			'is_post_management_page() without module name should return true on post edit pages'
+		);
+	}
+}


### PR DESCRIPTION
## Summary

- Implements `is_post_management_page()` method to properly scope module asset loading
- Module CSS/JS now only loads on post management pages (post.php, post-new.php, edit.php) instead of every admin page
- Optionally validates the current post type is supported by the module before loading assets

## Background

The old `is_whitelisted_functional_view()` method always returned `true` with a `@todo` comment, meaning module assets loaded on every admin page unnecessarily. This caused wasteful resource loading on pages like the dashboard, plugins page, and settings pages where Edit Flow functionality isn't needed.

This takes the simpler "module-by-module" approach suggested in the comments of the previously closed #487, rather than attempting a global change that could break functionality.

## Test plan

- [x] Verify assets load on post.php, post-new.php, edit.php
- [x] Verify assets don't load on dashboard, plugins page, options page, users page
- [x] Verify module-specific post type checking works (assets don't load for unsupported CPTs)
- [x] All 10 new integration tests pass

Closes #351

🤖 Generated with [Claude Code](https://claude.com/claude-code)