### PR TITLE
docs: add missing license fields to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ Requires at least: 6.4
 Requires PHP: 7.4  
 Tested up to: 6.9  
 Stable tag: 0.10.3  
+License: GPLv2 or later  
+License URI: https://www.gnu.org/licenses/gpl-2.0.html  
 
 Redefining your editorial workflow.
 


### PR DESCRIPTION
## Summary

WordPress.org flagged the readme as missing license information:

> The License field is missing. A GPLv2 or later compatible license should be specified.

The plugin header in `edit_flow.php` already includes these fields, but the `README.md` (which WordPress.org parses separately for the plugin directory page) was missing them.

## Changes

Adds to README.md header:
- `License: GPLv2 or later`
- `License URI: https://www.gnu.org/licenses/gpl-2.0.html`

## Test plan

- [x] Verify trailing double-spaces preserved for Markdown line breaks