### PR TITLE
Validate metadata term in calendar AJAX update handler

### DIFF
--- a/modules/calendar/calendar.php
+++ b/modules/calendar/calendar.php
@@ -1777,17 +1777,21 @@ if ( ! class_exists( 'EF_Calendar' ) ) {
 			$metadata_types = array_keys( EditFlow()->editorial_metadata->get_supported_metadata_types() );
 
 			// Update an editorial metadata field.
-			// phpcs:disable WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Values are sanitized below before use.
-			$metadata_term           = isset( $_POST['metadata_term'] ) ? $_POST['metadata_term'] : '';
-			$metadata_type           = isset( $_POST['metadata_type'] ) ? $_POST['metadata_type'] : '';
-			$incoming_metadata_value = isset( $_POST['metadata_value'] ) ? $_POST['metadata_value'] : '';
-			// phpcs:enable WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+			$metadata_term = isset( $_POST['metadata_term'] ) ? sanitize_text_field( wp_unslash( $_POST['metadata_term'] ) ) : '';
+			$metadata_type = isset( $_POST['metadata_type'] ) ? sanitize_text_field( wp_unslash( $_POST['metadata_type'] ) ) : '';
+			// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Value is sanitized below based on metadata type.
+			$incoming_metadata_value = isset( $_POST['metadata_value'] ) ? wp_unslash( $_POST['metadata_value'] ) : '';
 
-			if ( isset( $_POST['metadata_type'] ) && in_array( $_POST['metadata_type'], $metadata_types ) ) {
-				$post_meta_key = sanitize_text_field( '_ef_editorial_meta_' . $_POST['metadata_type'] . '_' . $metadata_term );
+			if ( in_array( $metadata_type, $metadata_types, true ) ) {
+				// Validate the term slug refers to an existing editorial metadata term before using it in a meta key.
+				if ( '' === $metadata_term || ! EditFlow()->editorial_metadata->get_editorial_metadata_term_by( 'slug', $metadata_term ) ) {
+					$this->print_ajax_response( 'error', $this->module->messages['update-error'] );
+				}
+
+				$post_meta_key = '_ef_editorial_meta_' . $metadata_type . '_' . $metadata_term;
 
 				// Javascript date parsing is terrible, so use strtotime in PHP.
-				if ( 'date' == $metadata_type ) {
+				if ( 'date' === $metadata_type ) {
 					$metadata_value = strtotime( sanitize_text_field( $incoming_metadata_value ) );
 				} else {
 					$metadata_value = sanitize_text_field( $incoming_metadata_value );
@@ -1796,8 +1800,12 @@ if ( ! class_exists( 'EF_Calendar' ) ) {
 				update_post_meta( $post->ID, $post_meta_key, $metadata_value );
 				$response = 'success';
 			} else {
-				switch ( $_POST['metadata_type'] ) {
+				switch ( $metadata_type ) {
 					case 'taxonomy':
+						// Validate that the term refers to a taxonomy registered for this post type.
+						if ( '' === $metadata_term || ! in_array( $metadata_term, get_object_taxonomies( $post->post_type ), true ) ) {
+							$this->print_ajax_response( 'error', $this->module->messages['update-error'] );
+						}
 						$response = wp_set_post_terms( $post->ID, $incoming_metadata_value, $metadata_term );
 						break;
 					default:

--- a/tests/Integration/CalendarMetadataAjaxTest.php
+++ b/tests/Integration/CalendarMetadataAjaxTest.php
@@ -1,0 +1,122 @@
+<?php
+/**
+ * Calendar metadata update AJAX integration tests.
+ *
+ * @package Automattic\EditFlow\Tests\Integration
+ */
+
+declare( strict_types=1 );
+
+namespace Automattic\EditFlow\Tests\Integration;
+
+use WPAjaxDieContinueException;
+use WPAjaxDieStopException;
+
+/**
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ */
+class CalendarMetadataAjaxTest extends AjaxTestCase {
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		global $edit_flow;
+		$edit_flow->calendar->install();
+		$edit_flow->calendar->init();
+		$edit_flow->editorial_metadata->install();
+		$edit_flow->editorial_metadata->init();
+	}
+
+	/**
+	 * Test: Unknown editorial metadata slug is rejected without writing post meta.
+	 */
+	public function test_update_metadata_rejects_unknown_editorial_term(): void {
+		$admin_id = $this->factory->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $admin_id );
+
+		$post_id = $this->factory->post->create( array(
+			'post_status' => 'draft',
+			'post_author' => $admin_id,
+		) );
+
+		$_POST['nonce']          = wp_create_nonce( 'ef-calendar-modify' );
+		$_POST['post_id']        = $post_id;
+		$_POST['metadata_type']  = 'text';
+		$_POST['metadata_term']  = 'bogus-nonexistent-slug';
+		$_POST['metadata_value'] = 'value';
+
+		$response_body = $this->capture_ajax_response( 'ef_calendar_update_metadata' );
+
+		$this->assertStringContainsString( '"status":"error"', $response_body );
+
+		// Ensure no post meta was written with the rogue key.
+		$this->assertEmpty(
+			get_post_meta( $post_id, '_ef_editorial_meta_text_bogus-nonexistent-slug', true ),
+			'Rogue metadata term must not create post meta.'
+		);
+	}
+
+	/**
+	 * Test: Unknown taxonomy name is rejected without attempting to set terms.
+	 */
+	public function test_update_metadata_rejects_unknown_taxonomy(): void {
+		$admin_id = $this->factory->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $admin_id );
+
+		$post_id = $this->factory->post->create( array(
+			'post_status' => 'draft',
+			'post_author' => $admin_id,
+		) );
+
+		$_POST['nonce']          = wp_create_nonce( 'ef-calendar-modify' );
+		$_POST['post_id']        = $post_id;
+		$_POST['metadata_type']  = 'taxonomy';
+		$_POST['metadata_term']  = 'not-a-real-taxonomy';
+		$_POST['metadata_value'] = 'something';
+
+		$response_body = $this->capture_ajax_response( 'ef_calendar_update_metadata' );
+
+		$this->assertStringContainsString( '"status":"error"', $response_body );
+	}
+
+	/**
+	 * Test: Empty metadata_term is rejected.
+	 */
+	public function test_update_metadata_rejects_empty_term(): void {
+		$admin_id = $this->factory->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $admin_id );
+
+		$post_id = $this->factory->post->create( array(
+			'post_status' => 'draft',
+			'post_author' => $admin_id,
+		) );
+
+		$_POST['nonce']          = wp_create_nonce( 'ef-calendar-modify' );
+		$_POST['post_id']        = $post_id;
+		$_POST['metadata_type']  = 'text';
+		$_POST['metadata_term']  = '';
+		$_POST['metadata_value'] = 'value';
+
+		$response_body = $this->capture_ajax_response( 'ef_calendar_update_metadata' );
+
+		$this->assertStringContainsString( '"status":"error"', $response_body );
+	}
+
+	/**
+	 * Capture the JSON body emitted by a print_ajax_response call.
+	 *
+	 * @param string $action AJAX action name.
+	 */
+	private function capture_ajax_response( string $action ): string {
+		try {
+			$this->_handleAjax( $action );
+		} catch ( WPAjaxDieContinueException $e ) {
+			unset( $e );
+		} catch ( WPAjaxDieStopException $e ) {
+			$this->fail( 'Unexpected stop exception: ' . $e->getMessage() );
+		}
+
+		return (string) $this->_last_response;
+	}
+}


### PR DESCRIPTION
## Summary

`EF_Calendar::handle_ajax_update_metadata` accepted a `metadata_term`
value from the request and used it in two ways without checking what
it referred to. For editorial metadata updates it was concatenated
into a post meta key of the form `_ef_editorial_meta_{type}_{term}`;
for taxonomy updates it was passed straight to `wp_set_post_terms`
as the taxonomy argument. A user with `edit_post` capability could
therefore write arbitrary post meta keys on a post, or assign terms
from any registered taxonomy — including taxonomies not intended to
be edited from the calendar.

This PR constrains `metadata_term` before it is used. For the
editorial metadata branch the term must match the slug of an
existing editorial metadata term (via `get_editorial_metadata_term_by`).
For the taxonomy branch it must be a taxonomy registered on the post's
post type (via `get_object_taxonomies`). Both inputs are also sanitised
up front so the `phpcs:disable` block narrows to the one value that is
still passed through to `wp_set_post_terms` unchanged (arrays of term
IDs/names continue to be accepted there).

A new integration test exercises the three rejection paths: unknown
editorial metadata slug, unknown taxonomy, and empty term.

## Test plan

- [ ] `composer test:integration -- tests/Integration/CalendarMetadataAjaxTest.php` passes in CI
- [ ] Editing an editorial metadata field from the calendar still saves as before
- [ ] Editing a taxonomy field (e.g. categories) from the calendar still saves as before