### PR TITLE
Fix stored XSS in the editorial metadata location field

### DIFF
--- a/modules/editorial-metadata/editorial-metadata.php
+++ b/modules/editorial-metadata/editorial-metadata.php
@@ -380,15 +380,21 @@ if ( ! class_exists( 'EF_Editorial_Metadata' ) ) {
 			foreach ( $terms as $term ) {
 				$meta_key = $this->get_postmeta_key( $term );
 
+				// Mirror the sanitisation applied on the classic (metabox) save path so the
+				// REST/Gutenberg write path cannot store unsanitised values. Paragraph fields
+				// keep their line breaks; every other type is treated as a single line.
+				$sanitize_callback = ( 'paragraph' === $term->type ) ? 'sanitize_textarea_field' : 'sanitize_text_field';
+
 				foreach ( $supported_post_types as $post_type ) {
 					register_post_meta(
 						$post_type,
 						$meta_key,
 						array(
-							'show_in_rest'  => true,
-							'single'        => true,
-							'type'          => 'string',
-							'auth_callback' => function ( $allowed, $meta_key, $post_id ) {
+							'show_in_rest'      => true,
+							'single'            => true,
+							'type'              => 'string',
+							'sanitize_callback' => $sanitize_callback,
+							'auth_callback'     => function ( $allowed, $meta_key, $post_id ) {
 								return current_user_can( 'edit_post', $post_id );
 							},
 						)
@@ -441,8 +447,9 @@ if ( ! class_exists( 'EF_Editorial_Metadata' ) ) {
 				echo '<p>' . wp_kses( $message, 'a' ) . '</p>';
 			} else {
 				foreach ( $terms as $term ) {
-					$postmeta_key     = $this->get_postmeta_key( $term );
-					$current_metadata = esc_attr( $this->get_postmeta_value( $term, $post->ID ) );
+					$postmeta_key = $this->get_postmeta_key( $term );
+					// Raw stored value; each field type below escapes it for its own output context.
+					$current_metadata = $this->get_postmeta_value( $term, $post->ID );
 					$type             = $term->type;
 					$description      = $term->description;
 					if ( $description ) {
@@ -486,11 +493,24 @@ if ( ! class_exists( 'EF_Editorial_Metadata' ) ) {
 							if ( $description_span ) {
 								echo '<label for="' . esc_attr( $postmeta_key ) . '">' . wp_kses_post( $description_span ) . '</label>';
 							}
-							echo '<input id="' . esc_attr( $postmeta_key ) . '" name="' . esc_attr( $postmeta_key ) . '"type=text value="' . esc_attr( $current_metadata ) . '" />';
+							echo '<input id="' . esc_attr( $postmeta_key ) . '" name="' . esc_attr( $postmeta_key ) . '" type="text" value="' . esc_attr( $current_metadata ) . '" />';
 							if ( ! empty( $current_metadata ) ) {
-								/* translators: %s is the google maps location. */
-								$google_maps_url = sprintf( esc_html__( 'View &#8220;%s&#8221; on Google Maps', 'edit-flow' ), esc_attr( $current_metadata ) );
-								echo '<div><a href=http://maps.google.com/?q="' . esc_attr( $current_metadata ) . '"&t=m target=_blank>"' . esc_attr( $google_maps_url ) . '"</a></div>';
+								// http_build_query() (unlike add_query_arg()) URL-encodes the value,
+								// so spaces, "&" and "=" cannot alter the URL structure.
+								$google_maps_url  = 'https://maps.google.com/?' . http_build_query(
+									array(
+										'q' => $current_metadata,
+										't' => 'm',
+									)
+								);
+								$google_maps_text = sprintf(
+									/* translators: %s: the location entered in the editorial metadata field. */
+									__( 'View “%s” on Google Maps', 'edit-flow' ),
+									$current_metadata
+								);
+								// Escape late: the label is translatable and filterable (gettext), so escape the
+								// whole composed string at output rather than trusting either source.
+								echo '<div><a href="' . esc_url( $google_maps_url ) . '" target="_blank" rel="noopener noreferrer">' . esc_html( $google_maps_text ) . '</a></div>';
 							}
 							break;
 						case 'text':

--- a/tests/Integration/EditorialMetadataTest.php
+++ b/tests/Integration/EditorialMetadataTest.php
@@ -110,4 +110,89 @@ class EditorialMetadataTest extends TestCase {
 		$first_draft_date_value = $edit_flow->editorial_metadata->get_postmeta_value( $first_draft_date_term, $id );
 		$this->assertEmpty( $first_draft_date_value );
 	}
+
+	/**
+	 * A stored "location" value must not be able to break out of the Google Maps
+	 * link's href attribute and inject an event handler.
+	 */
+	function test_location_field_metabox_output_is_escaped() {
+		global $edit_flow;
+
+		wp_set_current_user( self::$admin_user_id );
+
+		// The "location" field type is not part of the default install, so create one.
+		$edit_flow->editorial_metadata->insert_editorial_metadata_term(
+			array(
+				'name' => 'Test Location',
+				'slug' => 'test-location',
+				'type' => 'location',
+			)
+		);
+		$location_term = $edit_flow->editorial_metadata->get_editorial_metadata_term_by( 'slug', 'test-location' );
+		$location_key  = $edit_flow->editorial_metadata->get_postmeta_key( $location_term );
+
+		$post_id = wp_insert_post(
+			array(
+				'post_author'  => self::$admin_user_id,
+				'post_status'  => 'draft',
+				'post_title'   => rand_str(),
+				'post_content' => rand_str(),
+			)
+		);
+
+		// Attribute-injection payload: it contains no tags, so wp_strip_all_tags()/
+		// sanitize_text_field() leave it intact - the defence must be at output.
+		$payload = 'x onmouseover=alert(document.domain) y=';
+		update_post_meta( $post_id, $location_key, $payload );
+
+		ob_start();
+		$edit_flow->editorial_metadata->display_meta_box( get_post( $post_id ) );
+		$output = ob_get_clean();
+
+		// The Google Maps link must use a single, properly quoted https href.
+		$this->assertStringContainsString( 'href="https://maps.google.com', $output );
+		// The old unquoted href that allowed the breakout must be gone.
+		$this->assertStringNotContainsString( 'href=http://maps.google.com', $output );
+
+		// No event-handler attribute may be injected into the anchor's opening tag.
+		$anchor_start = strpos( $output, '<a href="https://maps.google.com' );
+		$this->assertNotFalse( $anchor_start, 'Expected the Google Maps anchor in the metabox output.' );
+		$opening_tag = substr( $output, $anchor_start, strpos( $output, '>', $anchor_start ) - $anchor_start + 1 );
+		$this->assertStringNotContainsString( 'onmouseover=', $opening_tag );
+	}
+
+	/**
+	 * Editorial metadata registered for the REST API must carry a sanitize_callback
+	 * so the Gutenberg/REST write path cannot store unsanitised values.
+	 */
+	function test_rest_meta_registers_a_sanitize_callback() {
+		global $edit_flow;
+
+		$em = $edit_flow->editorial_metadata;
+
+		// Ensure the module reports a post type so REST meta is registered for it.
+		if ( ! isset( $em->module->options ) || ! is_object( $em->module->options ) ) {
+			$em->module->options = new \stdClass();
+		}
+		$em->module->options->post_types = array( 'post' => 'on' );
+
+		// Invoke the production registration routine (private; runs at init in normal use).
+		$register = new \ReflectionMethod( $em, 'register_metadata_for_rest_api' );
+		$register->setAccessible( true );
+		$register->invoke( $em );
+
+		$registered = get_registered_meta_keys( 'post', 'post' );
+
+		$paragraph_term = $em->get_editorial_metadata_term_by( 'slug', 'assignment' ); // type: paragraph.
+		$number_term    = $em->get_editorial_metadata_term_by( 'slug', 'word-count' );  // type: number.
+		$paragraph_key  = $em->get_postmeta_key( $paragraph_term );
+		$number_key     = $em->get_postmeta_key( $number_term );
+
+		$this->assertArrayHasKey( $paragraph_key, $registered, 'Paragraph editorial-metadata key should be registered for REST.' );
+		$this->assertArrayHasKey( $number_key, $registered, 'Number editorial-metadata key should be registered for REST.' );
+
+		// Every write path must sanitise; paragraphs keep line breaks, other types are single-line.
+		$this->assertSame( 'sanitize_textarea_field', $registered[ $paragraph_key ]['sanitize_callback'] );
+		$this->assertSame( 'sanitize_text_field', $registered[ $number_key ]['sanitize_callback'] );
+	}
 }


### PR DESCRIPTION
## Summary

The Editorial Metadata "location" field rendered its stored value into an **unquoted** `href` attribute on the post edit screen, escaped only with `esc_attr()`. Because `esc_attr()` does not encode spaces or `=`, a low-privileged Contributor or Author could store a value such as `x onmouseover=alert(document.domain) y=` that broke out of the attribute and injected a live event handler. The script then executed in the browser of any editor or administrator who opened the post — a stored XSS escalating from a content role into the wp-admin session of a reviewer. The classic save only strips tags, so a payload made purely of spaces and `=` survived to the output context untouched.

The Google Maps link is now built with `http_build_query()` and emitted through a quoted `esc_url()` `href` with `esc_html()` link text, so neither the value nor a stray `&` can alter the markup or the URL structure. While here, the redundant `esc_attr()` applied to every metadata value at metabox setup is removed: each field type already escapes for its own output context, and the double pass was silently double-encoding values containing special characters.

The block editor saves editorial metadata through the REST API rather than the classic metabox form, and that `register_post_meta()` registration had no `sanitize_callback` — so the REST write path stored raw strings while the classic path stripped tags. A `sanitize_callback` is added (`sanitize_textarea_field` for paragraph fields, `sanitize_text_field` otherwise) so both write paths sanitise consistently.

Fixes VIPPLUG-2

## Test plan

- [ ] Two regression tests added in `EditorialMetadataTest.php`: one asserts the rendered location metabox keeps the payload inside a single quoted `https` href with no injected event handler; one asserts the REST meta registers a `sanitize_callback`.
- [ ] Targeted suite passes: `composer test:integration -- --filter EditorialMetadataTest` (5 tests, 11 assertions).
- [ ] PHPCS clean on the changed files.
- [ ] Manual: create a "location"-type editorial metadata field, save `x onmouseover=alert(document.domain) y=` as a Contributor, then open the post as an administrator and confirm no script runs and the Google Maps link is well-formed.

> Note: the full `composer test:integration` run terminates early partway through the Calendar tests on `develop` as well (a pre-existing issue, unrelated to this change), so verification used the targeted filter above.