### PR TITLE
fix: add missing imports for Extended Post Status block editor panel

### DIFF
--- a/modules/custom-status/lib/custom-status-block.js
+++ b/modules/custom-status/lib/custom-status-block.js
@@ -1,9 +1,11 @@
 import './editor.scss';
 import './style.scss';
 
+import { SelectControl } from '@wordpress/components';
 import { compose } from '@wordpress/compose';
 import { subscribe, dispatch, select } from '@wordpress/data';
 import { withSelect, withDispatch } from '@wordpress/data';
+import { PluginPostStatusInfo } from '@wordpress/editor';
 import { __ } from '@wordpress/i18n';
 import { registerPlugin } from '@wordpress/plugins';
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,3 +1,4 @@
+const path = require( 'path' );
 const defaultConfig = require( '@wordpress/scripts/config/webpack.config' );
 const DependencyExtractionWebpackPlugin = require( '@wordpress/dependency-extraction-webpack-plugin' );
 
@@ -20,7 +21,7 @@ const shouldBundleRequest = ( request ) => {
 
 // Replace the default DependencyExtractionWebpackPlugin with a configured one
 // Return false to explicitly prevent externalization of bundled packages
-const plugins = defaultConfig.plugins.map( ( plugin ) => {
+const calendarPlugins = defaultConfig.plugins.map( ( plugin ) => {
 	if ( plugin.constructor.name === 'DependencyExtractionWebpackPlugin' ) {
 		return new DependencyExtractionWebpackPlugin( {
 			requestToExternal( request ) {
@@ -40,11 +41,33 @@ const plugins = defaultConfig.plugins.map( ( plugin ) => {
 	return plugin;
 } );
 
-module.exports = {
+// Custom status block runs in the block editor where @wordpress packages are
+// available as globals, so use default externalization behavior.
+const customStatusBlockConfig = {
 	...defaultConfig,
 	entry: {
 		'custom-status-block': './modules/custom-status/lib/custom-status-block.js',
+	},
+	output: {
+		...defaultConfig.output,
+		path: path.resolve( __dirname, 'build' ),
+		clean: false,
+	},
+};
+
+// Calendar React needs @wordpress packages bundled since it runs outside
+// the block editor context.
+const calendarReactConfig = {
+	...defaultConfig,
+	entry: {
 		'calendar-react': './modules/calendar/lib/react/calendar.react.js',
 	},
-	plugins,
+	output: {
+		...defaultConfig.output,
+		path: path.resolve( __dirname, 'build' ),
+		clean: false,
+	},
+	plugins: calendarPlugins,
 };
+
+module.exports = [ customStatusBlockConfig, calendarReactConfig ];


### PR DESCRIPTION
## Summary

The "Extended Post Status" dropdown was not appearing in the block editor sidebar when editing posts. This panel allows users to select custom statuses (Pitch, Assigned, In Progress, etc.) instead of the core WordPress statuses.

**Root cause:** `SelectControl` and `PluginPostStatusInfo` were used in `custom-status-block.js` but never imported, causing the `registerPlugin()` call to fail silently.

**Additional fix:** Refactored `webpack.config.js` to use separate configurations:
- `custom-status-block`: Uses default wp-scripts externalization (runs in block editor where @wordpress packages are globals)
- `calendar-react`: Bundles @wordpress packages (runs outside block editor context where globals aren't available)

## Test plan

- [ ] Edit a draft post in the block editor
- [ ] Verify "Extended Post Status" panel appears in the sidebar (below the core Status panel)
- [ ] Verify custom statuses (Pitch, Assigned, In Progress, Draft, Pending Review) appear in the dropdown
- [ ] Verify selecting a custom status works and persists on save
- [ ] Verify the Calendar page still works correctly (uses calendar-react bundle)

🤖 Generated with [Claude Code](https://claude.ai/code)