### PR TITLE
chore: remove unused VIP feature flag setting and related code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Maintenance
 
+* chore: remove unused VIP feature flag setting and related code by @GaryJones in [#862](https://github.com/Automattic/Edit-Flow/pull/862)
 * chore: rename workflow to match plugin standards by @GaryJones in [#850](https://github.com/Automattic/Edit-Flow/pull/850)
 * chore: migrate build system from webpack to wp-scripts by @GaryJones in [#845](https://github.com/Automattic/Edit-Flow/pull/845)
 * chore: simplify ESLint config after eslint-plugin-wpvip fix by @GaryJones in [#844](https://github.com/Automattic/Edit-Flow/pull/844)

--- a/common/php/class-module.php
+++ b/common/php/class-module.php
@@ -47,19 +47,6 @@ if ( ! class_exists( 'EF_Module' ) ) {
 		}
 
 		/**
-		 * Returns whether vip features have been enabled or not.
-		 *
-		 * @since 0.10.0
-		 *
-		 * @return true, if the feature is enabled, false otherwise
-		 */
-		protected function are_vip_features_enabled() {
-			global $edit_flow;
-
-			return 'on' === $edit_flow->settings->module->options->vip_features;
-		}
-
-		/**
 		 * Returns whether analytics has been enabled or not.
 		 *
 		 * It's only enabled if the site is a production WPVIP site.

--- a/modules/settings/settings.php
+++ b/modules/settings/settings.php
@@ -22,7 +22,6 @@ if ( ! class_exists( 'EF_Settings' ) ) {
 				'settings_slug' => 'ef-settings',
 				'default_options' => array(
 					'enabled' => 'on',
-					'vip_features' => $this->is_vip_site() ? 'on' : 'off',
 				),
 				'configure_page_cb' => 'print_default_settings',
 				'autoload' => true,
@@ -35,7 +34,6 @@ if ( ! class_exists( 'EF_Settings' ) ) {
 		 */
 		public function init() {
 			add_action( 'admin_init', array( $this, 'helper_settings_validate_and_save' ), 100 );
-			add_action( 'admin_init', array( $this, 'register_settings' ) );
 
 			add_action( 'admin_print_styles', array( $this, 'action_admin_print_styles' ) );
 			add_action( 'admin_print_scripts', array( $this, 'action_admin_print_scripts' ) );
@@ -155,34 +153,6 @@ if ( ! class_exists( 'EF_Settings' ) ) {
 		}
 
 		/**
-		 * Register settings for notifications so we can partially use the Settings API
-		 * We use the Settings API for form generation, but not saving because we have our
-		 * own way of handling the data.
-		 *
-		 * @since 0.10.0
-		 */
-		public function register_settings() {
-			add_settings_section(
-				$this->module->options_group_name . '_general',
-				__( 'WordPress VIP', 'edit-flow' ),
-				array( $this, 'settings_vip_section_description' ),
-				$this->module->options_group_name
-			);
-			add_settings_field( 'vip_features', __( 'Enable VIP features', 'edit-flow' ), array( $this, 'settings_vip_features_option' ), $this->module->options_group_name, $this->module->options_group_name . '_general' );
-		}
-
-		/**
-		 * Print the description for the VIP features section.
-		 *
-		 * @since 0.10.0
-		 */
-		public function settings_vip_section_description() {
-			echo '<p>';
-			esc_html_e( 'WordPress VIP features provide enhanced editorial workflow capabilities optimised for enterprise environments.', 'edit-flow' );
-			echo '</p>';
-		}
-
-		/**
 		 * Disabling nonce verification because that is not available here, it's just rendering it. The actual save is done in helper_settings_validate_and_save and that's guarded well.
 		 * phpcs:disable:WordPress.Security.NonceVerification.Missing
 		 */
@@ -271,20 +241,6 @@ if ( ! class_exists( 'EF_Settings' ) ) {
 			<?php submit_button(); ?>
 		</form>
 			<?php
-		}
-
-		public function settings_vip_features_option() {
-			$options = array(
-				'off' => __( 'Disabled', 'edit-flow' ),
-				'on' => __( 'Enabled', 'edit-flow' ),
-			);
-			echo '<select id="vip_features" name="' . esc_attr( $this->module->options_group_name ) . '[vip_features]">';
-			foreach ( $options as $value => $label ) {
-				echo '<option value="' . esc_attr( $value ) . '"';
-				echo selected( $this->module->options->vip_features, $value );
-				echo '>' . esc_html( $label ) . '</option>';
-			}
-			echo '</select>';
 		}
 
 		public function print_default_footer( $current_module ) {


### PR DESCRIPTION
## Summary

- Removes the unused VIP feature flag that was added in preparation for repurposing Edit Flow as a workflow plugin for VIP
- This plan was shelved in favour of building vip-workflow-plugin as a new plugin
- The feature flag was never connected to any functionality

## What was removed

- `are_vip_features_enabled()` method from `EF_Module` class
- `vip_features` default option from settings module
- VIP features settings section and toggle from admin UI
- `settings_vip_section_description()` method
- `settings_vip_features_option()` method

## What was kept

- `is_vip_site()` method (still used for analytics feature)

## Test plan

- [ ] Verify the Edit Flow settings page loads without errors
- [ ] Verify no "WordPress VIP" section appears in settings
- [ ] Verify analytics functionality still works on VIP sites (uses `is_vip_site()`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)