### PR TITLE
Harden the settings and screen-options save handlers

### DIFF
--- a/common/php/screen-options.php
+++ b/common/php/screen-options.php
@@ -173,6 +173,13 @@ if ( ! class_exists( 'wsScreenOptions10' ) ) :
 			// Basic security check.
 			check_ajax_referer( 'save_settings-' . $id, '_wpnonce-' . $id );
 
+			// Baseline capability gate (defence-in-depth). Edit Flow's Screen Options panels
+			// are editorial admin features; each registered save_callback should additionally
+			// enforce its own specific authorisation.
+			if ( ! current_user_can( 'edit_posts' ) ) {
+				wp_die( '0' );
+			}
+
 			// Hand the request to the registered callback, if any
 			if ( ! isset( $this->registered_panels[ $id ] ) ) {
 				wp_die( '0' );

--- a/modules/settings/settings.php
+++ b/modules/settings/settings.php
@@ -421,6 +421,13 @@ if ( ! class_exists( 'EF_Settings' ) ) {
 			global $edit_flow;
 			$module_name = sanitize_key( $_POST['edit_flow_module_name'] );
 
+			// Validate the submitted module name resolves to a real module before
+			// dereferencing it; this runs ahead of the capability check below, so a bogus
+			// name must not reach a property access on a non-object.
+			if ( ! isset( $edit_flow->$module_name ) || ! is_object( $edit_flow->$module_name ) ) {
+				return false;
+			}
+
 			if ( 'update' != $_POST['action']
 			|| $_POST['option_page'] != $edit_flow->$module_name->module->options_group_name ) {
 				return false;
@@ -437,6 +444,12 @@ if ( ! class_exists( 'EF_Settings' ) ) {
 			// Only call the validation callback if it exists.
 			if ( method_exists( $edit_flow->$module_name, 'settings_validate' ) ) {
 				$new_options = $edit_flow->$module_name->settings_validate( $new_options );
+			} else {
+				// Without a module validator, accept only keys that already exist in the
+				// module's options and sanitise their values, rather than persisting
+				// arbitrary submitted keys into the autoloaded options row.
+				$existing    = (array) $edit_flow->$module_name->module->options;
+				$new_options = map_deep( array_intersect_key( (array) $new_options, $existing ), 'sanitize_text_field' );
 			}
 
 			// Cast our object and save the data.


### PR DESCRIPTION
## Summary

A small defence-in-depth pass over two admin save handlers. None of these is independently exploitable — each path is already gated by a nonce, `manage_options`, or logged-in-only AJAX — but they tighten the edges.

In `helper_settings_validate_and_save()`, the submitted `edit_flow_module_name` was used to reach `$edit_flow->$module_name->module->options_group_name` before the capability and nonce checks, so a bogus name caused a property access on a non-object. It is now validated to resolve to a real module first. In the same method, when a module provides no `settings_validate()`, the save previously merged the entire submitted options array into the autoloaded options row; it now accepts only keys that already exist in the module's options and sanitises their values, so arbitrary keys can't be persisted.

In the generic Screen Options autosave (`common/php/screen-options.php`), the handler verified the nonce but performed no capability check. It now applies a baseline `edit_posts` gate, with a note that each registered `save_callback` should still enforce its own specific authorisation.

Fixes VIPPLUG-18.

## Test plan

- [ ] PHPCS and `php -l` clean on both files.
- [ ] Manual: save module settings as an administrator and confirm they still persist; confirm a submission with an unknown module name is rejected cleanly.

> Reviewer note: both handlers `exit`/redirect and are gated on `is_admin()`/nonces, so they're awkward to unit-test without brittle scaffolding. Given the small, low-risk nature of these changes I validated them with PHPCS and `php -l` rather than adding new tests.