### PR TITLE
Escape custom status name in the Custom Statuses list table

### DIFF
--- a/modules/custom-status/custom-status.php
+++ b/modules/custom-status/custom-status.php
@@ -2226,7 +2226,13 @@ class EF_Custom_Status_List_Table extends WP_List_Table {
 				// phpcs:ignore Squiz.PHP.CommentedOutCode.Found, Squiz.Commenting.InlineComment.InvalidEndChar -- Intentionally commented out caching line for future implementation.
 				// wp_cache_set( "ef_custom_status_count_$column_name", $post_count );
 			}
-			$output = sprintf( '<a title="See all %1$ss saved as \'%2$s\'" href="%3$s">%4$s</a>', $column_name, $item->name, $edit_flow->helpers->filter_posts_link( $item->slug, $column_name ), $post_count );
+			$output = sprintf(
+				'<a title="See all %1$ss saved as \'%2$s\'" href="%3$s">%4$s</a>',
+				esc_attr( $column_name ),
+				esc_attr( $item->name ),
+				esc_url( $edit_flow->helpers->filter_posts_link( $item->slug, $column_name ) ),
+				esc_html( $post_count )
+			);
 			return $output;
 		}
 	}

--- a/tests/Integration/CustomStatusTest.php
+++ b/tests/Integration/CustomStatusTest.php
@@ -47,6 +47,32 @@ class CustomStatusTest extends TestCase {
 	}
 
 	/**
+	 * A custom status name must be escaped when rendered into the list table's
+	 * title attribute, so it cannot break out and inject markup.
+	 */
+	function test_list_table_column_escapes_status_name() {
+		require_once ABSPATH . 'wp-admin/includes/class-wp-list-table.php';
+		set_current_screen( 'edit-post' );
+
+		$table = new \EF_Custom_Status_List_Table();
+
+		$item = (object) array(
+			'term_id'  => 0,
+			'name'     => 'Bad" onmouseover=alert(1) x="',
+			'slug'     => 'bad-status',
+			'position' => 0,
+		);
+
+		$output = $table->column_default( $item, 'post' );
+
+		// The status name's double quote must be entity-encoded so it cannot close
+		// the title attribute and turn the rest of the value into tag attributes.
+		$this->assertStringContainsString( 'Bad&quot;', $output );
+		$this->assertStringNotContainsString( 'Bad" onmouseover', $output );
+		$this->assertStringContainsString( 'href="', $output );
+	}
+
+	/**
 	 * Test that a published post post_date_gmt is not altered
 	 */
 	function test_insert_post_publish_respect_post_date_gmt() {


### PR DESCRIPTION
## Summary

On the Custom Statuses settings screen, `EF_Custom_Status_List_Table::column_default()` built each post-count link by interpolating the status name straight into the link's `title` attribute without escaping. A status name containing a double quote could therefore close the attribute and have the remainder parsed as further tag attributes, injecting markup that runs when another administrator views the screen.

Every value is now escaped for its context: the title text with `esc_attr()`, the href with `esc_url()`, and the post count with `esc_html()`. This matches the escaping already used by the sibling column callbacks, and `column_default()` is the single render path for both the initial table and the row returned after an inline edit.

Fixes VIPPLUG-6.

## Test plan

- [ ] New regression test `test_list_table_column_escapes_status_name` in `CustomStatusTest.php`: a status name containing a double quote is entity-encoded in the rendered output and cannot break out of the `title` attribute.
- [ ] `composer test:integration -- --filter test_list_table_column_escapes_status_name` passes.
- [ ] PHPCS clean on the changed files.
- [ ] Manual: create a custom status whose name contains a quote and an event handler, then open Settings → Edit Flow → Custom Statuses and confirm no script runs.