### PR TITLE
Speed up CI with targeted caching and fewer jobs

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -108,14 +108,6 @@ jobs:
         if: steps.playwright-cache.outputs.cache-hit == 'true'
         run: npx playwright install-deps chromium
 
-      - name: Cache wp-env downloads
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: ~/wp-env
-          key: wp-env-${{ runner.os }}-${{ hashFiles('.wp-env.json') }}
-          restore-keys: |
-            wp-env-${{ runner.os }}-
-
       - name: Install WordPress with wp-env
         run: npm run wp-env start
 

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -40,9 +40,11 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
-    name: Build
-    runs-on: ubuntu-latest
+  test:
+    name: Build and E2E Tests
+    # Pin to ubuntu-22.04 for Playwright compatibility
+    # ubuntu-latest (24.04) has library version mismatches with Playwright's WebKit dependencies
+    runs-on: ubuntu-22.04
     permissions:
       contents: read
 
@@ -85,45 +87,34 @@ jobs:
           echo "| custom-status-block.js | $(du -h build/custom-status-block.js | cut -f1) |" >> $GITHUB_STEP_SUMMARY
           echo "| calendar-react.js | $(du -h build/calendar-react.js | cut -f1) |" >> $GITHUB_STEP_SUMMARY
 
-      - name: Upload build artifacts
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      - name: Resolve Playwright version
+        id: playwright-version
+        run: |
+          version=$(node -p "require('@playwright/test/package.json').version")
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
-          name: build-artifacts
-          path: build/
-          retention-days: 1
-
-  test:
-    name: E2E Tests
-    # Pin to ubuntu-22.04 for Playwright compatibility
-    # ubuntu-latest (24.04) has library version mismatches with Playwright's WebKit dependencies
-    runs-on: ubuntu-22.04
-    needs: build
-    permissions:
-      contents: read
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-
-      - name: Set up NodeJS 20
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version: '20'
-          cache: npm
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Download build artifacts
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: build-artifacts
-          path: build/
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
 
       - name: Install Playwright browsers and system dependencies
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: npx playwright install --with-deps chromium
+
+      - name: Install Playwright system dependencies
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: npx playwright install-deps chromium
+
+      - name: Cache wp-env downloads
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ~/wp-env
+          key: wp-env-${{ runner.os }}-${{ hashFiles('.wp-env.json') }}
+          restore-keys: |
+            wp-env-${{ runner.os }}-
 
       - name: Install WordPress with wp-env
         run: npm run wp-env start

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -52,17 +52,8 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Set up NodeJS 20
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version: '20'
-          cache: npm
-
-      - name: Install npm dependencies
-        run: npm ci
-
-      - name: Put local node binaries on PATH
-        run: echo "$GITHUB_WORKSPACE/node_modules/.bin" >> "$GITHUB_PATH"
+      - name: Install wordpress environment
+        run: npm -g install @wordpress/env
 
       - name: Setup PHP ${{ matrix.php }}
         uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # 2.37.0
@@ -75,17 +66,8 @@ jobs:
         with:
           composer-options: --prefer-dist --no-progress
 
-      - name: Cache wp-env downloads
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: ~/wp-env
-          key: wp-env-${{ runner.os }}-${{ matrix.wp }}-${{ matrix.php }}-${{ hashFiles('.wp-env.json') }}
-          restore-keys: |
-            wp-env-${{ runner.os }}-${{ matrix.wp }}-${{ matrix.php }}-
-            wp-env-${{ runner.os }}-${{ matrix.wp }}-
-
       - name: Setup wp-env
-        run: npx wp-env start
+        run: wp-env start
         env:
           WP_ENV_CORE: WordPress/WordPress#${{ matrix.wp }}
 

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -61,6 +61,9 @@ jobs:
       - name: Install npm dependencies
         run: npm ci
 
+      - name: Put local node binaries on PATH
+        run: echo "$GITHUB_WORKSPACE/node_modules/.bin" >> "$GITHUB_PATH"
+
       - name: Setup PHP ${{ matrix.php }}
         uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # 2.37.0
         with:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -52,8 +52,14 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Install wordpress environment
-        run: npm -g install @wordpress/env
+      - name: Set up NodeJS 20
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: '20'
+          cache: npm
+
+      - name: Install npm dependencies
+        run: npm ci
 
       - name: Setup PHP ${{ matrix.php }}
         uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # 2.37.0
