### PR TITLE
Correct GitHub brand capitalisation across modules and docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,7 +102,7 @@ Keep the first line of your commit message brief. A quick explanation of your ch
 
 Not sure what to include your commit message? Take a look at the ["Description" section of the WordPress commit message documentation](https://make.wordpress.org/core/handbook/best-practices/commit-messages/#description). There is great advice for what should be included in when writing a clear, concise and relevant commit message.
 
-After you've commited, push to your fork and create a Pull Request on Github.
+After you've commited, push to your fork and create a Pull Request on GitHub.
 
 Extending Edit Flow
 ------
@@ -113,4 +113,4 @@ The [Edit Flow Support Forums](https://wordpress.org/support/plugin/edit-flow) o
 
 It's a great way to add functionality to existing Edit Flow installations without having to go through the process of patching Edit Flow core.
 
-(Props to Jetpack. These contributing guidelines were based on the [Contribute](https://jetpack.com/contribute/#contribute) section on the Jetpack website and the [Contributing](https://github.com/Automattic/jetpack/blob/master/.github/CONTRIBUTING.md) section in the [Jetpack Github repository](https://github.com/Automattic/jetpack/))
+(Props to Jetpack. These contributing guidelines were based on the [Contribute](https://jetpack.com/contribute/#contribute) section on the Jetpack website and the [Contributing](https://github.com/Automattic/jetpack/blob/master/.github/CONTRIBUTING.md) section in the [Jetpack GitHub repository](https://github.com/Automattic/jetpack/))

--- a/modules/calendar/calendar.php
+++ b/modules/calendar/calendar.php
@@ -138,7 +138,7 @@ if ( ! class_exists( 'EF_Calendar' ) ) {
 					// phpcs:ignore WordPress.WP.I18n.NoHtmlWrappedStrings -- HTML is intentional for help tab content.
 					'content' => __( '<p>The calendar is a convenient week-by-week or month-by-month view into your content. Quickly see which stories are on track to being published on time, and which will need extra effort.</p>', 'edit-flow' ),
 				),
-				'settings_help_sidebar' => __( '<p><strong>For more information:</strong></p><p><a href="https://editflow.org/features/calendar/">Calendar Documentation</a></p><p><a href="https://wordpress.org/support/plugin/edit-flow/">Edit Flow Forum</a></p><p><a href="https://github.com/Automattic/Edit-Flow">Edit Flow on Github</a></p>', 'edit-flow' ),
+				'settings_help_sidebar' => __( '<p><strong>For more information:</strong></p><p><a href="https://editflow.org/features/calendar/">Calendar Documentation</a></p><p><a href="https://wordpress.org/support/plugin/edit-flow/">Edit Flow Forum</a></p><p><a href="https://github.com/Automattic/Edit-Flow">Edit Flow on GitHub</a></p>', 'edit-flow' ),
 			);
 			$this->module = EditFlow()->register_module( 'calendar', $args );
 		}

--- a/modules/custom-status/custom-status.php
+++ b/modules/custom-status/custom-status.php
@@ -83,7 +83,7 @@ if ( ! class_exists( 'EF_Custom_Status' ) ) {
 					'title'   => __( 'Overview', 'edit-flow' ),
 					'content' => __( '<p>Edit Flow’s custom statuses allow you to define the most important stages of your editorial workflow. Out of the box, WordPress only offers “Draft” and “Pending Review” as post states. With custom statuses, you can create your own post states like “In Progress”, “Pitch”, or “Waiting for Edit” and keep or delete the originals. You can also drag and drop statuses to set the best order for your workflow.</p><p>Custom statuses are fully integrated into the rest of Edit Flow and the WordPress admin. On the calendar and story budget, you can filter your view to see only posts of a specific post state. Furthermore, email notifications can be sent to a specific group of users when a post changes state.</p>', 'edit-flow' ),
 				],
-				'settings_help_sidebar' => __( '<p><strong>For more information:</strong></p><p><a href="https://editflow.org/features/custom-statuses/">Custom Status Documentation</a></p><p><a href="https://wordpress.org/support/plugin/edit-flow/">Edit Flow Forum</a></p><p><a href="https://github.com/Automattic/Edit-Flow">Edit Flow on Github</a></p>', 'edit-flow' ),
+				'settings_help_sidebar' => __( '<p><strong>For more information:</strong></p><p><a href="https://editflow.org/features/custom-statuses/">Custom Status Documentation</a></p><p><a href="https://wordpress.org/support/plugin/edit-flow/">Edit Flow Forum</a></p><p><a href="https://github.com/Automattic/Edit-Flow">Edit Flow on GitHub</a></p>', 'edit-flow' ),
 			];
 			$this->module = EditFlow()->register_module( 'custom_status', $args );
 		}

--- a/modules/editorial-comments/editorial-comments.php
+++ b/modules/editorial-comments/editorial-comments.php
@@ -48,7 +48,7 @@ if ( ! class_exists( 'EF_Editorial_Comments' ) ) {
 					'title'   => __( 'Overview', 'edit-flow' ),
 					'content' => __( '<p>Editorial comments help you cut down on email overload and keep the conversation close to where it matters: your content. Threaded commenting in the admin, similar to what you find at the end of a blog post, allows writers and editors to privately leave feedback and discuss what needs to be changed before publication.</p><p>Anyone with access to view the story in progress will also have the ability to comment on it. If you have notifications enabled, those following the post will receive an email every time a comment is left.</p>', 'edit-flow' ),
 				),
-				'settings_help_sidebar' => __( '<p><strong>For more information:</strong></p><p><a href="https://editflow.org/features/editorial-comments/">Editorial Comments Documentation</a></p><p><a href="https://wordpress.org/support/plugin/edit-flow/">Edit Flow Forum</a></p><p><a href="https://github.com/Automattic/Edit-Flow">Edit Flow on Github</a></p>', 'edit-flow' ),
+				'settings_help_sidebar' => __( '<p><strong>For more information:</strong></p><p><a href="https://editflow.org/features/editorial-comments/">Editorial Comments Documentation</a></p><p><a href="https://wordpress.org/support/plugin/edit-flow/">Edit Flow Forum</a></p><p><a href="https://github.com/Automattic/Edit-Flow">Edit Flow on GitHub</a></p>', 'edit-flow' ),
 			);
 			$this->module = EditFlow()->register_module( 'editorial_comments', $args );
 		}

