### PR TITLE
Restrict notification subscriptions and harden the webhook sender

### DIFF
--- a/modules/notifications/notifications.php
+++ b/modules/notifications/notifications.php
@@ -494,6 +494,10 @@ if ( ! class_exists( 'EF_Notifications' ) ) {
 			}
 
 			if ( 'ef-selected-users[]' === $_POST['ef_notifications_name'] ) {
+				// Only subscribe users offered by the subscription picker (the publish_posts
+				// set); arbitrary user IDs in the request must not be added as followers.
+				$user_group_ids = array_values( array_intersect( $user_group_ids, $this->get_subscribable_user_ids() ) );
+
 				// Prevent auto-subscribing users that have opted out of notifications.
 				add_filter( 'ef_notification_auto_subscribe_current_user', '__return_false', PHP_INT_MAX );
 				$this->save_post_following_users( $post, $user_group_ids );
@@ -622,8 +626,11 @@ if ( ! class_exists( 'EF_Notifications' ) ) {
 				return;
 			}
 
-			// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Values are sanitized when saved.
-			$users = isset( $_POST['ef-selected-users'] ) ? $_POST['ef-selected-users'] : [];
+			// Only subscribe users offered by the subscription picker (the publish_posts set);
+			// arbitrary user IDs in the request must not be added as followers.
+			// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Cast to integers and intersected with the allowed set below.
+			$submitted_users = isset( $_POST['ef-selected-users'] ) ? (array) wp_unslash( $_POST['ef-selected-users'] ) : [];
+			$users           = array_values( array_intersect( array_map( 'intval', $submitted_users ), $this->get_subscribable_user_ids() ) );
 			// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Values are sanitized when saved.
 			$usergroups = isset( $_POST['following_usergroups'] ) ? $_POST['following_usergroups'] : [];
 			$this->save_post_following_users( $post, $users );
@@ -1021,8 +1028,13 @@ if ( ! class_exists( 'EF_Notifications' ) ) {
 			// Apply filters to the payload.
 			$payload = apply_filters( 'ef_notification_send_to_webhook_payload', $payload, $action, $user, $post );
 
-			// Send the notification.
-			$response = wp_remote_post(
+			// The webhook is a side-effect fired from transition_post_status and editorial comment
+			// insertion, both of which have already completed by the time this runs (in AJAX and
+			// non-AJAX requests alike). A failure must therefore never die or abort, which would
+			// misreport an already-successful save/comment. Send best-effort with the SSRF-safe
+			// variant (private, loopback and link-local hosts are rejected) and expose any failure
+			// via an action so sites can log it.
+			$response = wp_safe_remote_post(
 				$webhook_url,
 				[
 					'body'    => wp_json_encode( $payload ),
@@ -1030,7 +1042,7 @@ if ( ! class_exists( 'EF_Notifications' ) ) {
 				]
 			);
 			if ( is_wp_error( $response ) ) {
-				$this->print_ajax_response( 'error', 'Unable to send notification to webhook provided', 400 );
+				do_action( 'ef_notification_webhook_failed', $response, $action, $user, $post );
 			}
 		}
 
@@ -1165,6 +1177,24 @@ if ( ! class_exists( 'EF_Notifications' ) ) {
 			 * @param int $post_id The post the user will be notified about.
 			 */
 			return (bool) apply_filters( 'ef_notification_user_can_be_notified', $can_be_notified, $user, $post_id );
+		}
+
+		/**
+		 * The set of user IDs that may be subscribed to a post, matching the subscription
+		 * picker (users_select_form). Used to reject arbitrary user IDs submitted in a request.
+		 *
+		 * @return int[] User IDs offered by the subscription picker.
+		 */
+		private function get_subscribable_user_ids() {
+			$args = apply_filters(
+				'ef_users_select_form_get_users_args',
+				array(
+					'capability' => 'publish_posts',
+					'fields'     => array( 'ID', 'display_name', 'user_nicename', 'user_email' ),
+					'orderby'    => 'display_name',
+				)
+			);
+			return array_map( 'intval', wp_list_pluck( get_users( $args ), 'ID' ) );
 		}
 
 		/**

--- a/tests/Integration/NotificationsTest.php
+++ b/tests/Integration/NotificationsTest.php
@@ -10,6 +10,7 @@ declare( strict_types=1 );
 namespace Automattic\EditFlow\Tests\Integration;
 
 use EF_Notifications;
+use WP_Error;
 use Yoast\WPTestUtils\WPIntegration\TestCase;
 
 class NotificationsTest extends TestCase {
@@ -107,5 +108,63 @@ class NotificationsTest extends TestCase {
 		$mailer = tests_retrieve_phpmailer_instance();
 
 		$this->assertTrue( strpos( $mailer->get_sent()->body, 'New => Draft' ) > 0 );
+	}
+
+	protected function tearDown(): void {
+		$_POST = array();
+		parent::tearDown();
+	}
+
+	/**
+	 * Saving subscriptions must ignore user IDs the subscription picker would not offer
+	 * (users without publish_posts), so arbitrary users cannot be subscribed to a post.
+	 */
+	public function test_save_subscriptions_ignores_ineligible_users() {
+		global $edit_flow;
+
+		wp_set_current_user( self::$admin_user_id );
+
+		$eligible_id   = self::factory()->user->create( array( 'role' => 'author' ) );      // has publish_posts.
+		$ineligible_id = self::factory()->user->create( array( 'role' => 'subscriber' ) );  // no publish_posts.
+
+		$post_id = self::factory()->post->create( array( 'post_author' => self::$admin_user_id ) );
+
+		$_POST['ef-save_followers']      = '1';
+		$_POST['ef_notifications_nonce'] = wp_create_nonce( 'save_user_usergroups' );
+		$_POST['ef-selected-users']      = array( (string) $eligible_id, (string) $ineligible_id );
+
+		$edit_flow->notifications->save_post_subscriptions( 'publish', 'draft', get_post( $post_id ) );
+
+		$followers = array_map( 'intval', (array) $edit_flow->notifications->get_following_users( $post_id, 'id' ) );
+
+		$this->assertContains( $eligible_id, $followers, 'An eligible (publish_posts) user should be subscribed.' );
+		$this->assertNotContains( $ineligible_id, $followers, 'A user the picker would not offer must not be subscribed.' );
+	}
+
+	/**
+	 * A failed webhook request must not abort the request it runs within (post transitions
+	 * and comment insertion are not always AJAX), so send_to_webhook returns instead of dying.
+	 */
+	public function test_webhook_failure_does_not_abort() {
+		global $edit_flow;
+
+		$edit_flow->notifications->module->options->webhook_url = 'https://example.com/webhook';
+
+		$blocker = static function () {
+			return new WP_Error( 'http_request_failed', 'blocked in test' );
+		};
+		add_filter( 'pre_http_request', $blocker );
+
+		$post_id = self::factory()->post->create();
+		$result  = $edit_flow->notifications->send_to_webhook(
+			'A message',
+			'status-change',
+			get_user_by( 'id', self::$admin_user_id ),
+			get_post( $post_id )
+		);
+
+		remove_filter( 'pre_http_request', $blocker );
+
+		$this->assertNull( $result, 'A failed webhook should return without aborting the request.' );
 	}
 }


### PR DESCRIPTION
## Summary

Two pieces of defence-in-depth in the notifications module.

The subscription picker only ever offers users who can `publish_posts`, but both save paths — the AJAX handler and the post-save form handler — stored whatever user IDs arrived in the request. An authorised editor could therefore add arbitrary users (a plain subscriber, say) as followers of a post. Both paths now intersect the submitted IDs with that same `publish_posts` candidate set before saving, so only users the picker would offer can be subscribed. The users auto-subscribed by the plugin (the current user and the post author) go through a separate path and are unaffected.

Separately, `send_to_webhook()` sent the payload with `wp_remote_post()` and, on failure, called `print_ajax_response()` which ends in `wp_die()`. That notification fires on post transitions and editorial-comment insertion, which are not always AJAX requests, so a failing webhook could abort an otherwise valid save. It now uses `wp_safe_remote_post()` — which validates the URL and rejects private, loopback and link-local hosts (SSRF) — and on failure fires an `ef_notification_webhook_failed` action for logging and returns rather than dying.

Fixes VIPPLUG-20.

## Test plan

- [ ] `composer test:integration -- --filter NotificationsTest` — a user the picker would not offer is not subscribed; a failed webhook returns without aborting.
- [ ] All notifications tests still pass (61 tests across the `Notifications*` classes).
- [ ] PHPCS and `php -l` clean.
- [ ] Manual: as an editor, subscribe a teammate (works) and confirm the saved followers never include non-editorial users; point the webhook at an unreachable URL and confirm post saves still succeed.