### PR TITLE
Gate calendar quick-create on the post type's create capability

### DIFF
--- a/modules/calendar/calendar.php
+++ b/modules/calendar/calendar.php
@@ -161,8 +161,13 @@ if ( ! class_exists( 'EF_Calendar' ) ) {
 				return false;
 			}
 
-			// Define the create-post capability.
-			$this->create_post_cap = apply_filters( 'ef_calendar_create_post_cap', 'edit_posts' );
+			// Define the create-post capability from the configured quick-create post type,
+			// rather than a generic 'edit_posts', so the check matches the post type actually
+			// being created. Falls back to 'edit_posts' if the type isn't registered yet.
+			$quick_create_type     = $this->module->options->quick_create_post_type;
+			$quick_create_type_obj = get_post_type_object( $quick_create_type );
+			$create_post_cap       = ( $quick_create_type_obj && ! empty( $quick_create_type_obj->cap->create_posts ) ) ? $quick_create_type_obj->cap->create_posts : 'edit_posts';
+			$this->create_post_cap = apply_filters( 'ef_calendar_create_post_cap', $create_post_cap );
 
 			add_action( 'admin_init', array( $this, 'add_screen_options_panel' ) );
 			add_action( 'admin_init', array( $this, 'handle_save_screen_options' ) );


### PR DESCRIPTION
## Summary

The calendar's quick-create feature decided who may add a placeholder post by checking a hard-coded, generic `edit_posts` capability, even though it creates a post of the configured quick-create post type. For a post type whose create capability differs from `edit_posts`, that check is the wrong gate.

The capability is now derived from the post type itself — `get_post_type_object( quick_create_post_type )->cap->create_posts`, falling back to `edit_posts` if the type isn't registered. Because this single value drives both the "add post" UI gating and the AJAX insert handler's check, the two stay consistent.

For the default `post` type, `create_posts` resolves to `edit_posts`, so there is no behaviour change; this is defence-in-depth for custom post types with distinct capabilities.

Fixes VIPPLUG-21.

## Test plan

- [ ] Existing calendar tests still pass (the default-`post` behaviour is unchanged).
- [ ] PHPCS and `php -l` clean.
- [ ] Manual (custom post type): set Quick Create to a post type whose `create_posts` capability differs from `edit_posts`, and confirm a user with `edit_posts` but not that create cap can no longer quick-create it.

> No bespoke automated test was added: the default-type path is a no-op covered by the existing calendar suite, and exercising the custom-post-type path would require registering a CPT with a distinct create capability and reflecting a private property — disproportionate for this benign change.