### PR TITLE
update EF_Module->users_select_form() to remove faulty escaping of checkbox attributes and fix "No one will be notified" message

### DIFF
--- a/common/php/class-module.php
+++ b/common/php/class-module.php
@@ -560,15 +560,22 @@ if ( ! class_exists( 'EF_Module' ) ) {
 			<ul class="<?php echo esc_attr( $list_class ); ?>">
 				<?php
 				foreach ( $users as $user ) :
-					$checked = ( in_array( $user->ID, $selected ) ) ? 'checked="checked"' : '';
-					// Add a class to checkbox of current user so we know not to add them in notified list during notifiedMessage() js function.
-					$current_user_class = ( get_current_user_id() == $user->ID ) ? 'class="post_following_list-current_user" ' : '';
+					$checked = in_array( $user->ID, $selected );
 					?>
 					<li>
 						<label for="<?php echo esc_attr( $input_id . '-' . $user->ID ); ?>">
 							<div class="ef-user-subscribe-actions">
 								<?php do_action( 'ef_user_subscribe_actions', $user->ID, $checked ); ?>
-								<input type="checkbox" id="<?php echo esc_attr( $input_id . '-' . $user->ID ); ?>" name="<?php echo esc_attr( $input_id ); ?>[]" value="<?php echo esc_attr( $user->ID ); ?>" <?php echo $checked; ?> <?php echo $current_user_class;?>
+								<input type="checkbox" id="<?php echo esc_attr( $input_id . '-' . $user->ID ); ?>" name="<?php echo esc_attr( $input_id ); ?>[]" value="<?php echo esc_attr( $user->ID ); ?>"
+								<?php 
+								if ( $checked ) {
+									echo "checked='checked' ";
+								}
+								// Add a class to checkbox of current user so we know not to add them in notified list during notifiedMessage() js function.
+								if ( get_current_user_id() == $user->ID ) {
+									echo 'class="post_following_list-current_user" ';
+								}
+								?>
 								/>
 							</div>
 

--- a/common/php/class-module.php
+++ b/common/php/class-module.php
@@ -568,11 +568,7 @@ if ( ! class_exists( 'EF_Module' ) ) {
 						<label for="<?php echo esc_attr( $input_id . '-' . $user->ID ); ?>">
 							<div class="ef-user-subscribe-actions">
 								<?php do_action( 'ef_user_subscribe_actions', $user->ID, $checked ); ?>
-								<input type="checkbox" id="<?php echo esc_attr( $input_id . '-' . $user->ID ); ?>" name="<?php echo esc_attr( $input_id ); ?>[]" value="<?php echo esc_attr( $user->ID ); ?>"
-																		<?php
-																		echo esc_attr( $checked );
-																		echo esc_attr( $current_user_class );
-																		?>
+								<input type="checkbox" id="<?php echo esc_attr( $input_id . '-' . $user->ID ); ?>" name="<?php echo esc_attr( $input_id ); ?>[]" value="<?php echo esc_attr( $user->ID ); ?>" <?php echo $checked; ?> <?php echo $current_user_class;?>
 								/>
 							</div>
 

--- a/tests/Integration/ModuleTest.php
+++ b/tests/Integration/ModuleTest.php
@@ -103,6 +103,59 @@ class ModuleTest extends TestCase {
 		set_current_screen( 'front' );
 	}
 
+	/**
+	 * The current user's checkbox must carry the marker class verbatim.
+	 *
+	 * Regression guard for PR #980: the class (and checked) attributes are
+	 * built as complete HTML strings, so running them through esc_attr()
+	 * entity-encodes the quotes and produces broken markup such as
+	 * `class=&quot;post_following_list-current_user&quot;`, which silently
+	 * drops the class the notifiedMessage() JS relies on.
+	 */
+	function test_users_select_form_outputs_current_user_class_unescaped() {
+		wp_set_current_user( self::$admin_user_id );
+
+		$html = $this->get_users_select_form_html( array( self::$admin_user_id ) );
+
+		$this->assertStringContainsString(
+			'class="post_following_list-current_user"',
+			$html,
+			'Current user checkbox is missing the marker class.'
+		);
+		$this->assertStringNotContainsString(
+			'&quot;',
+			$html,
+			'Attributes were entity-encoded, indicating esc_attr() corruption.'
+		);
+	}
+
+	/**
+	 * A selected user's checkbox should render a working checked attribute.
+	 */
+	function test_users_select_form_marks_selected_user_checked() {
+		wp_set_current_user( self::$admin_user_id );
+
+		$html = $this->get_users_select_form_html( array( self::$admin_user_id ) );
+
+		$this->assertMatchesRegularExpression(
+			'/checked=([\'"])checked\1/',
+			$html,
+			'Selected user checkbox is not marked as checked.'
+		);
+	}
+
+	/**
+	 * Capture the echoed output of users_select_form().
+	 *
+	 * @param array $selected User IDs to mark as selected.
+	 * @return string Rendered HTML.
+	 */
+	private function get_users_select_form_html( array $selected ): string {
+		ob_start();
+		self::$EditFlowModule->users_select_form( $selected );
+		return (string) ob_get_clean();
+	}
+
 	public static function wpTearDownAfterClass() {
 		self::delete_user( self::$admin_user_id );
 	}


### PR DESCRIPTION
Removes `esc_attr()` from use of `$checked` and `$current_user_class` variables before display.

Using `esc_html()` on these values destroys the quotations inside them, resulting in HTML output like this in the HTML source:

```html
checked=&quot;checked&quot;class=&quot;post_following_list-current_user&quot;
```

Notably, this leaves `checked` functional, because the browser interprets all that mess as `true`, so the basics of subscribing and unsubscribing people continues to function superficially, but of course the `class` is non-functional.

The bug that made me notice this was that the `$current_user_class` wasn't having the intended effect in Editorial Comments, where it should ensure that the current user doesn't show up as a recipient of editorial comments. Without this patch, you always see yourself listed as a recipient, and you will NEVER see the "No one will be notified" message.

I don't know who added that escaping but it seems unnecessary to me, considering the HTML being output is defined deterministically in the code right above the usage, so there's no way it could be suspicious. Honestly the way those lines were formatted makes me think it was a misbehaving AI. I reformatted them to match how the rest of the `<input>` is output.

I'm not familiar with the testing framework for EF, but it would be great to have some kind of test to confirm that "No one will be notified" shows up at the appropriate time in the UI, to avoid this kind of thing getting out in the future.

Thanks for reviewing!

## Steps to Test

* Open up a post, save, and reload so that Editorial Comments are functioning
* Click to start a new response
* Without the patch: 
  * See yourself listed as a recipient
  * HTML source shows mess of `&quot`
* With the patch: 
  * See "No one will be notified" until you add a user who is not yourself
  * HTML source shows clean `checked` and `class` attributes.