### PR TITLE
ci: optimise CI workflows with path filters and split tests

### DIFF
--- a/.github/workflows/e2e-and-js-tests.yml
+++ b/.github/workflows/e2e-and-js-tests.yml
@@ -1,11 +1,36 @@
 name: E2E and JS tests
 
 on:
-  pull_request:
   push:
-    branches-ignore:
-      - develop
-      - main
+    paths:
+      - '**.js'
+      - '**.jsx'
+      - '**.ts'
+      - '**.tsx'
+      - '**.scss'
+      - '**.css'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'webpack.config.js'
+      - '.wp-env.json'
+      - 'tests/e2e/**'
+      - '.github/workflows/e2e-and-js-tests.yml'
+  pull_request:
+    branches: [develop, main]
+    paths:
+      - '**.js'
+      - '**.jsx'
+      - '**.ts'
+      - '**.tsx'
+      - '**.scss'
+      - '**.css'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'webpack.config.js'
+      - '.wp-env.json'
+      - 'tests/e2e/**'
+      - '.github/workflows/e2e-and-js-tests.yml'
+  workflow_dispatch:
 
 # Disable all permissions by default; grant minimal permissions per job
 permissions: {}

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,4 +1,4 @@
-name: E2E and JS tests
+name: E2E Tests
 
 on:
   push:
@@ -14,7 +14,7 @@ on:
       - 'webpack.config.js'
       - '.wp-env.json'
       - 'tests/e2e/**'
-      - '.github/workflows/e2e-and-js-tests.yml'
+      - '.github/workflows/e2e-tests.yml'
   pull_request:
     branches: [develop, main]
     paths:
@@ -29,7 +29,7 @@ on:
       - 'webpack.config.js'
       - '.wp-env.json'
       - 'tests/e2e/**'
-      - '.github/workflows/e2e-and-js-tests.yml'
+      - '.github/workflows/e2e-tests.yml'
   workflow_dispatch:
 
 # Disable all permissions by default; grant minimal permissions per job
@@ -41,7 +41,7 @@ concurrency:
 
 jobs:
   build:
-    name: Build and Lint
+    name: Build
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -85,9 +85,6 @@ jobs:
           echo "| custom-status-block.js | $(du -h build/custom-status-block.js | cut -f1) |" >> $GITHUB_STEP_SUMMARY
           echo "| calendar-react.js | $(du -h build/calendar-react.js | cut -f1) |" >> $GITHUB_STEP_SUMMARY
 
-      - name: Run Lint JS
-        run: npm run lint-js
-
       - name: Upload build artifacts
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
@@ -96,7 +93,7 @@ jobs:
           retention-days: 1
 
   test:
-    name: E2E and Jest tests
+    name: E2E Tests
     # Pin to ubuntu-22.04 for Playwright compatibility
     # ubuntu-latest (24.04) has library version mismatches with Playwright's WebKit dependencies
     runs-on: ubuntu-22.04
@@ -131,5 +128,5 @@ jobs:
       - name: Install WordPress with wp-env
         run: npm run wp-env start
 
-      - name: Run tests
-        run: npm run test
+      - name: Run E2E tests
+        run: npm run test-e2e

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,11 +1,24 @@
 name: Integration Tests
 
 on:
-  pull_request:
   push:
-    branches-ignore:
-      - develop
-      - main
+    paths:
+      - '**.php'
+      - 'composer.json'
+      - 'composer.lock'
+      - 'phpunit.xml.dist'
+      - '.wp-env.json'
+      - '.github/workflows/integration.yml'
+  pull_request:
+    branches: [develop, main]
+    paths:
+      - '**.php'
+      - 'composer.json'
+      - 'composer.lock'
+      - 'phpunit.xml.dist'
+      - '.wp-env.json'
+      - '.github/workflows/integration.yml'
+  workflow_dispatch:
 
 # Disable all permissions by default; grant minimal permissions per job
 permissions: {}

--- a/.github/workflows/js-tests.yml
+++ b/.github/workflows/js-tests.yml
@@ -1,0 +1,60 @@
+name: JS Tests
+
+on:
+  push:
+    paths:
+      - '**.js'
+      - '**.jsx'
+      - '**.ts'
+      - '**.tsx'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'jest.config.js'
+      - '.github/workflows/js-tests.yml'
+  pull_request:
+    branches: [develop, main]
+    paths:
+      - '**.js'
+      - '**.jsx'
+      - '**.ts'
+      - '**.tsx'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'jest.config.js'
+      - '.github/workflows/js-tests.yml'
+  workflow_dispatch:
+
+# Disable all permissions by default; grant minimal permissions per job
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint-and-test:
+    name: Lint and Jest Tests
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up NodeJS 20
+        uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6.1.0
+        with:
+          node-version: '20'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run Lint JS
+        run: npm run lint-js
+
+      - name: Run Jest tests
+        run: npm run test-jest

--- a/.github/workflows/php-lint.yml
+++ b/.github/workflows/php-lint.yml
@@ -1,11 +1,22 @@
 name: PHP Lint
 
 on:
-  pull_request:
   push:
-    branches-ignore:
-      - develop
-      - main
+    paths:
+      - '**.php'
+      - 'composer.json'
+      - 'composer.lock'
+      - '.phpcs.xml.dist'
+      - '.github/workflows/php-lint.yml'
+  pull_request:
+    branches: [develop, main]
+    paths:
+      - '**.php'
+      - 'composer.json'
+      - 'composer.lock'
+      - '.phpcs.xml.dist'
+      - '.github/workflows/php-lint.yml'
+  workflow_dispatch:
 
 # Disable all permissions by default; grant minimal permissions per job
 permissions: {}


### PR DESCRIPTION
## Summary

- Add path filters to all CI workflows to skip tests for irrelevant changes (e.g., docs-only PRs)
- Split E2E and JS tests into separate workflows for faster feedback

## Changes

### Path Filters
All workflows now only run when relevant files change:
- **integration.yml**: PHP files, composer files, phpunit config
- **php-lint.yml**: PHP files, composer files, PHPCS config
- **e2e-tests.yml**: JS/CSS files, package files, webpack config, E2E tests
- **js-tests.yml**: JS/TS files, package files, Jest config

### Workflow Split
The previous `e2e-and-js-tests.yml` has been split into:
- **js-tests.yml**: Runs ESLint and Jest unit tests (fast, no wp-env needed)
- **e2e-tests.yml**: Runs E2E tests with Playwright (requires wp-env)

This provides faster feedback for pure JS changes since Jest doesn't need the full WordPress environment.

## Test plan
- [ ] Verify docs-only changes don't trigger test workflows
- [ ] Verify JS-only changes trigger js-tests.yml but not integration.yml
- [ ] Verify PHP-only changes trigger php-lint.yml and integration.yml but not js-tests.yml

🤖 Generated with [Claude Code](https://claude.com/claude-code)