### PR TITLE
Remove misapplied wp_kses_post from inline-save success paths

### DIFF
--- a/modules/custom-status/custom-status.php
+++ b/modules/custom-status/custom-status.php
@@ -1338,7 +1338,9 @@ if ( ! class_exists( 'EF_Custom_Status' ) ) {
 				set_current_screen( 'edit-custom-status' );
 				$wp_list_table = new EF_Custom_Status_List_Table();
 				$wp_list_table->prepare_items();
-				echo wp_kses_post( $wp_list_table->single_row( $return ) );
+				// single_row() echoes its own output; column_* callbacks are
+				// responsible for escaping, as per WP_List_Table's contract.
+				$wp_list_table->single_row( $return );
 				wp_die();
 			} else {
 				/* translators: 1: the status's name */

--- a/modules/editorial-metadata/editorial-metadata.php
+++ b/modules/editorial-metadata/editorial-metadata.php
@@ -1456,7 +1456,9 @@ if ( ! class_exists( 'EF_Editorial_Metadata' ) ) {
 				set_current_screen( 'edit-editorial-metadata' );
 				$wp_list_table = new EF_Editorial_Metadata_List_Table();
 				$wp_list_table->prepare_items();
-				echo wp_kses_post( $wp_list_table->single_row( $return ) );
+				// single_row() echoes its own output; column_* callbacks are
+				// responsible for escaping, as per WP_List_Table's contract.
+				$wp_list_table->single_row( $return );
 				wp_die();
 			} else {
 				/* Translators: 1: the name of the term that could not be found */

--- a/modules/user-groups/user-groups.php
+++ b/modules/user-groups/user-groups.php
@@ -553,7 +553,9 @@ if ( ! class_exists( 'EF_User_Groups' ) ) {
 				set_current_screen( 'edit-usergroup' );
 				$wp_list_table = new EF_Usergroups_List_Table();
 				$wp_list_table->prepare_items();
-				echo wp_kses_post( $wp_list_table->single_row( $return ) );
+				// single_row() echoes its own output; column_* callbacks are
+				// responsible for escaping, as per WP_List_Table's contract.
+				$wp_list_table->single_row( $return );
 				wp_die();
 			} else {
 				// translators: %s is the name of the user group.


### PR DESCRIPTION
## Summary

PR 947 fixed five PHP 8.1+ deprecations per row on the Custom
Statuses, Editorial Metadata and User Groups list screens. Three
further call sites with the same bug were missed because they
reference \`single_row()\` via a \`\$wp_list_table\` local variable
rather than \`\$this\` — my grep only caught the latter.

Each of these handlers runs on a successful inline save and echoes
the refreshed row back to the browser via:

\`\`\`php
echo wp_kses_post( \$wp_list_table->single_row( \$return ) );
\`\`\`

Because \`WP_List_Table::single_row()\` echoes internally and returns
void, the row HTML is already in the response before \`wp_kses_post()\`
receives \`null\`. On PHP 8.1+ that null propagates through the kses
chain (\`wp_kses_post\` → \`wp_kses\` → \`wp_kses_no_null\` → two
\`preg_replace\` calls) and emits five "passing null to non-nullable
parameter" deprecations every time an admin inline-saves a status,
editorial metadata term or user group.

Drop the wrappers and let \`single_row()\` do its own output. The
\`column_*\` callbacks in each list table already return pre-escaped
strings, which is the documented \`WP_List_Table\` contract.

Locations:

- \`modules/custom-status/custom-status.php:1341\`
- \`modules/editorial-metadata/editorial-metadata.php:1459\`
- \`modules/user-groups/user-groups.php:556\`

## Test plan

- [ ] With \`WP_DEBUG\` and \`WP_DEBUG_LOG\` on, inline-edit a Custom
      Status (Quick Edit → Update Status). No new \`Deprecated\`
      entries in \`debug.log\`, and the row refreshes in place.
- [ ] Same for an Editorial Metadata term.
- [ ] Same for a User Group.