### PR TITLE
fix: prevent spurious "Leave site?" warning on new posts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Fixed
 
+* fix: prevent spurious "Leave site?" warning on new posts with custom statuses by @GaryJones in [#860](https://github.com/Automattic/Edit-Flow/pull/860)
 * fix: scope module asset loading to relevant pages only by @GaryJones in [#858](https://github.com/Automattic/Edit-Flow/pull/858)
 * fix: allow text selection in calendar overlay without triggering drag by @GaryJones in [#857](https://github.com/Automattic/Edit-Flow/pull/857)
 * fix: update post date to current time when publishing from custom status by @GaryJones in [#856](https://github.com/Automattic/Edit-Flow/pull/856)

--- a/modules/custom-status/lib/custom-status-block.js
+++ b/modules/custom-status/lib/custom-status-block.js
@@ -24,11 +24,15 @@ subscribe( function () {
 	}
 
 	// For new posts, we need to force the default custom status.
+	// Only update if the current status differs to avoid marking the post as dirty.
 	const isCleanNewPost = select( 'core/editor' ).isCleanNewPost();
 	if ( isCleanNewPost ) {
-		dispatch( 'core/editor' ).editPost( {
-			status: ef_default_custom_status,
-		} );
+		const currentStatus = select( 'core/editor' ).getEditedPostAttribute( 'status' );
+		if ( currentStatus !== ef_default_custom_status ) {
+			dispatch( 'core/editor' ).editPost( {
+				status: ef_default_custom_status,
+			} );
+		}
 	}
 
 	// If the save button exists, let's update the text if needed.


### PR DESCRIPTION
## Summary

Fixes the "Leave site? Changes you made may not be saved" warning appearing immediately on new posts when Custom Statuses is enabled, even when the user hasn't made any changes.

## Root Cause

The block editor's subscribe handler was calling `editPost()` to set the default custom status on every new post. This marked the post as "dirty" (having unsaved changes) even though the user hadn't actually changed anything.

## Solution

Check if the current status already matches the default before calling `editPost()`. This prevents the unnecessary edit that was triggering the dirty state.

```javascript
// Before: Always called editPost()
if ( isCleanNewPost ) {
    dispatch( 'core/editor' ).editPost( { status: ef_default_custom_status } );
}

// After: Only call editPost() if status differs
if ( isCleanNewPost ) {
    const currentStatus = select( 'core/editor' ).getEditedPostAttribute( 'status' );
    if ( currentStatus !== ef_default_custom_status ) {
        dispatch( 'core/editor' ).editPost( { status: ef_default_custom_status } );
    }
}
```

## Test plan

1. Enable Custom Statuses module
2. Create a new post in the block editor
3. Without making any changes, try to close the tab or navigate away
4. Verify no "Leave site?" warning appears
5. Make an actual change, then try to leave - warning should appear

Closes #690

🤖 Generated with [Claude Code](https://claude.com/claude-code)