### PR TITLE
Fix PHP 8.1+ deprecations from misapplied wp_kses_post on list-table rows

### DIFF
--- a/modules/custom-status/custom-status.php
+++ b/modules/custom-status/custom-status.php
@@ -2316,10 +2316,11 @@ class EF_Custom_Status_List_Table extends WP_List_Table {
 	public function single_row( $item ) {
 		static $alternate_class = '';
 		$alternate_class        = ( '' == $alternate_class ? ' alternate' : '' );
-		$row_class              = ' class="term-static' . $alternate_class . '"';
 
-		echo wp_kses_post( '<tr id="term-' . $item->term_id . '"' . $row_class . '>' );
-		echo wp_kses_post( $this->single_row_columns( $item ) );
+		printf( '<tr id="term-%d" class="term-static%s">', (int) $item->term_id, esc_attr( $alternate_class ) );
+		// single_row_columns() echoes its own output; the column_* callbacks are
+		// responsible for escaping, as per WP_List_Table's contract.
+		$this->single_row_columns( $item );
 		echo '</tr>';
 	}
 

--- a/modules/editorial-metadata/editorial-metadata.php
+++ b/modules/editorial-metadata/editorial-metadata.php
@@ -1902,10 +1902,11 @@ class EF_Editorial_Metadata_List_Table extends WP_List_Table {
 	public function single_row( $term, $level = 0 ) {
 		static $alternate_class = '';
 		$alternate_class        = ( '' == $alternate_class ? ' alternate' : '' );
-		$row_class              = ' class="term-static' . $alternate_class . '"';
 
-		echo wp_kses_post( '<tr id="term-' . $term->term_id . '"' . $row_class . '>' );
-		echo wp_kses_post( $this->single_row_columns( $term ) );
+		printf( '<tr id="term-%d" class="term-static%s">', (int) $term->term_id, esc_attr( $alternate_class ) );
+		// single_row_columns() echoes its own output; the column_* callbacks are
+		// responsible for escaping, as per WP_List_Table's contract.
+		$this->single_row_columns( $term );
 		echo '</tr>';
 	}
 

--- a/modules/user-groups/user-groups.php
+++ b/modules/user-groups/user-groups.php
@@ -1372,11 +1372,17 @@ if ( ! class_exists( 'EF_Usergroups_List_Table' ) ) {
 		 * @param object $usergroup The usergroup object.
 		 */
 		public function single_row( $usergroup ) {
-			static $row_class = '';
-			$row_class        = ( '' == $row_class ? ' class="alternate"' : '' );
+			static $is_alternate = false;
+			$is_alternate        = ! $is_alternate;
 
-			echo wp_kses_post( '<tr id="usergroup-' . $usergroup->term_id . '"' . $row_class . '>' );
-			echo wp_kses_post( $this->single_row_columns( $usergroup ) );
+			printf(
+				'<tr id="usergroup-%d"%s>',
+				(int) $usergroup->term_id,
+				$is_alternate ? ' class="alternate"' : ''
+			);
+			// single_row_columns() echoes its own output; the column_* callbacks are
+			// responsible for escaping, as per WP_List_Table's contract.
+			$this->single_row_columns( $usergroup );
 			echo '</tr>';
 		}
 


### PR DESCRIPTION
## Summary

On every Custom Statuses, Editorial Metadata and User Groups
settings screen, each row rendered by `EF_*_List_Table::single_row()`
was triggering five PHP deprecation notices:

```
wp-includes/kses.php:2018  preg_replace()
wp-includes/kses.php:2018  wp_kses_no_null()
wp-includes/kses.php:963   wp_kses()
wp-includes/kses.php:2496  wp_kses_post()
…/custom-status.php:2322   EF_Custom_Status_List_Table->single_row()
```

The cause is a misapplied escape introduced when resolving PHPCS
violations: the code calls

```php
echo wp_kses_post( $this->single_row_columns( $item ) );
```

but `WP_List_Table::single_row_columns()` echoes its output
internally and returns `void`, so the row HTML is already written
to the response before `null` is handed to `wp_kses_post()`. On
PHP 8.1+ that null propagates through `wp_kses_post` → `wp_kses` →
`wp_kses_no_null` → two `preg_replace()` calls, each of which emits
a "passing null to non-nullable parameter" deprecation.

The fix is to drop the misapplied wrapper and let
`single_row_columns()` do its own output. The `column_*` callbacks
in each of the three list tables already return pre-escaped strings
— `esc_html()`, `esc_attr()`, `esc_url()` — which is the contract
`WP_List_Table` expects from subclasses. The opening `<tr>` tag is
rebuilt with `printf`, casting `term_id` through `(int)` and
running the alternating-class marker through `esc_attr`, which is
cleaner than wrapping a static string template in `wp_kses_post`.

The same pattern existed in all three modules and is fixed in all
three places.

## Test plan

- [ ] With `WP_DEBUG` and `WP_DEBUG_LOG` on, visit Edit Flow →
      Custom Statuses. No `Deprecated` entries in `debug.log`.
- [ ] Same for Edit Flow → Editorial Metadata.
- [ ] Same for Edit Flow → User Groups.
- [ ] Confirm row zebra-striping still alternates on each table.
- [ ] Confirm the row actions (Edit / Quick Edit / Make Default /
      Delete) still work on Custom Statuses and that nothing renders
      differently.