### PR TITLE
Secure the calendar iCal feed against unauthenticated disclosure

### DIFF
--- a/modules/calendar/calendar.php
+++ b/modules/calendar/calendar.php
@@ -128,7 +128,7 @@ if ( ! class_exists( 'EF_Calendar' ) ) {
 					'update-error'        => __( 'There was an error updating the post. Please try again.', 'edit-flow' ),
 					/* translators: %s: URL to the published post */
 					'published-post-ajax' => __( "Updating the post date dynamically doesn't work for published content. Please <a href='%s'>edit the post</a>.", 'edit-flow' ),
-					'key-regenerated'     => __( 'iCal secret key regenerated. Please inform all users they will need to resubscribe.', 'edit-flow' ),
+					'key-regenerated'     => __( 'Your iCal feed URL has been regenerated. Re-copy it from Screen Options on the Calendar.', 'edit-flow' ),
 				),
 				'configure_page_cb'     => 'print_configure_view',
 				'configure_link_text'   => __( 'Calendar Options', 'edit-flow' ),
@@ -339,10 +339,11 @@ if ( ! class_exists( 'EF_Calendar' ) ) {
 
 			$output = '';
 
+			$current_user      = wp_get_current_user();
 			$args              = array(
 				'action'   => 'ef_calendar_ics_subscription',
-				'user'     => wp_get_current_user()->user_login,
-				'user_key' => md5( wp_get_current_user()->user_login . $this->module->options->ics_secret_key ),
+				'user'     => $current_user->user_login,
+				'user_key' => $this->get_user_ics_secret( $current_user->ID ),
 			);
 			$subscription_link = add_query_arg( $args, admin_url( 'admin-ajax.php' ) );
 			$output           .= '<br />';
@@ -353,13 +354,32 @@ if ( ! class_exists( 'EF_Calendar' ) ) {
 		}
 
 		/**
+		 * Get the current user's personal .ics feed secret, creating one on first use.
+		 *
+		 * The secret is stored per user and is independently revocable, so a leaked feed URL
+		 * exposes only that user's calendar view and can be rotated without affecting anyone else.
+		 *
+		 * @param int $user_id The user to fetch the secret for.
+		 * @return string The per-user feed secret.
+		 */
+		private function get_user_ics_secret( $user_id ) {
+			$meta_key = self::usermeta_key_prefix . 'ics_secret';
+			$secret   = (string) $this->get_user_meta( $user_id, $meta_key, true );
+			if ( '' === $secret ) {
+				$secret = wp_generate_password( 32, false );
+				$this->update_user_meta( $user_id, $meta_key, $secret );
+			}
+			return $secret;
+		}
+
+		/**
 		 * Add module options to the screen panel
 		 *
 		 * @since 0.8.3
 		 */
 		public function add_screen_options_panel() {
 			require_once EDIT_FLOW_ROOT . '/common/php/screen-options.php';
-			if ( 'on' == $this->module->options->ics_subscription && $this->module->options->ics_secret_key ) {
+			if ( 'on' == $this->module->options->ics_subscription ) {
 				add_screen_options_panel( self::usermeta_key_prefix . 'screen_options', __( 'Calendar Options', 'edit-flow' ), array( $this, 'generate_screen_options' ), self::screen_id, false, true );
 			}
 		}
@@ -496,21 +516,41 @@ if ( ! class_exists( 'EF_Calendar' ) ) {
 				wp_die(); // @todo Return an error response.
 			}
 
-			// Confirm this is a valid request.
-			$user           = sanitize_user( $_GET['user'] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Public feed with secret key validation.
-			$user_key       = sanitize_user( $_GET['user_key'] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Public feed with secret key validation.
-			$ics_secret_key = $this->module->options->ics_secret_key;
-			if ( ! $ics_secret_key || md5( $user . $ics_secret_key ) !== $user_key ) {
+			// Resolve the feed user and validate their personal, per-user secret. The comparison
+			// runs unconditionally against a real-or-dummy secret to limit username enumeration
+			// via timing (best-effort: get_user_by() itself is not constant time). user_can() and
+			// the query below resolve against the current blog, the desired multisite behaviour.
+			$login    = sanitize_user( wp_unslash( $_GET['user'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Public feed validated by per-user secret below.
+			$user_key = sanitize_text_field( wp_unslash( $_GET['user_key'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Public feed validated by per-user secret below.
+
+			$feed_user = get_user_by( 'login', $login );
+			$view_cap  = apply_filters( 'ef_view_calendar_cap', 'ef_view_calendar' );
+
+			$stored_secret = ( $feed_user && user_can( $feed_user, $view_cap ) )
+				? (string) $this->get_user_meta( $feed_user->ID, self::usermeta_key_prefix . 'ics_secret', true )
+				: '';
+			$known_secret  = '' !== $stored_secret ? $stored_secret : str_repeat( '*', 32 );
+
+			if ( ! hash_equals( $known_secret, $user_key ) || '' === $stored_secret ) {
 				wp_die( esc_html( $this->module->messages['nonce-failed'] ) );
 			}
 
-			// Set up the post data to be printed.
-			$post_query_args  = array();
-			$calendar_filters = $this->calendar_filters();
+			// Run the feed as the resolved user so the read scoping below applies to them.
+			wp_set_current_user( $feed_user->ID );
+
+			// Set up the post data to be printed. In this public feed we never honour caller-
+			// supplied author/post_status filters: they are the disclosure levers. The feed is
+			// scoped to the resolved user's own readable posts in get_calendar_posts_for_week().
+			$post_query_args    = array();
+			$calendar_filters   = $this->calendar_filters();
+			$disallowed_filters = array( 'author', 'post_status' );
 			foreach ( $calendar_filters as $filter ) {
-				// phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Public feed with secret key validation, sanitized by sanitize_filter().
+				if ( in_array( $filter, $disallowed_filters, true ) ) {
+					continue;
+				}
+				// phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Public feed validated by per-user secret; sanitized by sanitize_filter().
 				if ( isset( $_GET[ $filter ] ) ) {
-					// phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Public feed with secret key validation, sanitized by sanitize_filter().
+					// phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Public feed validated by per-user secret; sanitized by sanitize_filter().
 					$value = $this->sanitize_filter( $filter, $_GET[ $filter ] );
 					if ( false !== $value ) {
 						$post_query_args[ $filter ] = $value;
@@ -681,15 +721,18 @@ if ( ! class_exists( 'EF_Calendar' ) ) {
 				return;
 			}
 
-			if ( ! current_user_can( 'manage_options' ) ) {
+			// Any calendar-capable user may rotate their own feed token (per-user revocation).
+			$view_cap = apply_filters( 'ef_view_calendar_cap', 'ef_view_calendar' );
+			if ( ! current_user_can( $view_cap ) ) {
 				wp_die( esc_html( $this->module->messages['invalid-permissions'] ) );
 			}
 
-			if ( ! isset( $_GET['_wpnonce'] ) || ! wp_verify_nonce( $_GET['_wpnonce'], 'ef-regenerate-ics-key' ) ) { // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+			if ( ! isset( $_GET['_wpnonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_GET['_wpnonce'] ) ), 'ef-regenerate-ics-key' ) ) {
 				wp_die( esc_html( $this->module->messages['nonce-failed'] ) );
 			}
 
-			EditFlow()->update_module_option( $this->module->name, 'ics_secret_key', wp_generate_password() );
+			// Mint a fresh secret for the current user only; other users' feed URLs are unaffected.
+			$this->update_user_meta( get_current_user_id(), self::usermeta_key_prefix . 'ics_secret', wp_generate_password( 32, false ) );
 
 			wp_safe_redirect( add_query_arg( 'message', 'key-regenerated', menu_page_url( $this->module->settings_slug, false ) ) );
 			exit;
@@ -1408,7 +1451,17 @@ if ( ! class_exists( 'EF_Calendar' ) ) {
 			);
 
 			// Filter for an end user to implement any of their own query args.
-			$args         = apply_filters( 'ef_calendar_posts_query_args', $args, $context );
+			$args = apply_filters( 'ef_calendar_posts_query_args', $args, $context );
+
+			// In the public .ics subscription context the request runs as the resolved feed user
+			// (see handle_ics_subscription()). Mirror the core posts list: a user who cannot edit
+			// others' posts only sees their own, so a leaked feed URL cannot disclose other
+			// authors' unpublished posts. Applied after the filter so it cannot be bypassed via
+			// ef_calendar_posts_query_args. The dashboard calendar (cap-gated) is unaffected.
+			if ( 'ics_subscription' === $context && ! current_user_can( 'edit_others_posts' ) ) {
+				$args['author'] = get_current_user_id();
+			}
+
 			$post_results = new WP_Query( $args );
 
 			$posts = array();
@@ -1612,11 +1665,6 @@ if ( ! class_exists( 'EF_Calendar' ) ) {
 			$regenerate_url = add_query_arg( 'action', 'ef_calendar_regenerate_calendar_feed_secret', admin_url( 'index.php' ) );
 			$regenerate_url = wp_nonce_url( $regenerate_url, 'ef-regenerate-ics-key' );
 			echo '&nbsp;&nbsp;&nbsp;<a href="' . esc_url( $regenerate_url ) . '">' . esc_html__( 'Regenerate calendar feed secret', 'edit-flow' ) . '</a>';
-
-			// If our secret key doesn't exist, create a new one.
-			if ( empty( $this->module->options->ics_secret_key ) ) {
-				EditFlow()->update_module_option( $this->module->name, 'ics_secret_key', wp_generate_password() );
-			}
 		}
 
 		/**

--- a/tests/Integration/CalendarIcsSubscriptionAjaxTest.php
+++ b/tests/Integration/CalendarIcsSubscriptionAjaxTest.php
@@ -1,0 +1,252 @@
+<?php
+/**
+ * Calendar .ics subscription feed AJAX integration tests.
+ *
+ * @package Automattic\EditFlow\Tests\Integration
+ */
+
+declare( strict_types=1 );
+
+namespace Automattic\EditFlow\Tests\Integration;
+
+use WPAjaxDieContinueException;
+use WPAjaxDieStopException;
+
+/**
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ */
+class CalendarIcsSubscriptionAjaxTest extends AjaxTestCase {
+
+	const SECRET_META_KEY = 'ef_calendar_ics_secret';
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		global $edit_flow;
+		$edit_flow->calendar->install();
+
+		// init() registers the feed AJAX actions only after the ef_view_calendar gate, so
+		// run it as a capable user (it runs per request as the logged-in user in production).
+		wp_set_current_user( $this->factory->user->create( array( 'role' => 'administrator' ) ) );
+		$edit_flow->calendar->init();
+
+		// The handler bails unless the subscription feature is enabled.
+		$edit_flow->calendar->module->options->ics_subscription = 'on';
+		// The module's post-type options are not loaded in the bare test harness; without a
+		// supported post type the calendar query matches nothing.
+		$edit_flow->calendar->module->options->post_types = array( 'post' => 'on' );
+	}
+
+	/**
+	 * The unauthenticated feed handler must be registered for logged-out users, i.e. the
+	 * nopriv hook must sit above the ef_view_calendar capability gate. This guards the
+	 * structural root cause of the disclosure against future refactors.
+	 */
+	public function test_nopriv_hook_registered_for_logged_out_users(): void {
+		global $edit_flow;
+
+		wp_set_current_user( 0 );
+		$edit_flow->calendar->init();
+
+		$this->assertNotFalse(
+			has_action( 'wp_ajax_nopriv_ef_calendar_ics_subscription', array( $edit_flow->calendar, 'handle_ics_subscription' ) ),
+			'The .ics feed handler must be registered for logged-out users.'
+		);
+	}
+
+	/**
+	 * A valid per-user token returns that user's feed to a logged-out caller.
+	 */
+	public function test_valid_token_returns_user_feed(): void {
+		$author_id = $this->factory->user->create( array( 'role' => 'author' ) );
+		$secret    = 'valid-secret-token-aaaaaaaaaaaaaa';
+		update_user_meta( $author_id, self::SECRET_META_KEY, $secret );
+		$this->create_scheduled_post( $author_id, 'AAA_OWN_SCHEDULED' );
+
+		$this->request_as_logged_out( get_userdata( $author_id )->user_login, $secret );
+		$result = $this->dispatch_feed();
+
+		$this->assertTrue( $result['ok'], 'A valid token should return the feed.' );
+		$this->assertStringContainsString( 'AAA_OWN_SCHEDULED', $result['body'] );
+	}
+
+	/**
+	 * Core regression: a leaked feed URL must not disclose other authors' unpublished posts.
+	 */
+	public function test_leaked_url_hides_other_authors_unpublished(): void {
+		$author_id = $this->factory->user->create( array( 'role' => 'author' ) );
+		$other_id  = $this->factory->user->create( array( 'role' => 'author' ) );
+		$secret    = 'author-a-secret-token-bbbbbbbbbb';
+		update_user_meta( $author_id, self::SECRET_META_KEY, $secret );
+
+		$this->create_scheduled_post( $author_id, 'AAA_OWN_SCHEDULED' );
+		$this->create_scheduled_post( $other_id, 'BBB_SECRET_SCHEDULED' );
+
+		$this->request_as_logged_out( get_userdata( $author_id )->user_login, $secret );
+		$result = $this->dispatch_feed();
+
+		$this->assertTrue( $result['ok'] );
+		$this->assertStringContainsString( 'AAA_OWN_SCHEDULED', $result['body'] );
+		$this->assertStringNotContainsString( 'BBB_SECRET_SCHEDULED', $result['body'], "Another author's unpublished post must not leak." );
+	}
+
+	/**
+	 * Privilege-correct: an editor (can edit others' posts) still sees the whole pipeline.
+	 */
+	public function test_editor_feed_includes_other_authors_unpublished(): void {
+		$editor_id = $this->factory->user->create( array( 'role' => 'editor' ) );
+		$other_id  = $this->factory->user->create( array( 'role' => 'author' ) );
+		$secret    = 'editor-secret-token-cccccccccccc';
+		update_user_meta( $editor_id, self::SECRET_META_KEY, $secret );
+
+		$this->create_scheduled_post( $editor_id, 'EEE_OWN_SCHEDULED' );
+		$this->create_scheduled_post( $other_id, 'BBB_OTHER_SCHEDULED' );
+
+		$this->request_as_logged_out( get_userdata( $editor_id )->user_login, $secret );
+		$result = $this->dispatch_feed();
+
+		$this->assertTrue( $result['ok'] );
+		$this->assertStringContainsString( 'EEE_OWN_SCHEDULED', $result['body'] );
+		$this->assertStringContainsString( 'BBB_OTHER_SCHEDULED', $result['body'] );
+	}
+
+	/**
+	 * An incorrect token is rejected and emits no calendar body.
+	 */
+	public function test_invalid_token_rejected(): void {
+		$author_id = $this->factory->user->create( array( 'role' => 'author' ) );
+		update_user_meta( $author_id, self::SECRET_META_KEY, 'the-real-secret-dddddddddddddddd' );
+
+		$this->request_as_logged_out( get_userdata( $author_id )->user_login, 'wrong-token' );
+		$result = $this->dispatch_feed();
+
+		$this->assertFalse( $result['ok'] );
+		$this->assertStringNotContainsString( 'BEGIN:VCALENDAR', $result['body'] );
+	}
+
+	/**
+	 * Back-compat: legacy URLs (user_key = md5(login . site secret)) no longer validate.
+	 */
+	public function test_legacy_site_secret_url_rejected(): void {
+		$author_id = $this->factory->user->create( array( 'role' => 'author' ) );
+		$login     = get_userdata( $author_id )->user_login;
+		// No per-user secret is stored; the old URL relied on a shared site secret.
+		$legacy_key = md5( $login . 'legacy-site-wide-secret' );
+
+		$this->request_as_logged_out( $login, $legacy_key );
+		$result = $this->dispatch_feed();
+
+		$this->assertFalse( $result['ok'], 'Legacy md5(site-secret) URLs must stop working.' );
+	}
+
+	/**
+	 * Caller-supplied author/post_status filters are ignored on the public feed.
+	 */
+	public function test_request_author_and_status_filters_ignored(): void {
+		$author_id = $this->factory->user->create( array( 'role' => 'author' ) );
+		$other_id  = $this->factory->user->create( array( 'role' => 'author' ) );
+		$secret    = 'filter-test-secret-eeeeeeeeeeee';
+		update_user_meta( $author_id, self::SECRET_META_KEY, $secret );
+
+		$this->create_scheduled_post( $author_id, 'AAA_OWN_SCHEDULED' );
+		$this->create_scheduled_post( $other_id, 'BBB_SECRET_SCHEDULED' );
+
+		$this->request_as_logged_out( get_userdata( $author_id )->user_login, $secret );
+		// Attempt to widen the feed to the other author's posts.
+		$_GET['author']      = (string) $other_id;
+		$_GET['post_status'] = 'future';
+
+		$result = $this->dispatch_feed();
+
+		$this->assertTrue( $result['ok'] );
+		$this->assertStringContainsString( 'AAA_OWN_SCHEDULED', $result['body'] );
+		$this->assertStringNotContainsString( 'BBB_SECRET_SCHEDULED', $result['body'], 'Request filters must not widen the feed.' );
+	}
+
+	/**
+	 * Per-user secrets are isolated: one user's token cannot read another user's feed.
+	 */
+	public function test_per_user_secrets_are_isolated(): void {
+		$author_a = $this->factory->user->create( array( 'role' => 'author' ) );
+		$author_b = $this->factory->user->create( array( 'role' => 'author' ) );
+		update_user_meta( $author_a, self::SECRET_META_KEY, 'secret-a-ffffffffffffffffffffff' );
+		update_user_meta( $author_b, self::SECRET_META_KEY, 'secret-b-gggggggggggggggggggggg' );
+
+		// A's token presented for B's feed must be rejected.
+		$this->request_as_logged_out( get_userdata( $author_b )->user_login, 'secret-a-ffffffffffffffffffffff' );
+		$result = $this->dispatch_feed();
+
+		$this->assertFalse( $result['ok'], "One user's secret must not validate another user's feed." );
+	}
+
+	/**
+	 * An unknown username is rejected (and does not error on the null-user path).
+	 */
+	public function test_unknown_user_rejected(): void {
+		$this->request_as_logged_out( 'ghost-user-does-not-exist', 'any-token' );
+		$result = $this->dispatch_feed();
+
+		$this->assertFalse( $result['ok'] );
+	}
+
+	/**
+	 * Create a scheduled (future) post within the feed window.
+	 *
+	 * The feed renders unpublished content; in the test harness the inner WP_Query runs in
+	 * non-admin mode, where scheduled posts are returned (drafts are not), so 'future' is
+	 * used to exercise the unpublished-disclosure scoping faithfully.
+	 *
+	 * @param int    $author_id The post author.
+	 * @param string $title     The post title to look for in the feed output.
+	 * @return int The created post ID.
+	 */
+	private function create_scheduled_post( int $author_id, string $title ): int {
+		return $this->factory->post->create( array(
+			'post_status' => 'future',
+			'post_author' => $author_id,
+			'post_title'  => $title,
+			'post_date'   => date( 'Y-m-d H:i:s', time() + 2 * DAY_IN_SECONDS ),
+		) );
+	}
+
+	/**
+	 * Simulate an unauthenticated feed request for the given login and key.
+	 *
+	 * @param string $login    The user_login to request the feed for.
+	 * @param string $user_key The feed secret presented by the caller.
+	 */
+	private function request_as_logged_out( string $login, string $user_key ): void {
+		wp_set_current_user( 0 );
+		$_GET['user']     = $login;
+		$_GET['user_key'] = $user_key;
+	}
+
+	/**
+	 * Dispatch the feed action and report whether it produced a body.
+	 *
+	 * @return array{ok: bool, body: string}
+	 */
+	private function dispatch_feed(): array {
+		$this->_last_response = '';
+		try {
+			$this->_handleAjax( 'ef_calendar_ics_subscription' );
+		} catch ( WPAjaxDieContinueException $e ) {
+			unset( $e );
+			return array(
+				'ok'   => true,
+				'body' => (string) $this->_last_response,
+			);
+		} catch ( WPAjaxDieStopException $e ) {
+			unset( $e );
+			return array(
+				'ok'   => false,
+				'body' => (string) $this->_last_response,
+			);
+		}
+		return array(
+			'ok'   => false,
+			'body' => (string) $this->_last_response,
+		);
+	}
+}


### PR DESCRIPTION
## Summary

The calendar's `.ics` subscription feed is served from a `nopriv` AJAX handler, so it is reachable without logging in. Its only gate was `user_key = md5( user_login . <single site-wide secret> )`, compared in non-constant time, and the feed query was never scoped to the named user — it even honoured caller-supplied `author`/`post_status` filters. Because admin-ajax runs with `is_admin()` true, anyone holding a feed URL could read other authors' unpublished posts, and a single leaked URL (or knowledge of the shared secret) compromised every user's feed.

This reworks the feed around a **per-user, revocable secret** stored in user meta. The handler resolves the supplied username to a real user, requires that user can view the calendar, and validates the secret with `hash_equals()` — run unconditionally against a real-or-dummy value to limit username enumeration via timing. It then runs the feed **as the resolved user** and restricts the query to that user's own posts unless they can edit others' (mirroring the core posts list), so a leaked URL can no longer disclose other authors' work. Caller-supplied `author`/`post_status` filters are ignored on this context, and the "Regenerate calendar feed secret" action now rotates only the current user's token rather than everyone's.

This is a deliberate hard cutover: old `md5(site-secret)` URLs stop working, and each user re-copies their new URL from Screen Options on the Calendar (it is minted on first view). That is the point — the old, broadly-guessable URLs are invalidated.

Fixes VIPPLUG-4.

## Test plan

- [ ] `composer test:integration -- --filter CalendarIcsSubscriptionAjaxTest` passes (9 tests): valid token returns the user's own feed; a leaked URL does not expose another author's unpublished posts; an editor still sees the whole pipeline; invalid, legacy `md5(site-secret)`, and unknown-user requests are rejected; per-user secrets are isolated; and caller `author`/`post_status` filters are ignored. It also asserts the `nopriv` hook is registered for logged-out users, guarding the structural root cause.
- [ ] Existing calendar tests still pass (`--filter 'CalendarModule|CalendarMetadataAjax'` and the `Calendar` unit class): 29 tests green; the dashboard query path is untouched (the new scoping is gated on the subscription context).
- [ ] PHPCS clean on the changed files.
- [ ] Manual: enable the feed, copy your URL from Screen Options, load it logged-out and confirm you see only your own pipeline; confirm an old URL no longer works; confirm "Regenerate" only rotates your own token.

> Reviewer note: the integration harness's inner `WP_Query` runs in non-admin mode, where scheduled (`future`) posts are returned but drafts are not, so the tests use `future` posts — a genuinely unpublished status the harness exposes — to exercise the scoping. In production (real admin-ajax) the same scoping covers drafts and pending too.