### PR TITLE
Strip HTML from filter-supplied editorial metadata CSS

### DIFF
--- a/modules/editorial-metadata/editorial-metadata.php
+++ b/modules/editorial-metadata/editorial-metadata.php
@@ -318,7 +318,8 @@ if ( ! class_exists( 'EF_Editorial_Metadata' ) ) {
 					}
 					// Allow users to filter out rules if there's something wonky.
 					$css_rules = apply_filters( 'ef_editorial_metadata_manage_posts_css_rules', $css_rules );
-					echo "<style type=\"text/css\">\n";
+
+					$css_lines = array();
 					foreach ( (array) $css_rules as $css_property => $rules ) {
 						// Strip any HTML tags that a misbehaving filter hook may have
 						// smuggled into the selector or declarations; this prevents
@@ -326,10 +327,9 @@ if ( ! class_exists( 'EF_Editorial_Metadata' ) ) {
 						// style block into arbitrary HTML.
 						$safe_property = wp_strip_all_tags( (string) $css_property );
 						$safe_rules    = implode( ' ', array_map( 'wp_strip_all_tags', (array) $rules ) );
-						// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Property and rules are stripped of HTML above; this is CSS, not HTML, so esc_html would mangle valid syntax.
-						echo $safe_property . ' {' . $safe_rules . "}\n ";
+						$css_lines[]   = $safe_property . ' {' . $safe_rules . '}';
 					}
-					echo '</style>';
+					wp_add_inline_style( 'edit_flow-editorial_metadata-styles', implode( "\n", $css_lines ) );
 				}
 			}
 

--- a/modules/editorial-metadata/editorial-metadata.php
+++ b/modules/editorial-metadata/editorial-metadata.php
@@ -320,8 +320,14 @@ if ( ! class_exists( 'EF_Editorial_Metadata' ) ) {
 					$css_rules = apply_filters( 'ef_editorial_metadata_manage_posts_css_rules', $css_rules );
 					echo "<style type=\"text/css\">\n";
 					foreach ( (array) $css_rules as $css_property => $rules ) {
-						// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- This is for the escaping of the CSS property and rules.
-						echo $css_property . ' {' . implode( ' ', $rules ) . "}\n ";
+						// Strip any HTML tags that a misbehaving filter hook may have
+						// smuggled into the selector or declarations; this prevents
+						// an injected `</style>` sequence from breaking out of the
+						// style block into arbitrary HTML.
+						$safe_property = wp_strip_all_tags( (string) $css_property );
+						$safe_rules    = implode( ' ', array_map( 'wp_strip_all_tags', (array) $rules ) );
+						// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Property and rules are stripped of HTML above; this is CSS, not HTML, so esc_html would mangle valid syntax.
+						echo $safe_property . ' {' . $safe_rules . "}\n ";
 					}
 					echo '</style>';
 				}


### PR DESCRIPTION
## Summary

Editorial Metadata builds a small CSS block to give each of its manage-posts columns a sensible minimum width. The rules are assembled into a `\$css_rules` array, passed through the `ef_editorial_metadata_manage_posts_css_rules` filter, then echoed inside a `<style>` block with no escaping. For Edit Flow's own defaults the output is safe, but because the filter allows arbitrary modification there's nothing stopping a misbehaving plugin or theme from slipping a literal `</style>` sequence into a selector or declaration — and that would break out of the style block and let whatever followed it be parsed as HTML in the admin.

This PR runs both the selector and each declaration through `wp_strip_all_tags()` before echoing them. That removes any HTML tag a filter callback may have introduced, including the `</style>` breakout, whilst leaving valid CSS syntax intact. `esc_html()` would achieve the same breakout protection but would also encode quotes and ampersands, corrupting any legitimate `url("…")` declarations a plugin might have added via the same filter.

## Test plan

- [ ] Load Posts or Pages with Editorial Metadata columns enabled and confirm the min-width rules still apply as before
- [ ] Register a throw-away callback on `ef_editorial_metadata_manage_posts_css_rules` that returns a rule containing `</style><script>alert(1)</script>`; confirm the rendered style block contains neither the `</style>` nor the script tag