### PR TITLE
ci: add PHP lint workflow for syntax and coding standards checks

### DIFF
--- a/.github/workflows/php-lint.yml
+++ b/.github/workflows/php-lint.yml
@@ -1,0 +1,47 @@
+name: PHP Lint
+
+on:
+  pull_request:
+  push:
+    branches-ignore:
+      - develop
+      - main
+
+# Disable all permissions by default; grant minimal permissions per job
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    name: PHP Syntax and Coding Standards
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@9e72090525849c5e82e596468b86eb55e9cc5401 # 2.32.0
+        with:
+          php-version: '8.2'
+          tools: composer, cs2pr
+
+      - name: Install Composer dependencies
+        uses: ramsey/composer-install@3cf229dc2919194e9e36783941438d17239e8520 # 3.1.1
+        with:
+          composer-options: --prefer-dist --no-progress
+
+      - name: PHP syntax lint
+        run: composer lint-ci | cs2pr
+
+      - name: PHP coding standards
+        # continue-on-error until existing violations are addressed
+        continue-on-error: true
+        run: composer cs -- --report=checkstyle | cs2pr


### PR DESCRIPTION
## Summary

- Add PHP syntax linting (`composer lint-ci`) to CI - catches parse errors
- Add PHPCS coding standards check (`composer cs`) - reports violations as PR annotations

## Details

The workflow runs on PRs and pushes, similar to existing workflows.

- **PHP syntax lint**: Blocks on errors (parse errors should never be merged)
- **PHPCS**: Non-blocking (`continue-on-error: true`) since there are existing violations to address over time

This provides visibility into PHP code quality issues via inline PR annotations using `cs2pr`.

## Test Plan

- [ ] Workflow runs successfully on this PR
- [ ] PHPCS violations appear as annotations but don't block merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)