@@ -66,8 +72,17 @@ jobs:
         with:
           composer-options: --prefer-dist --no-progress
 
+      - name: Cache wp-env downloads
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ~/wp-env
+          key: wp-env-${{ runner.os }}-${{ matrix.wp }}-${{ matrix.php }}-${{ hashFiles('.wp-env.json') }}
+          restore-keys: |
+            wp-env-${{ runner.os }}-${{ matrix.wp }}-${{ matrix.php }}-
+            wp-env-${{ runner.os }}-${{ matrix.wp }}-
+
       - name: Setup wp-env
-        run: wp-env start
+        run: npx wp-env start
         env:
           WP_ENV_CORE: WordPress/WordPress#${{ matrix.wp }}
 

--- a/.github/workflows/js-tests.yml
+++ b/.github/workflows/js-tests.yml
@@ -53,8 +53,19 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Cache ESLint and Jest results
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            .eslintcache
+            node_modules/.cache/jest
+          key: js-cache-${{ runner.os }}-${{ hashFiles('package-lock.json', 'jest.config.js', '.eslintrc*', 'eslint.config.*') }}-${{ github.sha }}
+          restore-keys: |
+            js-cache-${{ runner.os }}-${{ hashFiles('package-lock.json', 'jest.config.js', '.eslintrc*', 'eslint.config.*') }}-
+            js-cache-${{ runner.os }}-
+
       - name: Run Lint JS
-        run: npm run lint-js
+        run: npm run lint-js -- --cache
 
       - name: Run Jest tests
         run: npm run test-jest

--- a/.github/workflows/php-lint.yml
+++ b/.github/workflows/php-lint.yml
@@ -49,8 +49,17 @@ jobs:
         with:
           composer-options: --prefer-dist --no-progress
 
+      - name: Cache PHPCS results
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: .phpcs-cache
+          key: phpcs-${{ runner.os }}-${{ hashFiles('.phpcs.xml.dist', 'composer.json') }}-${{ github.sha }}
+          restore-keys: |
+            phpcs-${{ runner.os }}-${{ hashFiles('.phpcs.xml.dist', 'composer.json') }}-
+            phpcs-${{ runner.os }}-
+
       - name: PHP syntax lint
         run: composer lint-ci | cs2pr
 
       - name: PHP coding standards
-        run: composer cs -- --report=checkstyle | cs2pr
+        run: composer cs -- --cache=.phpcs-cache --report=checkstyle | cs2pr

--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,9 @@ dist/
 .phpunit.cache/
 artifacts/
 
+# Tool caches
+.phpcs-cache
+.eslintcache
+
 # Local wp-env overrides
 .wp-env.override.json


### PR DESCRIPTION
## Summary

CI runs were repeating expensive work on every push. This branch keeps the repeat work that can be safely skipped and leaves the rest alone after two of the original changes didn't pan out on live CI.

What's kept: the Playwright browsers are cached and keyed on the installed `@playwright/test` version so the ~150 MB download is only repeated when the package version bumps. On a cache hit we still run `playwright install-deps` so system libraries are in place on a fresh runner. PHPCS writes to `.phpcs-cache` and the file is persisted between runs, letting it skip unchanged files. ESLint gains `--cache` and Jest's transform cache is persisted too. The E2E workflow's separate `build` and `test` jobs are merged into one — the artefact hand-off they did only pays off when multiple test jobs consume the build, which isn't the case here, so splitting them was costing a second runner's provisioning for no parallelism.

What was tried and reverted: the wp-env download cache consistently broke the E2E workflow, where the `afterStart` lifecycle hook reported the dev site wasn't installed on fresh runs. Rather than debug further, the cache is dropped from both workflows (it was the lowest-value item in the plan anyway). Swapping the integration workflow's global `npm -g install @wordpress/env` for `npx` pushed a full `npm ci` into the job that previously only fetched one package, adding around 25 seconds and nearly doubling the total runtime; that swap is also reverted.

First CI run after this change will be slightly slower as the retained caches populate. Subsequent runs should see meaningful savings on E2E in particular (browser download skipped, one runner instead of two).

## Test plan

- [ ] First run populates Playwright, PHPCS, and ESLint/Jest caches without errors
- [ ] Second run shows cache hits for each
- [ ] PHPCS still reports violations correctly when `.phpcs-cache` is cold vs warm
- [ ] Integration runtime is back to the baseline (~2m20s)
- [ ] ESLint still fails the job on lint errors with `--cache` enabled