### PR TITLE
Fix broken CHANGELOG.md link in plugin readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,4 +60,4 @@ For support questions, feedback and ideas, please use the [WordPress.org forums]
 
 ## Changelog
 
-See [CHANGELOG.md](CHANGELOG.md) for the full changelog.
+See [CHANGELOG.md](https://github.com/Automattic/edit-flow/blob/develop/CHANGELOG.md) for the full changelog.


### PR DESCRIPTION
## Summary

The changelog link shown on the WordPress.org plugin page and in the wp-admin "View details" modal led nowhere, as reported in #979. Both surfaces are rendered from `README.md` (this plugin has no `readme.txt`, so wordpress.org parses the markdown readme instead), and its Changelog section linked to `CHANGELOG.md` with a relative path.

A relative link works on GitHub but resolves against the plugin page URL on wordpress.org, so it pointed back at the plugin listing rather than the changelog. The file is also `export-ignore`d and listed in `.distignore`, so it is never shipped in the distributed plugin, meaning a relative link could not resolve there under any circumstance.

The fix points the link at `CHANGELOG.md` on GitHub via an absolute URL, so it resolves correctly from both the public plugin page and the admin details modal while keeping the project's existing approach of maintaining the changelog as a separate file.

Fixes VIPPLUG-15
Closes #979

## Test plan

- [ ] Confirm the link in `README.md` resolves to the changelog on GitHub.
- [ ] After the next release, confirm the Changelog link on the wordpress.org plugin page and in the wp-admin plugin details modal opens the changelog.