### PR TITLE
Correct ICS text escaping per RFC 5545

### DIFF
--- a/modules/calendar/calendar.php
+++ b/modules/calendar/calendar.php
@@ -542,7 +542,7 @@ if ( ! class_exists( 'EF_Calendar' ) ) {
 						$formatted_post = array(
 							'BEGIN'         => 'VEVENT',
 							'UID'           => $post->guid,
-							'SUMMARY'       => $this->do_ics_escaping( apply_filters( 'the_title', $post->post_title ) ) . ' - ' . $post_status_obj->label,
+							'SUMMARY'       => $this->do_ics_escaping( apply_filters( 'the_title', $post->post_title ) ) . ' - ' . $this->do_ics_escaping( $post_status_obj->label ),
 							'DTSTART'       => $start_date,
 							'DTEND'         => $end_date,
 							'LAST-MODIFIED' => $last_modified,
@@ -554,7 +554,7 @@ if ( ! class_exists( 'EF_Calendar' ) ) {
 						$formatted_post['DESCRIPTION'] = '';
 						if ( ! empty( $information_fields ) ) {
 							foreach ( $information_fields as $key => $values ) {
-								$formatted_post['DESCRIPTION'] .= $values['label'] . ': ' . $values['value'] . '\n';
+								$formatted_post['DESCRIPTION'] .= $this->do_ics_escaping( $values['label'] ) . ': ' . $this->do_ics_escaping( $values['value'] ) . '\n';
 							}
 							$formatted_post['DESCRIPTION'] = rtrim( $formatted_post['DESCRIPTION'] );
 						}
@@ -626,16 +626,20 @@ if ( ! class_exists( 'EF_Calendar' ) ) {
 		}
 
 		/**
-		 * Perform the encoding necessary for ICS feed text.
+		 * Perform the encoding necessary for ICS feed text per RFC 5545, section 3.3.11.
+		 *
+		 * The backslash must be escaped first, otherwise the backslashes introduced
+		 * by the subsequent replacements would themselves be escaped a second time.
 		 *
 		 * @param string $text The string that needs to be escaped.
 		 * @return string The string after escaping for ICS.
 		 * @since 0.8
 		 */
 		public function do_ics_escaping( $text ) {
-			$text = str_replace( ',', '\,', $text );
-			$text = str_replace( ';', '\:', $text );
 			$text = str_replace( '\\', '\\\\', $text );
+			$text = str_replace( array( "\r\n", "\r", "\n" ), '\n', $text );
+			$text = str_replace( ';', '\;', $text );
+			$text = str_replace( ',', '\,', $text );
 			return $text;
 		}
 

--- a/tests/Integration/CalendarIcsEscapingTest.php
+++ b/tests/Integration/CalendarIcsEscapingTest.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * Tests for ICS text escaping per RFC 5545.
+ *
+ * @package Automattic\EditFlow\Tests\Integration
+ */
+
+declare( strict_types=1 );
+
+namespace Automattic\EditFlow\Tests\Integration;
+
+use Yoast\WPTestUtils\WPIntegration\TestCase;
+
+/**
+ * Test that do_ics_escaping escapes text correctly per RFC 5545, section 3.3.11.
+ */
+class CalendarIcsEscapingTest extends TestCase {
+
+	/**
+	 * Calendar module instance.
+	 *
+	 * @var \EF_Calendar
+	 */
+	protected $calendar;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		global $edit_flow;
+		$this->calendar = $edit_flow->calendar;
+	}
+
+	/**
+	 * A comma must be escaped as "\,".
+	 */
+	public function test_escapes_comma() {
+		$this->assertSame( 'one\,two', $this->calendar->do_ics_escaping( 'one,two' ) );
+	}
+
+	/**
+	 * A semicolon must be escaped as "\;" — not "\:".
+	 */
+	public function test_escapes_semicolon() {
+		$this->assertSame( 'one\;two', $this->calendar->do_ics_escaping( 'one;two' ) );
+	}
+
+	/**
+	 * A backslash must be escaped as "\\".
+	 */
+	public function test_escapes_backslash() {
+		$this->assertSame( 'one\\\\two', $this->calendar->do_ics_escaping( 'one\\two' ) );
+	}
+
+	/**
+	 * Newlines must be escaped as "\n" to avoid breaking the feed structure.
+	 */
+	public function test_escapes_newlines() {
+		$this->assertSame( 'a\nb\nc\nd', $this->calendar->do_ics_escaping( "a\nb\rc\r\nd" ) );
+	}
+
+	/**
+	 * Backslashes must be escaped first so the escape character introduced by
+	 * subsequent replacements is not itself doubled.
+	 */
+	public function test_does_not_double_escape_inserted_backslashes() {
+		$this->assertSame( '\,', $this->calendar->do_ics_escaping( ',' ) );
+		$this->assertSame( '\;', $this->calendar->do_ics_escaping( ';' ) );
+		$this->assertSame( '\n', $this->calendar->do_ics_escaping( "\n" ) );
+	}
+
+	/**
+	 * A plain text string with none of the special characters must pass through untouched.
+	 */
+	public function test_plain_text_is_unchanged() {
+		$this->assertSame( 'Hello world', $this->calendar->do_ics_escaping( 'Hello world' ) );
+	}
+
+	/**
+	 * All escapable characters combined must be escaped together.
+	 */
+	public function test_combined_special_characters() {
+		$input    = "Status: pending, draft; notes\\ with\nnewline";
+		$expected = 'Status: pending\, draft\; notes\\\\ with\nnewline';
+		$this->assertSame( $expected, $this->calendar->do_ics_escaping( $input ) );
+	}
+}


### PR DESCRIPTION
## Summary

The calendar module's ICS subscription feed had three long-standing escaping bugs that could produce invalid `.ics` output for any event text containing common punctuation or user-supplied content.

`do_ics_escaping()` replaced semicolons with backslash-colon rather than the RFC 5545 backslash-semicolon sequence, so any event text containing a semicolon produced an invalid escape. The same function escaped backslashes as its final step, which meant the backslashes it had just inserted whilst escaping commas and semicolons were themselves doubled on the second pass, corrupting the output for any string that contained those characters. Newlines were not escaped at all, so a stray LF in a post title, taxonomy term or metadata field would terminate the line and break every calendar client's parse of the remainder of the feed.

Two call sites in `handle_ics_subscription()` also bypassed the escaper entirely. The SUMMARY field concatenated the post status label directly, and the DESCRIPTION field concatenated the label and value of every information field without passing them through. Since taxonomy term names, custom status labels, and filter-supplied field values can all contain any of the special characters, the only safe option is to escape them.

The fix reorders `do_ics_escaping()` to match RFC 5545 section 3.3.11 (escape backslashes first, then newlines, then semicolons, then commas) and routes the previously-unescaped call sites through it. New tests pin the escaper's behaviour across each character class and their combination so any future regression is caught immediately.

## Test plan

- [ ] `composer test:integration` — the new `CalendarIcsEscapingTest` cases pass
- [ ] Subscribe to a calendar that includes a post whose title contains a comma, semicolon, backslash or newline, and verify the resulting `.ics` feed parses cleanly in a calendar client