--- a/modules/editorial-metadata/editorial-metadata.php
+++ b/modules/editorial-metadata/editorial-metadata.php
@@ -89,7 +89,7 @@ if ( ! class_exists( 'EF_Editorial_Metadata' ) ) {
 					'title'   => __( 'Overview', 'edit-flow' ),
 					'content' => __( '<p>Keep track of important details about your content with editorial metadata. This feature allows you to create as many date, text, number, etc. fields as you like, and then use them to store information like contact details, required word count, or the location of an interview.</p><p>Once you’ve set your fields up, editorial metadata integrates with both the calendar and the story budget. Make an editorial metadata item visible to have it appear to the rest of your team. Keep it hidden to restrict the information between the writer and their editor.</p>', 'edit-flow' ),
 				),
-				'settings_help_sidebar' => __( '<p><strong>For more information:</strong></p><p><a href="https://editflow.org/features/editorial-metadata/">Editorial Metadata Documentation</a></p><p><a href="https://wordpress.org/support/plugin/edit-flow/">Edit Flow Forum</a></p><p><a href="https://github.com/Automattic/Edit-Flow">Edit Flow on Github</a></p>', 'edit-flow' ),
+				'settings_help_sidebar' => __( '<p><strong>For more information:</strong></p><p><a href="https://editflow.org/features/editorial-metadata/">Editorial Metadata Documentation</a></p><p><a href="https://wordpress.org/support/plugin/edit-flow/">Edit Flow Forum</a></p><p><a href="https://github.com/Automattic/Edit-Flow">Edit Flow on GitHub</a></p>', 'edit-flow' ),
 			);
 			EditFlow()->register_module( $this->module_name, $args );
 		}

