### PR TITLE
Restrict Story Budget to a user's own posts when they cannot edit others'

### DIFF
--- a/modules/story-budget/story-budget.php
+++ b/modules/story-budget/story-budget.php
@@ -603,6 +603,16 @@ class EF_Story_Budget extends EF_Module {
 		// Filter for an end user to implement any of their own query args.
 		$args = apply_filters( 'ef_story_budget_posts_query_args', $args );
 
+		// Restrict users who cannot edit others' posts to their own, mirroring the core
+		// posts list (edit.php). The budget renders in an admin context, where WP_Query
+		// would otherwise return every author's unpublished posts; without this the
+		// status, author, title and date columns disclose other users' drafts, pending
+		// and scheduled posts to lower-privileged roles (e.g. Contributors). Applied
+		// after the filter above so it cannot be bypassed by a query-args filter.
+		if ( ! current_user_can( 'edit_others_posts' ) ) {
+			$args['author'] = get_current_user_id();
+		}
+
 		$term_posts_query_results = new WP_Query( $args );
 
 		$term_posts = array();

--- a/tests/Integration/StoryBudgetTest.php
+++ b/tests/Integration/StoryBudgetTest.php
@@ -126,6 +126,63 @@ class StoryBudgetTest extends TestCase {
 	}
 
 	/**
+	 * The Story Budget must not surface another user's unpublished posts to a
+	 * low-privileged role that can view the budget but cannot read those posts.
+	 */
+	public function test_get_posts_for_term_hides_other_users_unpublished_posts() {
+		global $edit_flow;
+		$story_budget = $edit_flow->story_budget;
+
+		$author_id      = self::factory()->user->create( array( 'role' => 'author' ) );
+		$contributor_id = self::factory()->user->create( array( 'role' => 'contributor' ) );
+
+		$cat_id = self::factory()->category->create( array( 'name' => 'Budget Cat' ) );
+		$term   = get_term( $cat_id, 'category' );
+
+		$now = date( 'Y-m-d H:i:s' );
+
+		$others_draft = wp_insert_post(
+			array(
+				'post_author'   => $author_id,
+				'post_status'   => 'draft',
+				'post_title'    => 'Another author secret draft',
+				'post_date'     => $now,
+				'post_category' => array( $cat_id ),
+			)
+		);
+		$own_draft    = wp_insert_post(
+			array(
+				'post_author'   => $contributor_id,
+				'post_status'   => 'draft',
+				'post_title'    => 'My own draft',
+				'post_date'     => $now,
+				'post_category' => array( $cat_id ),
+			)
+		);
+
+		$story_budget->taxonomy_used = 'category';
+		$story_budget->user_filters  = array(
+			'post_status' => 'draft',
+			'cat'         => '',
+			'author'      => '',
+			'start_date'  => date( 'Y-m-d', strtotime( '-1 day' ) ),
+			'number_days' => 30,
+		);
+
+		// As the contributor: own draft is visible, the other author's draft is not.
+		wp_set_current_user( $contributor_id );
+		$contributor_ids = wp_list_pluck( $story_budget->get_posts_for_term( $term, $story_budget->user_filters ), 'ID' );
+		$this->assertContains( $own_draft, $contributor_ids, 'Contributor should see their own draft.' );
+		$this->assertNotContains( $others_draft, $contributor_ids, "Contributor must not see another user's draft." );
+
+		// An administrator still sees the whole pipeline.
+		wp_set_current_user( self::$admin_user_id );
+		$admin_ids = wp_list_pluck( $story_budget->get_posts_for_term( $term, $story_budget->user_filters ), 'ID' );
+		$this->assertContains( $own_draft, $admin_ids );
+		$this->assertContains( $others_draft, $admin_ids );
+	}
+
+	/**
 	 * Test that calendar has default custom statuses
 	 */
 	public function test_calendar_custom_statuses() {


### PR DESCRIPTION
## Summary

The Story Budget dashboard grants its viewing capability (`ef_view_story_budget`) to Contributors by default, but `get_posts_for_term()` built its `WP_Query` without scoping by author. Because the budget renders on an admin screen, `WP_Query` returns every author's unpublished posts in that context, so the status, author, title and date columns exposed other users' drafts, pending and scheduled posts to any low-privileged role that could open the budget. A stock Contributor could enumerate the whole team's unpublished pipeline — content they cannot see in the standard posts list.

The fix mirrors core's `edit.php`: when the current user cannot edit others' posts, the query is restricted to their own posts. Editors and administrators are unaffected and still see the full pipeline. The restriction is applied after the `ef_story_budget_posts_query_args` filter so it cannot be bypassed by a query-args filter.

Fixes VIPPLUG-3.

## Test plan

- [ ] New regression test `test_get_posts_for_term_hides_other_users_unpublished_posts` in `StoryBudgetTest.php`: a Contributor sees their own draft but not another author's; an administrator sees both.
- [ ] `composer test:integration -- --filter test_get_posts_for_term_hides_other_users_unpublished_posts` passes.
- [ ] PHPCS clean on the changed files.
- [ ] Manual: as a Contributor, open Dashboard → Story Budget (optionally with the "Unpublished" filter) and confirm only your own posts appear; as an Editor, confirm all authors' posts still appear.

> The pre-existing `test_calendar_custom_statuses` failure in `StoryBudgetTest` is present on `develop` already and is unrelated to this change, so verification used the targeted filter above.