### PR TITLE
Update WordPress forums link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Edit Flow empowers you to collaborate with your editorial team inside WordPress.
 
 More details for each feature, screenshots and documentation can be found on [our website](http://editflow.org/).
 
-We'd love to hear from you! For support questions, feedback and ideas, please use the [WordPress.org forums](http://wordpress.org/tags/edit-flow?forum_id=10), which we look at often. If you'd like to contribute code, [we'd love to have you involved](http://editflow.org/contribute/).
+We'd love to hear from you! For support questions, feedback and ideas, please use the [WordPress.org forums](https://wordpress.org/support/plugin/edit-flow/), which we look at often. If you'd like to contribute code, [we'd love to have you involved](http://editflow.org/contribute/).
 
 ## Installation
 
@@ -48,7 +48,7 @@ Yep, in the sense that you can activate Edit Flow on each subsite. Edit Flow doe
 
 All development happens on [GitHub](https://github.com/Automattic/Edit-Flow).
 
-For support questions, feedback and ideas, please use the [WordPress.org forums](http://wordpress.org/tags/edit-flow?forum_id=10), which we look at often. For everything else, say [hello@editflow.org](mailto:hello@editflow.org).
+For support questions, feedback and ideas, please use the [WordPress.org forums](https://wordpress.org/support/plugin/edit-flow/), which we look at often. For everything else, say [hello@editflow.org](mailto:hello@editflow.org).
 
 ## Screenshots
 


### PR DESCRIPTION
## Description

WordPress.org forum links 404. Updating to the correct forum.
