### PR TITLE
docs: move Development section from README to CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,6 +46,43 @@ Here's a sample of what a great summary looks like:
 
 	Screenshots: *screenshot of behavior/error goes here*
 
+Development Setup
+------
+
+This plugin uses `wp-env` for development and is required to run the tests written for the plugin. `wp-env` requires Docker so please ensure you have that installed on your system first. To install `wp-env`, use the following command:
+
+```
+npm -g i @wordpress/env
+```
+
+Read more about `wp-env` [here](https://www.npmjs.com/package/@wordpress/env).
+
+This plugin also uses Composer to manage PHP dependencies. Composer can be downloaded [here](https://getcomposer.org/download/).
+
+###### Getting started
+
+1. Clone the plugin repo: `git clone git@github.com:Automattic/Edit-Flow.git`
+2. Change to cloned directory: `cd /path/to/repo`
+3. Install PHP dependencies: `composer install`
+4. Install NPM dependencies: `npm install`
+5. Start dev environment: `wp-env start`
+
+###### Running tests
+
+Ensure that the dev environment has already been started with `wp-env start`.
+
+**PHP Integration Tests:**
+1. Integration test: `composer run integration`
+2. Multi-site integration test: `composer run integration-ms`
+
+**E2E Tests (Playwright):**
+1. Run E2E tests: `npm run test-e2e`
+2. Run with visible browser: `npm run test-e2e:headed`
+3. Debug mode: `npm run test-e2e:debug`
+
+**JavaScript Tests:**
+1. Run Jest tests: `npm run test-jest`
+
 Creating and submitting Patches
 ------
 

--- a/README.md
+++ b/README.md
@@ -36,42 +36,6 @@ If the automatic process above fails, follow these simple steps to do a manual i
 2. Activate the plugin through the 'Plugins' menu in WordPress
 3. Write and enjoy the merits of a structured editorial workflow!
 
-## Development
-
-This plugin uses `wp-env` for development and is required to run the tests written for the plugin. `wp-env` requires Docker so please ensure you have that installed on your system first. To install `wp-env`, use the following command:
-
-```
-npm -g i @wordpress/env
-```
-
-Read more about `wp-env` [here](https://www.npmjs.com/package/@wordpress/env).
-
-This plugin also uses Composer to manage PHP dependencies. Composer can be downloaded [here](https://getcomposer.org/download/).
-
-### Getting started
-
-1. Clone the plugin repo: `git clone git@github.com:Automattic/Edit-Flow.git`
-2. Changed to cloned directory: `cd /path/to/repo`
-3. Install PHP dependencies: `composer install`
-4. Install NPM dependencies: `npm install`
-5. Start dev environment: `wp-env start`
-
-### Running tests
-
-Ensure that the dev environment has already been started with `wp-env start`.
-
-**PHP Integration Tests:**
-1. Integration test: `composer run integration`
-2. Multi-site integration test: `composer run integration-ms`
-
-**E2E Tests (Playwright):**
-1. Run E2E tests: `npm run test-e2e`
-2. Run with visible browser: `npm run test-e2e:headed`
-3. Debug mode: `npm run test-e2e:debug`
-
-**JavaScript Tests:**
-1. Run Jest tests: `npm run test-jest`
-
 ## Frequently Asked Questions
 
 ### Does Edit Flow work with multisite?


### PR DESCRIPTION
## Summary

Moves the Development section from README.md to CONTRIBUTING.md.

The README.md is used for the WordPress.org plugin page where:
- Development info isn't relevant for end users
- Code fences don't render properly

CONTRIBUTING.md is the appropriate place for developer setup instructions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)