### PR TITLE
Exclude eslint from Dependabot dev-dependencies group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -56,6 +56,8 @@ updates:
           - "eslint*"
           - "prettier*"
           - "@types/*"
+        exclude-patterns:
+          - "eslint"
     labels:
       - "dependencies"
     commit-message:


### PR DESCRIPTION
## Summary

PR #903 bundles an eslint v9-to-v10 major version bump alongside routine WordPress package updates. Because `@automattic/eslint-plugin-wpvip` (up to its latest release, v1.2.0) still requires `peer eslint@"^9.7.0"`, the entire grouped PR fails `npm ci` with an `ERESOLVE` conflict, blocking the otherwise harmless WordPress updates from landing.

This adds an `exclude-patterns` entry for the bare `eslint` package in the npm Dependabot group. The `eslint*` glob still matches eslint plugins (e.g. `eslint-plugin-*`, `eslint-config-*`), so they remain grouped as before. The `eslint` package itself will get its own standalone PR, making the peer dependency conflict visible and isolated rather than blocking unrelated updates.

Once `@automattic/eslint-plugin-wpvip` releases eslint v10 support, the standalone eslint PR will pass CI and can be merged independently.

## Test plan

- [ ] After merging, close #903 so Dependabot regenerates fresh grouped PRs
- [ ] Verify the next Dependabot run creates separate PRs for `eslint` and for the `@wordpress/*` group