### PR TITLE
feat(custom-status): add status migration tool and WP-CLI commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Added
 
+* feat(custom-status): add status migration tool and WP-CLI commands by @GaryJones in [#859](https://github.com/Automattic/Edit-Flow/pull/859)
 * feat(notifications): add Post Author and Auto-subscribed badges by @GaryJones in [#847](https://github.com/Automattic/Edit-Flow/pull/847)
 * feat(story-budget): improve UX with Screen Options and collapsible categories by @GaryJones in [#846](https://github.com/Automattic/Edit-Flow/pull/846)
 

--- a/modules/custom-status/custom-status.php
+++ b/modules/custom-status/custom-status.php
@@ -54,6 +54,7 @@ if ( ! class_exists( 'EF_Custom_Status' ) ) {
 					'term-updated'            => __( 'Post status updated.', 'edit-flow' ),
 					'status-deleted'          => __( 'Post status deleted.', 'edit-flow' ),
 					'status-position-updated' => __( 'Status order updated.', 'edit-flow' ),
+					'status-migrated'         => __( 'Posts migrated successfully.', 'edit-flow' ),
 				],
 				'autoload'              => false,
 				'settings_help_tab'     => [
@@ -71,6 +72,11 @@ if ( ! class_exists( 'EF_Custom_Status' ) ) {
 		 */
 		public function init() {
 			global $edit_flow;
+
+			// Load WP-CLI commands.
+			if ( defined( 'WP_CLI' ) && WP_CLI ) {
+				require_once __DIR__ . '/lib/class-cli.php';
+			}
 
 			// Register custom statuses as a taxonomy
 			$this->register_custom_statuses();
@@ -100,6 +106,7 @@ if ( ! class_exists( 'EF_Custom_Status' ) ) {
 			add_action( 'admin_init', [ $this, 'handle_edit_custom_status' ] );
 			add_action( 'admin_init', [ $this, 'handle_make_default_custom_status' ] );
 			add_action( 'admin_init', [ $this, 'handle_delete_custom_status' ] );
+			add_action( 'admin_init', [ $this, 'handle_migrate_status' ] );
 			add_action( 'wp_ajax_update_status_positions', [ $this, 'handle_ajax_update_status_positions' ] );
 			add_action( 'wp_ajax_inline_save_status', [ $this, 'ajax_inline_save_status' ] );
 
@@ -1052,6 +1059,79 @@ if ( ! class_exists( 'EF_Custom_Status' ) ) {
 		}
 
 		/**
+		 * Handle a POST request to migrate posts between statuses.
+		 *
+		 * @since 0.9.10
+		 */
+		public function handle_migrate_status() {
+			// Check that this is our POST request.
+			if ( ! isset( $_POST['action'] ) || 'migrate' !== $_POST['action'] ) {
+				return;
+			}
+
+			// Verify the page.
+			if ( ! isset( $_GET['page'] ) || $_GET['page'] !== $this->module->settings_slug ) {
+				return;
+			}
+
+			// Check for proper nonce.
+			if ( ! isset( $_POST['_wpnonce'] ) || ! wp_verify_nonce( $_POST['_wpnonce'], 'custom-status-migrate-nonce' ) ) {
+				wp_die( esc_html__( 'Invalid nonce for submission.', 'edit-flow' ) );
+			}
+
+			// Only allow users with the proper caps.
+			if ( ! current_user_can( 'manage_options' ) ) {
+				wp_die( esc_html__( 'Sorry, you do not have permission to migrate posts.', 'edit-flow' ) );
+			}
+
+			$from_status = isset( $_POST['migrate_from'] ) ? sanitize_key( $_POST['migrate_from'] ) : '';
+			$to_status   = isset( $_POST['migrate_to'] ) ? sanitize_key( $_POST['migrate_to'] ) : '';
+
+			// Validate inputs.
+			if ( empty( $from_status ) || empty( $to_status ) ) {
+				wp_die( esc_html__( 'Please select both a source and target status.', 'edit-flow' ) );
+			}
+
+			if ( $from_status === $to_status ) {
+				wp_die( esc_html__( 'Source and target status cannot be the same.', 'edit-flow' ) );
+			}
+
+			// Perform the migration.
+			$this->reassign_post_status( $from_status, $to_status );
+
+			// Clear caches.
+			wp_cache_flush();
+
+			$redirect_url = $this->get_link(
+				[
+					'action'  => 'migrate-status',
+					'message' => 'status-migrated',
+				]
+			);
+			wp_redirect( $redirect_url );
+			exit;
+		}
+
+		/**
+		 * Get count of posts with a specific status.
+		 *
+		 * @since 0.9.10
+		 *
+		 * @param string $status The status slug.
+		 * @return int The number of posts with this status.
+		 */
+		public function get_post_count_for_status( $status ) {
+			global $wpdb;
+
+			return (int) $wpdb->get_var(
+				$wpdb->prepare(
+					"SELECT COUNT(*) FROM {$wpdb->posts} WHERE post_status = %s",
+					$status
+				)
+			);
+		}
+
+		/**
 		 * Generate a link to one of the custom status actions
 		 *
 		 * @since 0.7
@@ -1261,7 +1341,7 @@ if ( ! class_exists( 'EF_Custom_Status' ) ) {
 		 */
 		public function print_configure_view() {
 			// phpcs:ignore WordPress.Security.NonceVerification.Recommended,WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- No verification required for unprivileged URL check.
-			$action = isset( $_GET['action'] ) && in_array( $_GET['action'], [ 'edit-status', 'change-options' ] ) ? $_GET['action'] : '';
+			$action = isset( $_GET['action'] ) && in_array( $_GET['action'], [ 'edit-status', 'change-options', 'migrate-status' ] ) ? $_GET['action'] : '';
 
 			// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- No verification required for unprivileged URL check.
 			$term_id = isset( $_GET['term-id'] ) ? absint( $_GET['term-id'] ) : false;

--- a/modules/custom-status/lib/class-cli.php
+++ b/modules/custom-status/lib/class-cli.php
@@ -1,0 +1,333 @@
+<?php
+/**
+ * WP-CLI commands for Edit Flow Custom Statuses.
+ *
+ * @package EditFlow
+ * @subpackage CustomStatus
+ */
+
+if ( ! defined( 'WP_CLI' ) || ! WP_CLI ) {
+	return;
+}
+
+/**
+ * Manage Edit Flow custom statuses.
+ */
+class EF_Custom_Status_CLI extends WP_CLI_Command {
+
+	/**
+	 * List all custom statuses.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--format=<format>]
+	 * : Output format.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - csv
+	 *   - json
+	 *   - yaml
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     # List all custom statuses
+	 *     $ wp edit-flow custom-status list
+	 *
+	 *     # List statuses as JSON
+	 *     $ wp edit-flow custom-status list --format=json
+	 *
+	 * @subcommand list
+	 *
+	 * @param array $args       Positional arguments.
+	 * @param array $assoc_args Associative arguments.
+	 */
+	public function list_statuses( $args, $assoc_args ) {
+		$custom_status_module = $this->get_custom_status_module();
+
+		if ( ! $custom_status_module ) {
+			WP_CLI::error( 'Custom Status module is not available.' );
+		}
+
+		$statuses = $custom_status_module->get_custom_statuses();
+
+		if ( empty( $statuses ) ) {
+			WP_CLI::warning( 'No custom statuses found.' );
+			return;
+		}
+
+		$items = [];
+		foreach ( $statuses as $status ) {
+			$count   = $this->get_post_count_for_status( $status->slug );
+			$items[] = [
+				'slug'        => $status->slug,
+				'name'        => $status->name,
+				'description' => $status->description,
+				'position'    => $status->position ?? '',
+				'post_count'  => $count,
+			];
+		}
+
+		$format = $assoc_args['format'] ?? 'table';
+
+		WP_CLI\Utils\format_items( $format, $items, [ 'slug', 'name', 'description', 'position', 'post_count' ] );
+	}
+
+	/**
+	 * Migrate posts from one status to another.
+	 *
+	 * ## OPTIONS
+	 *
+	 * --from=<status>
+	 * : The source status slug to migrate from.
+	 *
+	 * --to=<status>
+	 * : The target status slug to migrate to.
+	 *
+	 * [--post-type=<post-type>]
+	 * : Only migrate posts of this type. Default: all supported post types.
+	 *
+	 * [--dry-run]
+	 * : Show what would be migrated without making changes.
+	 *
+	 * [--yes]
+	 * : Skip confirmation prompt.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     # Migrate all posts from 'pitch' to 'draft'
+	 *     $ wp edit-flow custom-status migrate --from=pitch --to=draft
+	 *
+	 *     # Preview migration without making changes
+	 *     $ wp edit-flow custom-status migrate --from=pitch --to=draft --dry-run
+	 *
+	 *     # Migrate only posts of type 'post'
+	 *     $ wp edit-flow custom-status migrate --from=pitch --to=draft --post-type=post
+	 *
+	 * @subcommand migrate
+	 *
+	 * @param array $args       Positional arguments.
+	 * @param array $assoc_args Associative arguments.
+	 */
+	public function migrate( $args, $assoc_args ) {
+		$custom_status_module = $this->get_custom_status_module();
+
+		if ( ! $custom_status_module ) {
+			WP_CLI::error( 'Custom Status module is not available.' );
+		}
+
+		$from_status = $assoc_args['from'] ?? '';
+		$to_status   = $assoc_args['to'] ?? '';
+		$post_type   = $assoc_args['post-type'] ?? '';
+		$dry_run     = isset( $assoc_args['dry-run'] );
+
+		if ( empty( $from_status ) ) {
+			WP_CLI::error( 'Please specify a source status with --from=<status>' );
+		}
+
+		if ( empty( $to_status ) ) {
+			WP_CLI::error( 'Please specify a target status with --to=<status>' );
+		}
+
+		if ( $from_status === $to_status ) {
+			WP_CLI::error( 'Source and target status cannot be the same.' );
+		}
+
+		// Validate target status exists.
+		$valid_statuses = $this->get_all_valid_statuses();
+		if ( ! in_array( $to_status, $valid_statuses, true ) ) {
+			WP_CLI::error( sprintf( "Target status '%s' is not a valid status. Valid statuses: %s", $to_status, implode( ', ', $valid_statuses ) ) );
+		}
+
+		// Get posts with the source status.
+		$query_args = [
+			'post_status'    => $from_status,
+			'posts_per_page' => -1,
+			'fields'         => 'ids',
+		];
+
+		if ( ! empty( $post_type ) ) {
+			$query_args['post_type'] = $post_type;
+		} else {
+			$query_args['post_type'] = 'any';
+		}
+
+		$posts = get_posts( $query_args );
+		$count = count( $posts );
+
+		if ( 0 === $count ) {
+			WP_CLI::success( sprintf( "No posts found with status '%s'.", $from_status ) );
+			return;
+		}
+
+		if ( $dry_run ) {
+			WP_CLI::log( sprintf( "[Dry Run] Would migrate %d post(s) from '%s' to '%s'.", $count, $from_status, $to_status ) );
+
+			if ( $count <= 20 ) {
+				foreach ( $posts as $post_id ) {
+					$post = get_post( $post_id );
+					WP_CLI::log( sprintf( '  - #%d: %s (%s)', $post_id, $post->post_title, $post->post_type ) );
+				}
+			}
+			return;
+		}
+
+		// Confirmation prompt.
+		if ( ! isset( $assoc_args['yes'] ) ) {
+			WP_CLI::confirm( sprintf( "Are you sure you want to migrate %d post(s) from '%s' to '%s'?", $count, $from_status, $to_status ) );
+		}
+
+		// Perform the migration.
+		global $wpdb;
+
+		if ( ! empty( $post_type ) ) {
+			// Migrate only specific post type.
+			$result = $wpdb->query(
+				$wpdb->prepare(
+					"UPDATE {$wpdb->posts} SET post_status = %s WHERE post_status = %s AND post_type = %s",
+					$to_status,
+					$from_status,
+					$post_type
+				)
+			);
+		} else {
+			// Migrate all post types.
+			$result = $wpdb->query(
+				$wpdb->prepare(
+					"UPDATE {$wpdb->posts} SET post_status = %s WHERE post_status = %s",
+					$to_status,
+					$from_status
+				)
+			);
+		}
+
+		// Clear caches.
+		wp_cache_flush();
+		clean_post_cache( $posts );
+
+		WP_CLI::success( sprintf( "Migrated %d post(s) from '%s' to '%s'.", $count, $from_status, $to_status ) );
+	}
+
+	/**
+	 * Get post counts for each status.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--post-type=<post-type>]
+	 * : Only count posts of this type. Default: post.
+	 *
+	 * [--format=<format>]
+	 * : Output format.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - csv
+	 *   - json
+	 *   - yaml
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     # Show post counts per status
+	 *     $ wp edit-flow custom-status counts
+	 *
+	 *     # Show counts for pages
+	 *     $ wp edit-flow custom-status counts --post-type=page
+	 *
+	 * @subcommand counts
+	 *
+	 * @param array $args       Positional arguments.
+	 * @param array $assoc_args Associative arguments.
+	 */
+	public function counts( $args, $assoc_args ) {
+		$post_type = $assoc_args['post-type'] ?? 'post';
+		$format    = $assoc_args['format'] ?? 'table';
+
+		$counts = wp_count_posts( $post_type );
+		$items  = [];
+
+		foreach ( $counts as $status => $count ) {
+			if ( (int) $count > 0 ) {
+				$status_obj = get_post_status_object( $status );
+				$items[]    = [
+					'status' => $status,
+					'label'  => $status_obj ? $status_obj->label : $status,
+					'count'  => (int) $count,
+				];
+			}
+		}
+
+		if ( empty( $items ) ) {
+			WP_CLI::warning( sprintf( 'No posts found for post type: %s', $post_type ) );
+			return;
+		}
+
+		// Sort by count descending.
+		usort( $items, function ( $a, $b ) {
+			return $b['count'] - $a['count'];
+		} );
+
+		WP_CLI\Utils\format_items( $format, $items, [ 'status', 'label', 'count' ] );
+	}
+
+	/**
+	 * Get the custom status module instance.
+	 *
+	 * @return EF_Custom_Status|null
+	 */
+	private function get_custom_status_module() {
+		global $edit_flow;
+
+		if ( isset( $edit_flow->custom_status ) ) {
+			return $edit_flow->custom_status;
+		}
+
+		return null;
+	}
+
+	/**
+	 * Get post count for a specific status.
+	 *
+	 * @param string $status The status slug.
+	 * @return int
+	 */
+	private function get_post_count_for_status( $status ) {
+		global $wpdb;
+
+		return (int) $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT COUNT(*) FROM {$wpdb->posts} WHERE post_status = %s",
+				$status
+			)
+		);
+	}
+
+	/**
+	 * Get all valid status slugs (custom + core).
+	 *
+	 * @return array
+	 */
+	private function get_all_valid_statuses() {
+		$statuses = [];
+
+		// Add core statuses.
+		$core_statuses = [ 'publish', 'pending', 'draft', 'private', 'trash', 'future' ];
+		$statuses      = array_merge( $statuses, $core_statuses );
+
+		// Add custom statuses.
+		$custom_status_module = $this->get_custom_status_module();
+		if ( $custom_status_module ) {
+			$custom_statuses = $custom_status_module->get_custom_statuses();
+			foreach ( $custom_statuses as $status ) {
+				$statuses[] = $status->slug;
+			}
+		}
+
+		return array_unique( $statuses );
+	}
+}
+
+WP_CLI::add_command( 'edit-flow custom-status', 'EF_Custom_Status_CLI' );

--- a/modules/custom-status/views/configure.php
+++ b/modules/custom-status/views/configure.php
@@ -24,6 +24,8 @@ global $edit_flow;
 				<a href="<?php echo esc_url( $this->get_link() ); ?>" class="nav-tab <?php echo esc_attr( $add_new_nav_class ); ?>"><?php esc_html_e( 'Add New', 'edit-flow' ); ?></a>
 				<?php $options_nav_class = 'change-options' === $action ? 'nav-tab-active' : ''; ?>
 				<a href="<?php echo esc_url( $this->get_link( array( 'action' => 'change-options' ) ) ); ?>" class="nav-tab <?php echo esc_attr( $options_nav_class ); ?>"><?php esc_html_e( 'Options', 'edit-flow' ); ?></a>
+				<?php $migrate_nav_class = 'migrate-status' === $action ? 'nav-tab-active' : ''; ?>
+				<a href="<?php echo esc_url( $this->get_link( array( 'action' => 'migrate-status' ) ) ); ?>" class="nav-tab <?php echo esc_attr( $migrate_nav_class ); ?>"><?php esc_html_e( 'Migrate', 'edit-flow' ); ?></a>
 			</h3>
 
 			<?php if ( 'change-options' === $action ) { ?>
@@ -32,6 +34,76 @@ global $edit_flow;
 				<?php do_settings_sections( $this->module->options_group_name ); ?>
 				<input id="edit_flow_module_name" name="edit_flow_module_name" type="hidden" value="<?php echo esc_attr( $this->module->name ); ?>" />
 				<?php submit_button(); ?>
+			</form>
+			<?php } elseif ( 'migrate-status' === $action ) { ?>
+			<!-- Migrate posts between statuses -->
+				<?php
+				$custom_statuses = $this->get_custom_statuses();
+				$core_statuses   = [
+					'draft'   => __( 'Draft', 'edit-flow' ),
+					'pending' => __( 'Pending Review', 'edit-flow' ),
+					'publish' => __( 'Published', 'edit-flow' ),
+					'private' => __( 'Private', 'edit-flow' ),
+					'trash'   => __( 'Trash', 'edit-flow' ),
+				];
+				?>
+			<p class="description" style="margin-bottom: 1em;">
+				<?php esc_html_e( 'Use this tool to migrate posts from one status to another. This is useful when deactivating Edit Flow or consolidating statuses.', 'edit-flow' ); ?>
+			</p>
+			<form action="<?php echo esc_url( $this->get_link( array( 'action' => 'migrate-status' ) ) ); ?>" method="post" id="migrate-status-form">
+				<div class="form-field">
+					<label for="migrate_from"><?php esc_html_e( 'From Status', 'edit-flow' ); ?></label>
+					<select id="migrate_from" name="migrate_from">
+						<option value=""><?php esc_html_e( '— Select Status —', 'edit-flow' ); ?></option>
+						<optgroup label="<?php esc_attr_e( 'Custom Statuses', 'edit-flow' ); ?>">
+							<?php foreach ( $custom_statuses as $status ) : ?>
+								<?php
+								$count = $this->get_post_count_for_status( $status->slug );
+								?>
+								<option value="<?php echo esc_attr( $status->slug ); ?>">
+									<?php echo esc_html( $status->name ); ?> (<?php echo esc_html( $count ); ?>)
+								</option>
+							<?php endforeach; ?>
+						</optgroup>
+						<optgroup label="<?php esc_attr_e( 'Core Statuses', 'edit-flow' ); ?>">
+							<?php foreach ( $core_statuses as $slug => $label ) : ?>
+								<?php
+								$count = $this->get_post_count_for_status( $slug );
+								?>
+								<option value="<?php echo esc_attr( $slug ); ?>">
+									<?php echo esc_html( $label ); ?> (<?php echo esc_html( $count ); ?>)
+								</option>
+							<?php endforeach; ?>
+						</optgroup>
+					</select>
+					<p class="description"><?php esc_html_e( 'Select the status to migrate posts from.', 'edit-flow' ); ?></p>
+				</div>
+
+				<div class="form-field">
+					<label for="migrate_to"><?php esc_html_e( 'To Status', 'edit-flow' ); ?></label>
+					<select id="migrate_to" name="migrate_to">
+						<option value=""><?php esc_html_e( '— Select Status —', 'edit-flow' ); ?></option>
+						<optgroup label="<?php esc_attr_e( 'Custom Statuses', 'edit-flow' ); ?>">
+							<?php foreach ( $custom_statuses as $status ) : ?>
+								<option value="<?php echo esc_attr( $status->slug ); ?>">
+									<?php echo esc_html( $status->name ); ?>
+								</option>
+							<?php endforeach; ?>
+						</optgroup>
+						<optgroup label="<?php esc_attr_e( 'Core Statuses', 'edit-flow' ); ?>">
+							<?php foreach ( $core_statuses as $slug => $label ) : ?>
+								<option value="<?php echo esc_attr( $slug ); ?>">
+									<?php echo esc_html( $label ); ?>
+								</option>
+							<?php endforeach; ?>
+						</optgroup>
+					</select>
+					<p class="description"><?php esc_html_e( 'Select the target status for the posts.', 'edit-flow' ); ?></p>
+				</div>
+
+				<?php wp_nonce_field( 'custom-status-migrate-nonce' ); ?>
+				<input type="hidden" name="action" value="migrate" />
+				<?php submit_button( __( 'Migrate Posts', 'edit-flow' ), 'primary', 'submit', true, array( 'id' => 'migrate-submit' ) ); ?>
 			</form>
 			<?php } else { ?>
 			<!-- Custom form for adding a new Custom Status term -->

--- a/tests/Integration/StatusMigrationTest.php
+++ b/tests/Integration/StatusMigrationTest.php
@@ -1,0 +1,218 @@
+<?php
+/**
+ * Tests for status migration functionality.
+ *
+ * @package Automattic\EditFlow\Tests\Integration
+ * @see https://github.com/Automattic/edit-flow/issues/230
+ */
+
+declare( strict_types=1 );
+
+namespace Automattic\EditFlow\Tests\Integration;
+
+use Yoast\WPTestUtils\WPIntegration\TestCase;
+
+/**
+ * Test status migration functionality.
+ *
+ * Tests both the get_post_count_for_status() helper and the
+ * reassign_post_status() migration method.
+ */
+class StatusMigrationTest extends TestCase {
+
+	protected static $admin_user_id;
+
+	/**
+	 * Custom status module instance.
+	 *
+	 * @var \EF_Custom_Status
+	 */
+	protected $custom_status;
+
+	public static function wpSetUpBeforeClass( $factory ) {
+		self::$admin_user_id = $factory->user->create( array( 'role' => 'administrator' ) );
+	}
+
+	public static function wpTearDownAfterClass() {
+		self::delete_user( self::$admin_user_id );
+	}
+
+	protected function setUp(): void {
+		parent::setUp();
+		wp_set_current_user( self::$admin_user_id );
+
+		global $edit_flow;
+		$this->custom_status = $edit_flow->custom_status;
+	}
+
+	/**
+	 * Test get_post_count_for_status returns correct count.
+	 */
+	public function test_get_post_count_for_status_returns_correct_count() {
+		// Create posts with 'pitch' status.
+		$this->factory()->post->create( array( 'post_status' => 'pitch' ) );
+		$this->factory()->post->create( array( 'post_status' => 'pitch' ) );
+		$this->factory()->post->create( array( 'post_status' => 'pitch' ) );
+
+		$count = $this->custom_status->get_post_count_for_status( 'pitch' );
+
+		$this->assertEquals( 3, $count, 'Should count 3 posts with pitch status' );
+	}
+
+	/**
+	 * Test get_post_count_for_status returns zero for empty status.
+	 */
+	public function test_get_post_count_for_status_returns_zero_for_empty() {
+		$count = $this->custom_status->get_post_count_for_status( 'nonexistent-status' );
+
+		$this->assertEquals( 0, $count, 'Should return 0 for status with no posts' );
+	}
+
+	/**
+	 * Test reassign_post_status migrates posts correctly.
+	 */
+	public function test_reassign_post_status_migrates_posts() {
+		// Create posts with 'pitch' status.
+		$post_id_1 = $this->factory()->post->create( array( 'post_status' => 'pitch' ) );
+		$post_id_2 = $this->factory()->post->create( array( 'post_status' => 'pitch' ) );
+
+		// Migrate from pitch to draft.
+		$this->custom_status->reassign_post_status( 'pitch', 'draft' );
+
+		// Clear caches.
+		clean_post_cache( $post_id_1 );
+		clean_post_cache( $post_id_2 );
+
+		// Verify migration.
+		$this->assertEquals( 'draft', get_post_status( $post_id_1 ), 'Post 1 should be migrated to draft' );
+		$this->assertEquals( 'draft', get_post_status( $post_id_2 ), 'Post 2 should be migrated to draft' );
+	}
+
+	/**
+	 * Test reassign_post_status only affects matching status.
+	 */
+	public function test_reassign_post_status_only_affects_matching_status() {
+		// Create posts with different statuses.
+		$pitch_post    = $this->factory()->post->create( array( 'post_status' => 'pitch' ) );
+		$assigned_post = $this->factory()->post->create( array( 'post_status' => 'assigned' ) );
+		$draft_post    = $this->factory()->post->create( array( 'post_status' => 'draft' ) );
+
+		// Migrate only pitch to pending.
+		$this->custom_status->reassign_post_status( 'pitch', 'pending' );
+
+		// Clear caches.
+		clean_post_cache( $pitch_post );
+		clean_post_cache( $assigned_post );
+		clean_post_cache( $draft_post );
+
+		// Verify only pitch was migrated.
+		$this->assertEquals( 'pending', get_post_status( $pitch_post ), 'Pitch post should be migrated to pending' );
+		$this->assertEquals( 'assigned', get_post_status( $assigned_post ), 'Assigned post should remain unchanged' );
+		$this->assertEquals( 'draft', get_post_status( $draft_post ), 'Draft post should remain unchanged' );
+	}
+
+	/**
+	 * Test reassign_post_status uses default when no target specified.
+	 */
+	public function test_reassign_post_status_uses_default_when_no_target() {
+		// Get the default status first.
+		$default_status = $this->custom_status->get_default_custom_status();
+
+		// Skip if no default status is set.
+		if ( ! $default_status ) {
+			$this->markTestSkipped( 'No default custom status is set in the test environment.' );
+		}
+
+		// Create post with 'assigned' status.
+		$post_id = $this->factory()->post->create( array( 'post_status' => 'assigned' ) );
+
+		// Migrate without specifying target (should use default).
+		$this->custom_status->reassign_post_status( 'assigned' );
+
+		// Clear cache.
+		clean_post_cache( $post_id );
+
+		$this->assertEquals(
+			$default_status->slug,
+			get_post_status( $post_id ),
+			'Post should be migrated to default status when no target specified'
+		);
+	}
+
+	/**
+	 * Test migration works with core statuses.
+	 */
+	public function test_reassign_post_status_works_with_core_statuses() {
+		// Create a draft post.
+		$post_id = $this->factory()->post->create( array( 'post_status' => 'draft' ) );
+
+		// Migrate to pending.
+		$this->custom_status->reassign_post_status( 'draft', 'pending' );
+
+		// Clear cache.
+		clean_post_cache( $post_id );
+
+		$this->assertEquals( 'pending', get_post_status( $post_id ), 'Draft post should be migrated to pending' );
+	}
+
+	/**
+	 * Test migration from custom to core status.
+	 */
+	public function test_reassign_custom_to_core_status() {
+		// Create post with custom status.
+		$post_id = $this->factory()->post->create( array( 'post_status' => 'in-progress' ) );
+
+		// Migrate to core draft status.
+		$this->custom_status->reassign_post_status( 'in-progress', 'draft' );
+
+		// Clear cache.
+		clean_post_cache( $post_id );
+
+		$this->assertEquals( 'draft', get_post_status( $post_id ), 'Custom status post should be migrated to core draft' );
+	}
+
+	/**
+	 * Test get_post_count_for_status counts all post types.
+	 */
+	public function test_get_post_count_for_status_counts_all_post_types() {
+		// Create posts of different types with same status.
+		$this->factory()->post->create( array( 'post_status' => 'pitch', 'post_type' => 'post' ) );
+		$this->factory()->post->create( array( 'post_status' => 'pitch', 'post_type' => 'page' ) );
+
+		$count = $this->custom_status->get_post_count_for_status( 'pitch' );
+
+		$this->assertEquals( 2, $count, 'Should count posts of all types' );
+	}
+
+	/**
+	 * Test handle_migrate_status requires nonce.
+	 */
+	public function test_handle_migrate_status_requires_nonce() {
+		$_POST['action']       = 'migrate';
+		$_GET['page']          = $this->custom_status->module->settings_slug;
+		$_POST['migrate_from'] = 'pitch';
+		$_POST['migrate_to']   = 'draft';
+		// No nonce set.
+
+		$this->expectException( \WPDieException::class );
+		$this->custom_status->handle_migrate_status();
+	}
+
+	/**
+	 * Test handle_migrate_status requires capability.
+	 */
+	public function test_handle_migrate_status_requires_capability() {
+		// Switch to a user without manage_options.
+		$subscriber_id = $this->factory()->user->create( array( 'role' => 'subscriber' ) );
+		wp_set_current_user( $subscriber_id );
+
+		$_POST['action']       = 'migrate';
+		$_GET['page']          = $this->custom_status->module->settings_slug;
+		$_POST['migrate_from'] = 'pitch';
+		$_POST['migrate_to']   = 'draft';
+		$_POST['_wpnonce']     = wp_create_nonce( 'custom-status-migrate-nonce' );
+
+		$this->expectException( \WPDieException::class );
+		$this->custom_status->handle_migrate_status();
+	}
+}


### PR DESCRIPTION
## Summary

Adds tools to migrate posts between statuses, addressing the long-standing issue of posts becoming inaccessible when Edit Flow is deactivated while posts have custom statuses.

- New **Migrate** tab in Custom Status settings with UI to select source and target statuses
- Shows post counts for each status to help users understand the scope of migration
- WP-CLI commands for programmatic/scripted migrations:
  - `wp edit-flow custom-status list` - list all custom statuses with post counts
  - `wp edit-flow custom-status migrate --from=pitch --to=draft` - migrate posts between statuses
  - `wp edit-flow custom-status counts` - show post counts per status for a post type

## Background

When Edit Flow is deactivated, posts with custom statuses (like "pitch", "assigned") remain in the database with those status values, but WordPress no longer recognizes them, making the posts inaccessible.

This adds "service-oriented" tools that allow users to migrate posts to core statuses before deactivating, or to re-enable Edit Flow, migrate posts, and then deactivate again.
<img width="834" height="583" alt="Screenshot 2025-12-22 at 17 21 41" src="https://github.com/user-attachments/assets/690ea0c5-9aa4-44c8-bba0-1a3a87172ea7" />

<img width="834" height="622" alt="Screenshot 2025-12-22 at 17 21 49" src="https://github.com/user-attachments/assets/d6d22c37-ccb8-4c7e-b68c-55d347a254d7" />



## Test plan

- [x] Migrate tab displays correctly with status dropdowns
- [x] Post counts display correctly for each status
- [x] Migration form submits and migrates posts
- [x] WP-CLI `list` command shows all statuses
- [x] WP-CLI `migrate` command migrates posts
- [x] WP-CLI `migrate --dry-run` previews without changes
- [x] WP-CLI `counts` command shows post counts
- [x] All 10 integration tests pass

Closes #230

🤖 Generated with [Claude Code](https://claude.com/claude-code)