--- a/modules/notifications/notifications.php
+++ b/modules/notifications/notifications.php
@@ -78,7 +78,7 @@ if ( ! class_exists( 'EF_Notifications' ) ) {
 					'title'   => __( 'Overview', 'edit-flow' ),
 					'content' => __( '<p>Notifications ensure you keep up to date with progress your most important content. Users can be subscribed to notifications on a post one by one or by selecting user groups.</p><p>When enabled, email notifications can be sent when a post changes status or an editorial comment is left by a writer or an editor.</p>', 'edit-flow' ),
 				],
-				'settings_help_sidebar' => __( '<p><strong>For more information:</strong></p><p><a href="https://editflow.org/features/notifications/">Notifications Documentation</a></p><p><a href="https://wordpress.org/support/plugin/edit-flow/">Edit Flow Forum</a></p><p><a href="https://github.com/Automattic/Edit-Flow">Edit Flow on Github</a></p>', 'edit-flow' ),
+				'settings_help_sidebar' => __( '<p><strong>For more information:</strong></p><p><a href="https://editflow.org/features/notifications/">Notifications Documentation</a></p><p><a href="https://wordpress.org/support/plugin/edit-flow/">Edit Flow Forum</a></p><p><a href="https://github.com/Automattic/Edit-Flow">Edit Flow on GitHub</a></p>', 'edit-flow' ),
 			];
 			$this->module     = EditFlow()->register_module( 'notifications', $args );
 		}

--- a/modules/user-groups/user-groups.php
+++ b/modules/user-groups/user-groups.php
@@ -85,7 +85,7 @@ if ( ! class_exists( 'EF_User_Groups' ) ) {
 					'title'   => __( 'Overview', 'edit-flow' ),
 					'content' => __( '<p>For those with many people involved in the publishing process, user groups helps you keep them organized.</p><p>Currently, user groups are primarily used for subscribing a set of users to a post for notifications.</p>', 'edit-flow' ),
 				),
-				'settings_help_sidebar' => __( '<p><strong>For more information:</strong></p><p><a href="https://editflow.org/features/user-groups/">User Groups Documentation</a></p><p><a href="https://wordpress.org/support/plugin/edit-flow/">Edit Flow Forum</a></p><p><a href="https://github.com/Automattic/Edit-Flow">Edit Flow on Github</a></p>', 'edit-flow' ),
+				'settings_help_sidebar' => __( '<p><strong>For more information:</strong></p><p><a href="https://editflow.org/features/user-groups/">User Groups Documentation</a></p><p><a href="https://wordpress.org/support/plugin/edit-flow/">Edit Flow Forum</a></p><p><a href="https://github.com/Automattic/Edit-Flow">Edit Flow on GitHub</a></p>', 'edit-flow' ),
 			);
 			$this->module = EditFlow()->register_module( 'user_groups', $args );
 		}

--- a/tests/Integration/StarterTest.php
+++ b/tests/Integration/StarterTest.php
@@ -27,7 +27,7 @@ class StarterTest extends TestCase {
 		$minimum_version = '3.4.0';
 		$running_version = get_bloginfo( 'version' );
 
-		// trunk is always "master" in github terms, but WordPress has a specific way of describing it
+		// trunk is always "master" in GitHub terms, but WordPress has a specific way of describing it
 		// grab the exact version number to verify that we're on trunk
 		if ( 'master' === $running_version || 'trunk' === $running_version ) {
 			$file = file_get_contents( 'https://raw.github.com/WordPress/WordPress/master/wp-includes/version.php' );


### PR DESCRIPTION
## Summary

[#969](https://github.com/Automattic/edit-flow/pull/969) corrected the calendar module's help-sidebar link text from `Github` to the official `GitHub` capitalisation, but the same miscapitalisation was left untouched everywhere else it appears. This change finishes the job.

The identical `Edit Flow on Github` link text lived in the help sidebars of five further modules — custom status, editorial comments, editorial metadata, notifications, and user groups — as well as the calendar module's source line itself, which #969 had not yet reached on this branch. Two further instances sat in `CONTRIBUTING.md`. All are now aligned with GitHub's branding.

The `languages/edit-flow.pot` template also contains the old strings, but it is deliberately left untouched here; it will be regenerated at release time, so hand-editing it now would only risk drift.

## Test plan

- [ ] Confirm a case-insensitive search for `Github` returns no matches in source or docs (the `.pot` aside).