### PR TITLE
Require manage_options to add a custom status

### DIFF
--- a/modules/custom-status/custom-status.php
+++ b/modules/custom-status/custom-status.php
@@ -888,6 +888,10 @@ if ( ! class_exists( 'EF_Custom_Status' ) ) {
 				wp_die( esc_html( $this->module->messages['nonce-failed'] ) );
 			}
 
+			if ( ! current_user_can( 'manage_options' ) ) {
+				wp_die( esc_html( $this->module->messages['invalid-permissions'] ) );
+			}
+
 			// Validate and sanitize the form data.
 			// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Sanitized with sanitize_text_field().
 			$status_name = isset( $_POST['status_name'] ) ? sanitize_text_field( trim( $_POST['status_name'] ) ) : '';

--- a/tests/Integration/CustomStatusAddHandlerTest.php
+++ b/tests/Integration/CustomStatusAddHandlerTest.php
@@ -1,0 +1,94 @@
+<?php
+/**
+ * Tests for the handle_add_custom_status admin form handler.
+ *
+ * @package Automattic\EditFlow\Tests\Integration
+ */
+
+declare( strict_types=1 );
+
+namespace Automattic\EditFlow\Tests\Integration;
+
+use Yoast\WPTestUtils\WPIntegration\TestCase;
+
+/**
+ * Test that handle_add_custom_status checks both nonce and capability.
+ */
+class CustomStatusAddHandlerTest extends TestCase {
+
+	protected static $admin_user_id;
+
+	/**
+	 * Custom status module instance.
+	 *
+	 * @var \EF_Custom_Status
+	 */
+	protected $custom_status;
+
+	public static function wpSetUpBeforeClass( $factory ) {
+		self::$admin_user_id = $factory->user->create( array( 'role' => 'administrator' ) );
+	}
+
+	public static function wpTearDownAfterClass() {
+		self::delete_user( self::$admin_user_id );
+	}
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		global $edit_flow;
+		$this->custom_status = $edit_flow->custom_status;
+	}
+
+	protected function tearDown(): void {
+		unset( $_POST['submit'], $_POST['action'], $_POST['status_name'], $_POST['_wpnonce'] );
+		unset( $_GET['page'] );
+
+		parent::tearDown();
+	}
+
+	/**
+	 * A user without manage_options must not be able to add a custom status,
+	 * even with a valid nonce.
+	 */
+	public function test_handle_add_custom_status_requires_capability() {
+		$subscriber_id = $this->factory()->user->create( array( 'role' => 'subscriber' ) );
+		wp_set_current_user( $subscriber_id );
+
+		$_POST['submit']      = 'Add New Status';
+		$_POST['action']      = 'add-new';
+		$_GET['page']         = $this->custom_status->module->settings_slug;
+		$_POST['status_name'] = 'Unauthorised Status';
+		$_POST['_wpnonce']    = wp_create_nonce( 'custom-status-add-nonce' );
+
+		$this->expectException( \WPDieException::class );
+		$this->custom_status->handle_add_custom_status();
+	}
+
+	/**
+	 * An administrator must be able to add a custom status end-to-end.
+	 */
+	public function test_handle_add_custom_status_succeeds_for_admin() {
+		wp_set_current_user( self::$admin_user_id );
+
+		$status_name = 'Security Test Status ' . wp_generate_password( 6, false );
+
+		$_POST['submit']      = 'Add New Status';
+		$_POST['action']      = 'add-new';
+		$_GET['page']         = $this->custom_status->module->settings_slug;
+		$_POST['status_name'] = $status_name;
+		$_POST['_wpnonce']    = wp_create_nonce( 'custom-status-add-nonce' );
+
+		try {
+			$this->custom_status->handle_add_custom_status();
+			// Successful paths end with wp_redirect(); exit. The test framework
+			// may or may not throw depending on configuration, so both outcomes
+			// are acceptable.
+		} catch ( \WPDieException $e ) {
+			$this->fail( 'Admin should not hit wp_die on a valid add request: ' . $e->getMessage() );
+		}
+
+		$status = $this->custom_status->get_custom_status_by( 'slug', sanitize_title( $status_name ) );
+		$this->assertNotFalse( $status, 'Custom status should have been created.' );
+	}
+}


### PR DESCRIPTION
## Summary

`EF_Custom_Status::handle_add_custom_status()` verified the form's nonce but did not re-check the user's capability, leaving the action relying on the surrounding admin page's render-time cap check. That is fragile as defence in depth: a user who obtains a valid `custom-status-add-nonce` (for example through an XSS chain, a shared clipboard, or a leaked form) could submit the handler directly and have a status created on their behalf, even if they lack `manage_options`.

This change adds an explicit `current_user_can( 'manage_options' )` check immediately after the nonce is verified, mirroring the pattern already used by the migrate, edit, and delete handlers in the same class. New integration tests cover both directions: a subscriber with a valid nonce hits `wp_die`, and an administrator can still complete the flow end-to-end.

## Test plan

- [ ] `composer test` — the two new tests in `CustomStatusAddHandlerTest` pass
- [ ] Manually submit the Add Status form as an administrator; the status is created
- [ ] Manually submit the same form as a subscriber (with a forged cap but valid nonce); the request is rejected with the "invalid permissions" message