### PR TITLE
Harden calendar trashed-message Undo URL construction

### DIFF
--- a/modules/calendar/calendar.php
+++ b/modules/calendar/calendar.php
@@ -826,8 +826,8 @@ if ( ! class_exists( 'EF_Calendar' ) ) {
 					// Only build an Undo link from strictly-numeric ids; a
 					// user-crafted value must not be able to inject extra
 					// query arguments into the resulting URL.
-					$ids_raw  = isset( $_GET['ids'] ) ? wp_unslash( $_GET['ids'] ) : '';
-					$pid_list = array_values( array_filter( array_map( 'absint', explode( ',', (string) $ids_raw ) ) ) );
+					$ids_raw  = isset( $_GET['ids'] ) ? sanitize_text_field( wp_unslash( $_GET['ids'] ) ) : '';
+					$pid_list = array_values( array_filter( array_map( 'absint', explode( ',', $ids_raw ) ) ) );
 					if ( ! empty( $pid_list ) ) {
 						$post_type = get_post_type( $pid_list[0] );
 						if ( $post_type && post_type_exists( $post_type ) ) {

--- a/modules/calendar/calendar.php
+++ b/modules/calendar/calendar.php
@@ -815,25 +815,44 @@ if ( ! class_exists( 'EF_Calendar' ) ) {
 
 			<?php
 				// Handle posts that have been trashed or untrashed.
-				// phpcs:disable WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- These GET params are set by WordPress core's trash/untrash actions.
+				// phpcs:disable WordPress.Security.NonceVerification.Recommended -- These GET params are set by WordPress core's trash/untrash actions.
 			if ( isset( $_GET['trashed'] ) || isset( $_GET['untrashed'] ) ) {
 				echo '<div id="trashed-message" class="updated"><p>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 				if ( isset( $_GET['trashed'] ) && (int) $_GET['trashed'] ) {
+					$trashed_count = (int) $_GET['trashed'];
 					/* translators: %d: number of posts trashed */
-					echo esc_html( sprintf( _n( '%d post moved to the trash.', '%d posts moved to the trash.', $_GET['trashed'], 'edit-flow' ), number_format_i18n( $_GET['trashed'] ) ) );
-					$ids       = isset( $_GET['ids'] ) ? $_GET['ids'] : 0;
-					$pid       = explode( ',', $ids );
-					$post_type = get_post_type( $pid[0] );
-					echo ' <a href="' . esc_url( wp_nonce_url( "edit.php?post_type=$post_type&doaction=undo&action=untrash&ids=$ids", 'bulk-posts' ) ) . '">' . esc_html__( 'Undo', 'edit-flow' ) . '</a><br />';
+					echo esc_html( sprintf( _n( '%d post moved to the trash.', '%d posts moved to the trash.', $trashed_count, 'edit-flow' ), number_format_i18n( $trashed_count ) ) );
+
+					// Only build an Undo link from strictly-numeric ids; a
+					// user-crafted value must not be able to inject extra
+					// query arguments into the resulting URL.
+					$ids_raw  = isset( $_GET['ids'] ) ? wp_unslash( $_GET['ids'] ) : '';
+					$pid_list = array_values( array_filter( array_map( 'absint', explode( ',', (string) $ids_raw ) ) ) );
+					if ( ! empty( $pid_list ) ) {
+						$post_type = get_post_type( $pid_list[0] );
+						if ( $post_type && post_type_exists( $post_type ) ) {
+							$undo_url = add_query_arg(
+								array(
+									'post_type' => $post_type,
+									'doaction'  => 'undo',
+									'action'    => 'untrash',
+									'ids'       => implode( ',', $pid_list ),
+								),
+								admin_url( 'edit.php' )
+							);
+							echo ' <a href="' . esc_url( wp_nonce_url( $undo_url, 'bulk-posts' ) ) . '">' . esc_html__( 'Undo', 'edit-flow' ) . '</a><br />';
+						}
+					}
 					unset( $_GET['trashed'] );
 				}
 				if ( isset( $_GET['untrashed'] ) && (int) $_GET['untrashed'] ) {
+					$untrashed_count = (int) $_GET['untrashed'];
 					/* translators: %d: number of posts restored */
-					echo esc_html( sprintf( _n( '%d post restored from the Trash.', '%d posts restored from the Trash.', $_GET['untrashed'], 'edit-flow' ), number_format_i18n( $_GET['untrashed'] ) ) );
-					unset( $_GET['undeleted'] );
+					echo esc_html( sprintf( _n( '%d post restored from the Trash.', '%d posts restored from the Trash.', $untrashed_count, 'edit-flow' ), number_format_i18n( $untrashed_count ) ) );
+					unset( $_GET['untrashed'] );
 				}
 				echo '</p></div>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-				// phpcs:enable WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+				// phpcs:enable WordPress.Security.NonceVerification.Recommended
 			}
 			?>
 


### PR DESCRIPTION
## Summary

The calendar view renders a "post moved to the trash" notice with an Undo link when the admin arrives with `?trashed=N&ids=...` in the URL. That notice was built by interpolating the raw `\$_GET['ids']` value straight into the link's href, deriving the post type from the first comma-separated value, and leaning on `esc_url()` to make the result safe.

`esc_url()` only makes a URL safe to emit into HTML — it escapes the ampersand for HTML context so that reading the href in the source shows `&amp;`, but it does not URL-encode values inside the query string. A crafted request like `?trashed=1&ids=1%26action%3Dmalicious` would therefore produce an Undo link whose query string contained an injected `action=malicious` parameter alongside `ids=1`. The post type, read from the first value in the list with no validation, could similarly be any arbitrary string.

The fix pushes every id through `absint()`, reassembles the list from the resulting integers, and only proceeds when `post_type_exists()` confirms the derived post type is real. The URL itself is then built with `add_query_arg()` so the `&` separator can never originate from user input. As tidying whilst in the file, the count values for both branches are cast to `int` once and reused, a stray `unset( \$_GET['undeleted'] )` is corrected to the parameter the branch actually guards on (`untrashed`), and the `ValidatedSanitizedInput` phpcs suppression is dropped now that sanitisation happens in code rather than by comment.

## Test plan

- [ ] Trash a post from the calendar view; confirm the "moved to the trash" notice renders with a working Undo link
- [ ] Manually append `&ids=1%26action%3Dmalicious` to a `?trashed=1` calendar URL and confirm the rendered Undo link carries only a clean `ids=1` value and a registered post type
- [ ] Untrash from the Undo link and confirm the "restored from the Trash" notice renders correctly