### PR TITLE
Stop the calendar metadata AJAX from creating arbitrary taxonomy terms

### DIFF
--- a/modules/calendar/calendar.php
+++ b/modules/calendar/calendar.php
@@ -1829,7 +1829,35 @@ if ( ! class_exists( 'EF_Calendar' ) ) {
 						if ( '' === $metadata_term || ! in_array( $metadata_term, get_object_taxonomies( $post->post_type ), true ) ) {
 							$this->print_ajax_response( 'error', $this->module->messages['update-error'] );
 						}
-						$response = wp_set_post_terms( $post->ID, $incoming_metadata_value, $metadata_term );
+
+						// Resolve the submitted value(s) to EXISTING term IDs only. This endpoint
+						// must not create new terms: passing free-text names to wp_set_post_terms()
+						// would let any user who can edit a single post create arbitrary taxonomy
+						// terms, which normally requires the taxonomy's term-management capability.
+						$incoming_terms = is_array( $incoming_metadata_value ) ? $incoming_metadata_value : array( $incoming_metadata_value );
+						$term_ids       = array();
+						foreach ( $incoming_terms as $incoming_term ) {
+							$incoming_term = sanitize_text_field( $incoming_term );
+							if ( '' === $incoming_term ) {
+								continue;
+							}
+							if ( is_numeric( $incoming_term ) ) {
+								$existing_term = get_term( (int) $incoming_term, $metadata_term );
+							} else {
+								$existing_term = get_term_by( 'slug', sanitize_title( $incoming_term ), $metadata_term );
+								if ( ! $existing_term ) {
+									$existing_term = get_term_by( 'name', $incoming_term, $metadata_term );
+								}
+							}
+							if ( $existing_term instanceof WP_Term ) {
+								$term_ids[] = (int) $existing_term->term_id;
+							} else {
+								// A non-empty value matching no existing term: reject rather than create one.
+								$this->print_ajax_response( 'error', $this->module->messages['update-error'] );
+							}
+						}
+
+						$response = wp_set_post_terms( $post->ID, $term_ids, $metadata_term, false );
 						break;
 					default:
 						$response = new WP_Error( 'invalid-type', __( 'Invalid metadata type', 'edit-flow' ) );

--- a/tests/Integration/CalendarMetadataAjaxTest.php
+++ b/tests/Integration/CalendarMetadataAjaxTest.php
@@ -23,8 +23,13 @@ class CalendarMetadataAjaxTest extends AjaxTestCase {
 
 		global $edit_flow;
 		$edit_flow->calendar->install();
-		$edit_flow->calendar->init();
 		$edit_flow->editorial_metadata->install();
+
+		// EF_Calendar::init() only registers its AJAX actions for users who can view the
+		// calendar; in production that runs per-request as the logged-in user. Set such a
+		// user before init() so the ef_calendar_update_metadata action is actually wired up.
+		wp_set_current_user( $this->factory->user->create( array( 'role' => 'administrator' ) ) );
+		$edit_flow->calendar->init();
 		$edit_flow->editorial_metadata->init();
 	}
 
@@ -101,6 +106,65 @@ class CalendarMetadataAjaxTest extends AjaxTestCase {
 		$response_body = $this->capture_ajax_response( 'ef_calendar_update_metadata' );
 
 		$this->assertStringContainsString( '"status":"error"', $response_body );
+	}
+
+	/**
+	 * Test: a free-text taxonomy value must not create a brand-new term.
+	 * A user who can edit one post should not be able to create arbitrary terms.
+	 */
+	public function test_update_metadata_taxonomy_does_not_create_new_terms(): void {
+		$author_id = $this->factory->user->create( array( 'role' => 'author' ) );
+		wp_set_current_user( $author_id );
+
+		$post_id = $this->factory->post->create( array(
+			'post_status' => 'draft',
+			'post_author' => $author_id,
+		) );
+
+		$term_name = 'Brand New Rogue Term';
+
+		$_POST['nonce']          = wp_create_nonce( 'ef-calendar-modify' );
+		$_POST['post_id']        = $post_id;
+		$_POST['metadata_type']  = 'taxonomy';
+		$_POST['metadata_term']  = 'category';
+		$_POST['metadata_value'] = $term_name;
+
+		$response_body = $this->capture_ajax_response( 'ef_calendar_update_metadata' );
+
+		$this->assertFalse(
+			get_term_by( 'name', $term_name, 'category' ),
+			'The endpoint must not create a new taxonomy term from free text.'
+		);
+		$this->assertStringContainsString( '"status":"error"', $response_body );
+	}
+
+	/**
+	 * Test: an existing taxonomy term is still assigned by name.
+	 */
+	public function test_update_metadata_taxonomy_assigns_existing_term(): void {
+		$admin_id = $this->factory->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $admin_id );
+
+		$post_id = $this->factory->post->create( array(
+			'post_status' => 'draft',
+			'post_author' => $admin_id,
+		) );
+		$term    = $this->factory->term->create_and_get( array(
+			'taxonomy' => 'category',
+			'name'     => 'Existing Cat',
+		) );
+
+		$_POST['nonce']          = wp_create_nonce( 'ef-calendar-modify' );
+		$_POST['post_id']        = $post_id;
+		$_POST['metadata_type']  = 'taxonomy';
+		$_POST['metadata_term']  = 'category';
+		$_POST['metadata_value'] = 'Existing Cat';
+
+		$response_body = $this->capture_ajax_response( 'ef_calendar_update_metadata' );
+
+		$assigned = wp_get_post_terms( $post_id, 'category', array( 'fields' => 'ids' ) );
+		$this->assertContains( (int) $term->term_id, $assigned, 'An existing term should be assigned.' );
+		$this->assertStringContainsString( '"status":"success"', $response_body );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

The calendar's `ef_calendar_update_metadata` AJAX handler passed the submitted value straight to `wp_set_post_terms()` for the taxonomy branch. Because that function creates terms from free-text names, any user who could edit a single post — for example an author or contributor with `ef_view_calendar` — could create arbitrary terms in any taxonomy attached to the post type, something that normally requires the taxonomy's term-management capability.

The handler now resolves each submitted value to an existing term (by ID, slug, or name) and assigns only those IDs. A non-empty value that matches no existing term is rejected rather than created, so the endpoint can no longer be used to mint terms. Assigning an existing term continues to work as before.

While adding regression tests I found that `CalendarMetadataAjaxTest` was already failing in its entirety on `develop`: its `setUp()` ran `EF_Calendar::init()` while the current user was 0, so `init()` early-returned at the `ef_view_calendar` gate and never registered the AJAX action — the handler was never actually exercised, and every assertion ran against an empty response. `setUp()` now runs `init()` as a capable user (mirroring production, where `init()` runs per request as the logged-in user), which repairs the three existing tests and lets the new ones reach the handler.

Fixes VIPPLUG-5.

## Test plan

- [ ] `composer test:integration -- --filter CalendarMetadataAjaxTest` passes (5 tests): the three existing rejection tests, plus a new test proving a free-text value creates no term and one proving an existing term is still assigned.
- [ ] PHPCS clean on the changed files.
- [ ] Manual: as an author, use the calendar to set a taxonomy field to a brand-new value and confirm no term is created; set it to an existing term and confirm it is assigned.