### PR TITLE
Stop double-escaping editorial comment fields

### DIFF
--- a/modules/editorial-comments/editorial-comments.php
+++ b/modules/editorial-comments/editorial-comments.php
@@ -366,12 +366,14 @@ if ( ! class_exists( 'EF_Editorial_Comments' ) ) {
 				// Set current time.
 				$time = current_time( 'mysql', $gmt = 0 );
 
-				// Set comment data.
+				// Set comment data. wp_insert_comment() runs every value through
+				// wpdb->prepare() internally, so callers must not pre-escape;
+				// doing so stores the literal escape sequences in the database.
 				$data = array(
 					'comment_post_ID'      => (int) $post_id,
-					'comment_author'       => esc_sql( $current_user->display_name ),
-					'comment_author_email' => esc_sql( $current_user->user_email ),
-					'comment_author_url'   => esc_sql( $current_user->user_url ),
+					'comment_author'       => $current_user->display_name,
+					'comment_author_email' => $current_user->user_email,
+					'comment_author_url'   => $current_user->user_url,
 					'comment_content'      => wp_kses( $comment_content, array(
 						'a'          => array(
 							'href'  => array(),
@@ -390,12 +392,10 @@ if ( ! class_exists( 'EF_Editorial_Comments' ) ) {
 					'comment_type'         => self::comment_type,
 					'comment_parent'       => (int) $parent,
 					'user_id'              => (int) $user_ID,
-					// This is just used for logging in the DB, and it's been escaped as well.
-					// phpcs:ignore WordPressVIPMinimum.Variables.ServerVariables.UserControlledHeaders, WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___SERVER__REMOTE_ADDR__, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-					'comment_author_IP'    => isset( $_SERVER['REMOTE_ADDR'] ) ? esc_sql( $_SERVER['REMOTE_ADDR'] ) : '',
-					// This is just used for logging in the DB, and it's been escaped as well.
-					// phpcs:ignore WordPressVIPMinimum.Variables.ServerVariables.UserControlledHeaders, WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___SERVER__HTTP_USER_AGENT__, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-					'comment_agent'        => isset( $_SERVER['HTTP_USER_AGENT'] ) ? esc_sql( $_SERVER['HTTP_USER_AGENT'] ) : '',
+					// phpcs:ignore WordPressVIPMinimum.Variables.ServerVariables.UserControlledHeaders, WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___SERVER__REMOTE_ADDR__
+					'comment_author_IP'    => isset( $_SERVER['REMOTE_ADDR'] ) ? sanitize_text_field( wp_unslash( $_SERVER['REMOTE_ADDR'] ) ) : '',
+					// phpcs:ignore WordPressVIPMinimum.Variables.ServerVariables.UserControlledHeaders, WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___SERVER__HTTP_USER_AGENT__
+					'comment_agent'        => isset( $_SERVER['HTTP_USER_AGENT'] ) ? sanitize_text_field( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) ) : '',
 					'comment_date'         => $time,
 					'comment_date_gmt'     => $time,
 					// Set to -1?

--- a/tests/Integration/EditorialCommentsAjaxTest.php
+++ b/tests/Integration/EditorialCommentsAjaxTest.php
@@ -169,4 +169,46 @@ class EditorialCommentsAjaxTest extends AjaxTestCase {
 		$this->expectException( WPAjaxDieStopException::class );
 		$this->_handleAjax( 'editflow_ajax_insert_comment' );
 	}
+
+	/**
+	 * Test: Author display name with a special character is stored verbatim.
+	 *
+	 * Regression: the handler previously passed the display name through
+	 * esc_sql() before handing it to wp_insert_comment(), which itself escapes
+	 * via $wpdb->prepare(). The double escape meant a name like "O'Brien" was
+	 * persisted as "O\'Brien".
+	 */
+	public function test_insert_comment_does_not_double_escape_author_name(): void {
+		$author_user_id = $this->factory->user->create( array(
+			'role'         => 'author',
+			'display_name' => "O'Brien",
+		) );
+		wp_set_current_user( $author_user_id );
+
+		$post_id = $this->factory->post->create( array(
+			'post_status' => 'draft',
+			'post_author' => $author_user_id,
+		) );
+
+		$_POST['_nonce']  = wp_create_nonce( 'comment' );
+		$_POST['post_id'] = $post_id;
+		$_POST['parent']  = 0;
+		$_POST['content'] = 'Comment from O\'Brien';
+
+		global $current_user, $user_ID;
+		$current_user = wp_get_current_user();
+		$user_ID      = $author_user_id;
+
+		try {
+			$this->_handleAjax( 'editflow_ajax_insert_comment' );
+		} catch ( WPAjaxDieContinueException $e ) {
+			unset( $e );
+		}
+
+		preg_match( '/<comment id=\'(\d+)\'/', $this->_last_response, $matches );
+		$this->assertNotEmpty( $matches, 'Comment ID should be extracted from response.' );
+
+		$comment = get_comment( (int) $matches[1] );
+		$this->assertSame( "O'Brien", $comment->comment_author, 'Author should be stored verbatim without escape sequences.' );
+	}
 }


### PR DESCRIPTION
## Summary

When a user added an editorial comment, five fields on the comment — author name, email, URL, IP address and user agent — were passed through `esc_sql()` before being handed to `wp_insert_comment()`. That function already escapes every value via `$wpdb->prepare()`, so the pre-escape was applied a second time and the literal backslash-quote sequences from the first pass were stored as data in the comments table.

The most visible symptom was an author whose display name contained an apostrophe. "O'Brien" appeared on their editorial comment as "O\'Brien", and the same corruption silently affected comment author email, URL, IP and user agent. The `WordPress.Security.ValidatedSanitizedInput.InputNotSanitized` phpcs notice on the two `$_SERVER` lines had gradually cemented the belief that `esc_sql()` was a sanitisation step; it is not.

Removing `esc_sql()` from all five fields is the correct fix. The two `$_SERVER` values retain a light sanitisation via `sanitize_text_field( wp_unslash( ... ) )` so phpcs's input-not-sanitised rule is satisfied without reintroducing the double escape. A regression test pins the behaviour: a user whose display name contains an apostrophe must have that apostrophe stored verbatim on their editorial comment.

## Test plan

- [ ] `composer test:integration` — the new `test_insert_comment_does_not_double_escape_author_name` case passes, and the existing editorial-comments AJAX tests continue to pass
- [ ] Create a user with a display name like "O'Brien" and add an editorial comment from them; the comment author on the resulting comment should read "O'Brien", not "O\'Brien"