### PR TITLE
Show "Immediately" for custom status posts in block editor

### DIFF
--- a/modules/custom-status/custom-status.php
+++ b/modules/custom-status/custom-status.php
@@ -136,6 +136,7 @@ if ( ! class_exists( 'EF_Custom_Status' ) ) {
 			add_filter( 'wp_insert_post_data', [ $this, 'fix_custom_status_timestamp' ], 10, 2 );
 			add_filter( 'wp_insert_post_data', [ $this, 'maybe_keep_post_name_empty' ], 10, 2 );
 			add_filter( 'wp_insert_post_data', [ $this, 'update_post_date_on_publish_from_custom_status' ], 10, 2 );
+			add_action( 'rest_api_init', [ $this, 'register_rest_api_filters' ] );
 			add_filter( 'pre_wp_unique_post_slug', [ $this, 'fix_unique_post_slug' ], 10, 6 );
 			add_filter( 'preview_post_link', [ $this, 'fix_preview_link_part_one' ] );
 			add_filter( 'post_link', [ $this, 'fix_preview_link_part_two' ], 10, 3 );
@@ -1622,6 +1623,63 @@ if ( ! class_exists( 'EF_Custom_Status' ) ) {
 			$data['post_date_gmt'] = current_time( 'mysql', true );
 
 			return $data;
+		}
+
+		/**
+		 * Register REST API filters for every post type that supports custom statuses.
+		 *
+		 * @since 0.10.4
+		 */
+		public function register_rest_api_filters() {
+			$post_types = $this->get_post_types_for_module( $this->module );
+			foreach ( $post_types as $post_type ) {
+				add_filter( "rest_prepare_{$post_type}", [ $this, 'fix_custom_status_rest_date_gmt' ], 10, 2 );
+			}
+		}
+
+		/**
+		 * Return null for date_gmt in REST responses for posts in a custom status
+		 * whose GMT date has not been explicitly set.
+		 *
+		 * WP core's WP_REST_Posts_Controller::prepare_item_for_response() only returns
+		 * null for date_gmt when a post's status is 'draft' or 'pending'. For any
+		 * other status — including Edit Flow's custom statuses — core converts
+		 * post_date_gmt of '0000-00-00 00:00:00' into a concrete ISO 8601 date derived
+		 * from post_date. The block editor then shows that concrete date in the
+		 * Publish field instead of "Immediately".
+		 *
+		 * This filter restores parity with core's draft/pending behaviour so the
+		 * sidebar accurately reflects that the post has no scheduled publish time.
+		 *
+		 * @since 0.10.4
+		 *
+		 * @see https://github.com/Automattic/edit-flow/issues/925
+		 *
+		 * @param \WP_REST_Response $response The response object.
+		 * @param \WP_Post          $post     Post object.
+		 * @return \WP_REST_Response
+		 */
+		public function fix_custom_status_rest_date_gmt( $response, $post ) {
+			if ( ! $response instanceof \WP_REST_Response ) {
+				return $response;
+			}
+
+			if ( '0000-00-00 00:00:00' !== $post->post_date_gmt ) {
+				return $response;
+			}
+
+			$status_slugs = wp_list_pluck( $this->get_custom_statuses(), 'slug' );
+			if ( ! in_array( $post->post_status, $status_slugs, true ) ) {
+				return $response;
+			}
+
+			$data = $response->get_data();
+			if ( is_array( $data ) && array_key_exists( 'date_gmt', $data ) ) {
+				$data['date_gmt'] = null;
+				$response->set_data( $data );
+			}
+
+			return $response;
 		}
 
 		/**

--- a/modules/custom-status/custom-status.php
+++ b/modules/custom-status/custom-status.php
@@ -1638,18 +1638,25 @@ if ( ! class_exists( 'EF_Custom_Status' ) ) {
 		}
 
 		/**
-		 * Return null for date_gmt in REST responses for posts in a custom status
-		 * whose GMT date has not been explicitly set.
+		 * Return null for date and date_gmt in REST responses for posts in a
+		 * custom status whose GMT date has not been explicitly set.
 		 *
 		 * WP core's WP_REST_Posts_Controller::prepare_item_for_response() only returns
-		 * null for date_gmt when a post's status is 'draft' or 'pending'. For any
-		 * other status — including Edit Flow's custom statuses — core converts
-		 * post_date_gmt of '0000-00-00 00:00:00' into a concrete ISO 8601 date derived
-		 * from post_date. The block editor then shows that concrete date in the
-		 * Publish field instead of "Immediately".
+		 * null for date_gmt when a post's status is 'draft' or 'pending'. Custom
+		 * statuses fall through to the branch that converts post_date_gmt of
+		 * '0000-00-00 00:00:00' into a concrete ISO 8601 date derived from post_date.
 		 *
-		 * This filter restores parity with core's draft/pending behaviour so the
-		 * sidebar accurately reflects that the post has no scheduled publish time.
+		 * Even nulling date_gmt alone is insufficient: Gutenberg's
+		 * isEditedPostDateFloating selector hardcodes the status whitelist to
+		 * 'draft'/'auto-draft'/'pending', so for a custom status it short-circuits
+		 * to false and the Publish field falls back to formatting the concrete date.
+		 * Nulling date as well pushes Gutenberg's label renderer into its
+		 * "Immediately" branch (which triggers when date itself is null) without
+		 * needing to modify core.
+		 *
+		 * The saved post_date in the database is untouched: Gutenberg only sends
+		 * changed fields on save, so a nulled date in the response does not
+		 * propagate back unless the user actively edits the schedule.
 		 *
 		 * @since 0.10.4
 		 *
@@ -1674,10 +1681,18 @@ if ( ! class_exists( 'EF_Custom_Status' ) ) {
 			}
 
 			$data = $response->get_data();
-			if ( is_array( $data ) && array_key_exists( 'date_gmt', $data ) ) {
-				$data['date_gmt'] = null;
-				$response->set_data( $data );
+			if ( ! is_array( $data ) ) {
+				return $response;
 			}
+
+			if ( array_key_exists( 'date_gmt', $data ) ) {
+				$data['date_gmt'] = null;
+			}
+			if ( array_key_exists( 'date', $data ) ) {
+				$data['date'] = null;
+			}
+
+			$response->set_data( $data );
 
 			return $response;
 		}

--- a/tests/Integration/CustomStatusRestApiDateTest.php
+++ b/tests/Integration/CustomStatusRestApiDateTest.php
@@ -1,0 +1,159 @@
+<?php
+/**
+ * Tests for REST API date_gmt serialisation for posts in custom statuses.
+ *
+ * @package Automattic\EditFlow\Tests\Integration
+ * @see https://github.com/Automattic/edit-flow/issues/925
+ */
+
+declare( strict_types=1 );
+
+namespace Automattic\EditFlow\Tests\Integration;
+
+use EF_Custom_Status;
+use Yoast\WPTestUtils\WPIntegration\TestCase;
+
+/**
+ * Test that the REST API returns null for date_gmt on posts in a custom status
+ * whose GMT date has not been explicitly set, matching WP core's handling of
+ * 'draft' and 'pending'. This ensures the block editor shows "Immediately"
+ * rather than a concrete date in the Publish field.
+ */
+class CustomStatusRestApiDateTest extends TestCase {
+
+	protected static $admin_user_id;
+	protected static $ef_custom_status;
+
+	public static function wpSetUpBeforeClass( $factory ) {
+		self::$admin_user_id = $factory->user->create( array( 'role' => 'administrator' ) );
+
+		self::$ef_custom_status = new EF_Custom_Status();
+		self::$ef_custom_status->install();
+		self::$ef_custom_status->init();
+
+		// Ensure our REST filters are registered; rest_api_init only fires once
+		// per REST request boot, so we invoke the registrar directly for tests.
+		self::$ef_custom_status->register_rest_api_filters();
+	}
+
+	public static function wpTearDownAfterClass() {
+		self::delete_user( self::$admin_user_id );
+		self::$ef_custom_status = null;
+	}
+
+	protected function setUp(): void {
+		parent::setUp();
+		wp_set_current_user( self::$admin_user_id );
+	}
+
+	/**
+	 * A post in a custom status with no GMT date set should serialise
+	 * date_gmt as null so the block editor shows "Immediately".
+	 */
+	public function test_custom_status_post_returns_null_date_gmt() {
+		$post_id = self::factory()->post->create(
+			array(
+				'post_status' => 'pitch',
+				'post_author' => self::$admin_user_id,
+				'post_title'  => 'Pitch Post',
+				'post_date'   => '2020-01-15 10:30:00',
+			)
+		);
+
+		$post = get_post( $post_id );
+		$this->assertSame( '0000-00-00 00:00:00', $post->post_date_gmt, 'Precondition: GMT date should be unset.' );
+
+		$data = $this->fetch_rest_item( $post_id );
+
+		$this->assertArrayHasKey( 'date_gmt', $data );
+		$this->assertNull( $data['date_gmt'], 'date_gmt should be null for custom status posts with no GMT date.' );
+	}
+
+	/**
+	 * A published post should keep its concrete date_gmt — our filter must
+	 * not interfere with posts that have real GMT dates.
+	 */
+	public function test_published_post_retains_concrete_date_gmt() {
+		$post_id = self::factory()->post->create(
+			array(
+				'post_status' => 'publish',
+				'post_author' => self::$admin_user_id,
+				'post_title'  => 'Published Post',
+			)
+		);
+
+		$data = $this->fetch_rest_item( $post_id );
+
+		$this->assertNotNull( $data['date_gmt'], 'Published posts should serialise a concrete date_gmt.' );
+	}
+
+	/**
+	 * A draft post should still get null date_gmt — core already handles this,
+	 * and our filter should not change that behaviour.
+	 */
+	public function test_draft_post_still_returns_null_date_gmt() {
+		$post_id = self::factory()->post->create(
+			array(
+				'post_status' => 'draft',
+				'post_author' => self::$admin_user_id,
+				'post_title'  => 'Draft Post',
+				'post_date'   => '2020-01-15 10:30:00',
+			)
+		);
+
+		$data = $this->fetch_rest_item( $post_id );
+
+		$this->assertNull( $data['date_gmt'], 'Core draft behaviour must be preserved.' );
+	}
+
+	/**
+	 * A post in a custom status but with an explicitly set GMT date (e.g. a
+	 * scheduled pitch) should retain that date in the REST response.
+	 */
+	public function test_custom_status_post_with_explicit_gmt_date_is_preserved() {
+		$future_date     = gmdate( 'Y-m-d H:i:s', strtotime( '+1 day' ) );
+		$future_date_gmt = get_gmt_from_date( $future_date );
+
+		$post_id = self::factory()->post->create(
+			array(
+				'post_status'   => 'pitch',
+				'post_author'   => self::$admin_user_id,
+				'post_title'    => 'Scheduled Pitch',
+				'post_date'     => $future_date,
+				'post_date_gmt' => $future_date_gmt,
+			)
+		);
+
+		$data = $this->fetch_rest_item( $post_id );
+
+		$this->assertNotNull( $data['date_gmt'], 'Explicit GMT date should be preserved even for custom statuses.' );
+	}
+
+	/**
+	 * A post in a non-registered status should be untouched by our filter.
+	 */
+	public function test_pending_post_is_unaffected() {
+		$post_id = self::factory()->post->create(
+			array(
+				'post_status' => 'pending',
+				'post_author' => self::$admin_user_id,
+				'post_title'  => 'Pending Post',
+				'post_date'   => '2020-01-15 10:30:00',
+			)
+		);
+
+		$data = $this->fetch_rest_item( $post_id );
+
+		// Core returns null for pending — we're just asserting we didn't break that.
+		$this->assertNull( $data['date_gmt'] );
+	}
+
+	private function fetch_rest_item( int $post_id ): array {
+		$request  = new \WP_REST_Request( 'GET', sprintf( '/wp/v2/posts/%d', $post_id ) );
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertSame( 200, $response->get_status(), 'REST request should succeed.' );
+
+		return $response->get_data();
+	}
+}

--- a/tests/Integration/CustomStatusRestApiDateTest.php
+++ b/tests/Integration/CustomStatusRestApiDateTest.php
@@ -14,10 +14,12 @@ use EF_Custom_Status;
 use Yoast\WPTestUtils\WPIntegration\TestCase;
 
 /**
- * Test that the REST API returns null for date_gmt on posts in a custom status
- * whose GMT date has not been explicitly set, matching WP core's handling of
- * 'draft' and 'pending'. This ensures the block editor shows "Immediately"
- * rather than a concrete date in the Publish field.
+ * Test that the REST API returns null for date and date_gmt on posts in a
+ * custom status whose GMT date has not been explicitly set. Nulling date_gmt
+ * matches WP core's handling of 'draft' and 'pending'; nulling date in
+ * addition is required because Gutenberg's isEditedPostDateFloating selector
+ * hardcodes the status whitelist and would otherwise render the concrete
+ * date in the Publish field instead of "Immediately".
  */
 class CustomStatusRestApiDateTest extends TestCase {
 
@@ -47,10 +49,10 @@ class CustomStatusRestApiDateTest extends TestCase {
 	}
 
 	/**
-	 * A post in a custom status with no GMT date set should serialise
-	 * date_gmt as null so the block editor shows "Immediately".
+	 * A post in a custom status with no GMT date set should serialise both
+	 * date and date_gmt as null so the block editor shows "Immediately".
 	 */
-	public function test_custom_status_post_returns_null_date_gmt() {
+	public function test_custom_status_post_returns_null_dates() {
 		$post_id = self::factory()->post->create(
 			array(
 				'post_status' => 'pitch',
@@ -66,14 +68,16 @@ class CustomStatusRestApiDateTest extends TestCase {
 		$data = $this->fetch_rest_item( $post_id );
 
 		$this->assertArrayHasKey( 'date_gmt', $data );
+		$this->assertArrayHasKey( 'date', $data );
 		$this->assertNull( $data['date_gmt'], 'date_gmt should be null for custom status posts with no GMT date.' );
+		$this->assertNull( $data['date'], 'date should be null so Gutenberg renders "Immediately".' );
 	}
 
 	/**
-	 * A published post should keep its concrete date_gmt — our filter must
+	 * A published post should keep its concrete dates — our filter must
 	 * not interfere with posts that have real GMT dates.
 	 */
-	public function test_published_post_retains_concrete_date_gmt() {
+	public function test_published_post_retains_concrete_dates() {
 		$post_id = self::factory()->post->create(
 			array(
 				'post_status' => 'publish',
@@ -85,6 +89,7 @@ class CustomStatusRestApiDateTest extends TestCase {
 		$data = $this->fetch_rest_item( $post_id );
 
 		$this->assertNotNull( $data['date_gmt'], 'Published posts should serialise a concrete date_gmt.' );
+		$this->assertNotNull( $data['date'], 'Published posts should serialise a concrete date.' );
 	}
 
 	/**
@@ -127,6 +132,7 @@ class CustomStatusRestApiDateTest extends TestCase {
 		$data = $this->fetch_rest_item( $post_id );
 
 		$this->assertNotNull( $data['date_gmt'], 'Explicit GMT date should be preserved even for custom statuses.' );
+		$this->assertNotNull( $data['date'], 'Explicit date should be preserved even for custom statuses.' );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Closes #925.

When a post sits in an Edit Flow custom status (Pitch, Assigned, In Progress, and so on), the block editor's Publish field displays a concrete date like "Today at 2:44 pm" rather than "Immediately". Without Edit Flow active, the same underlying post correctly shows "Immediately" — so this is a regression introduced by the REST API round-trip, not the database layer.

The root cause lives in WP core. `WP_REST_Posts_Controller::prepare_item_for_response()` only returns `null` for `date_gmt` when a post's status is `draft` or `pending`. Any other status — including every Edit Flow custom status — falls through to the branch that converts `0000-00-00 00:00:00` into a concrete ISO 8601 date derived from `post_date`. The block editor reads that value, interprets it literally, and renders the confusing concrete date.

The existing `fix_custom_status_timestamp()` already preserves `0000-00-00 00:00:00` in the database on save, and `update_post_date_on_publish_from_custom_status()` handles the publish transition correctly, so posts do publish at the right time. The bug is purely cosmetic — but it still undermines editorial trust in what the Publish field is telling them.

The fix adds a `rest_prepare_{post_type}` filter, registered for every post type that supports custom statuses, which restores parity with core's draft/pending handling. When the post is in a custom status and `post_date_gmt` is unset, the response's `date_gmt` is nulled so Gutenberg's `PostScheduleLabel` falls back to "Immediately". Posts with an explicitly scheduled GMT date are left alone, and draft/pending posts continue to flow through core's own logic untouched.

A new integration test file (`CustomStatusRestApiDateTest`) covers the happy path plus the obvious regression traps: published posts keeping their concrete date, draft posts still getting null from core, scheduled pitches preserving their explicit GMT date, and pending posts remaining unaffected.

## Test plan

- [x] CI: integration tests and PHP lint pass on the branch
- [ ] Manual: on a fresh WP install with Edit Flow active, create a post and save it with the default "Pitch" status; confirm the block editor sidebar shows "Immediately" rather than a concrete date
- [ ] Manual: schedule a post in a custom status with an explicit future GMT date; confirm that scheduled date is still shown
- [ ] Manual: confirm published posts continue to show their publish date in the sidebar
- [ ] Manual: deactivate Edit Flow and reload the same post; behaviour matches core (unchanged)