### PR TITLE
Harden custom status migration and the publish-timestamp workaround

### DIFF
--- a/modules/custom-status/custom-status.php
+++ b/modules/custom-status/custom-status.php
@@ -805,6 +805,19 @@ if ( ! class_exists( 'EF_Custom_Status' ) ) {
 		}
 
 		/**
+		 * Get every status slug a post may validly be assigned: the core statuses plus all
+		 * registered custom statuses. Used to validate migration/reassignment targets.
+		 *
+		 * @return string[] Valid status slugs.
+		 */
+		public function get_all_valid_statuses() {
+			$core_statuses = [ 'publish', 'pending', 'draft', 'private', 'trash', 'future' ];
+			$custom_slugs  = wp_list_pluck( $this->get_custom_statuses(), 'slug' );
+
+			return array_values( array_unique( array_merge( $core_statuses, $custom_slugs ) ) );
+		}
+
+		/**
 		 * Display our custom post statuses in post listings when needed.
 		 *
 		 * @param array   $post_states An array of post display states.
@@ -1169,6 +1182,11 @@ if ( ! class_exists( 'EF_Custom_Status' ) ) {
 				wp_die( esc_html__( 'Source and target status cannot be the same.', 'edit-flow' ) );
 			}
 
+			// The target must be a real status, otherwise posts would be stranded in a status that does not exist.
+			if ( ! in_array( $to_status, $this->get_all_valid_statuses(), true ) ) {
+				wp_die( esc_html__( 'Please select a valid target status.', 'edit-flow' ) );
+			}
+
 			// Perform the migration.
 			$this->reassign_post_status( $from_status, $to_status );
 
@@ -1476,13 +1494,23 @@ if ( ! class_exists( 'EF_Custom_Status' ) ) {
 				return;
 			}
 
-			// Handles the transition to 'publish' on edit.php.
-			// phpcs:disable WordPress.Security.NonceVerification.Recommended -- Core request data checked for bulk edit transition.
+			// Handles the transition to 'publish' on edit.php (bulk edit).
+			// phpcs:disable WordPress.Security.NonceVerification.Recommended -- The bulk-edit nonce is verified below before any write.
 			if ( isset( $edit_flow ) && 'edit.php' === $pagenow && isset( $_REQUEST['bulk_edit'] ) ) {
+				// Verify the bulk-edit nonce before touching any posts.
+				// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Nonce value passed directly to wp_verify_nonce().
+				if ( ! isset( $_REQUEST['_wpnonce'] ) || ! wp_verify_nonce( $_REQUEST['_wpnonce'], 'bulk-posts' ) ) {
+					return;
+				}
+
 				// For every post_id, set the post_status as 'pending' only when there's no timestamp set for $post_date_gmt.
 				if ( isset( $_REQUEST['post'] ) && isset( $_REQUEST['_status'] ) && 'publish' == $_REQUEST['_status'] ) {
 					$post_ids = array_map( 'intval', (array) $_REQUEST['post'] );
 					foreach ( $post_ids as $post_id ) {
+						// Only act on posts the current user is allowed to edit.
+						if ( ! current_user_can( 'edit_post', $post_id ) ) {
+							continue;
+						}
 						// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Core workaround for custom status timestamp.
 						$wpdb->update( $wpdb->posts, [ 'post_status' => 'pending' ], [
 							'ID'            => $post_id,
@@ -1495,31 +1523,36 @@ if ( ! class_exists( 'EF_Custom_Status' ) ) {
 			// phpcs:enable
 
 			// Handles the transition to 'publish' on post.php.
-			// phpcs:disable WordPress.Security.NonceVerification.Missing -- Core post edit transition check.
-			if ( isset( $edit_flow ) && 'post.php' == $pagenow && isset( $_POST['publish'] ) ) {
+			// phpcs:disable WordPress.Security.NonceVerification.Missing -- The post-edit nonce is verified below before any write.
+			if ( isset( $edit_flow ) && 'post.php' == $pagenow && isset( $_POST['publish'] ) && isset( $_POST['post_ID'] ) ) {
+				$post_id = (int) $_POST['post_ID'];
+
+				// Verify the post-edit nonce and capability before touching the post.
+				// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Nonce value passed directly to wp_verify_nonce().
+				if ( ! isset( $_POST['_wpnonce'] ) || ! wp_verify_nonce( $_POST['_wpnonce'], 'update-post_' . $post_id ) || ! current_user_can( 'edit_post', $post_id ) ) {
+					return;
+				}
+
 				// Set the post_status as 'pending' only when there's no timestamp set for $post_date_gmt.
-				if ( isset( $_POST['post_ID'] ) ) {
-					$post_id = (int) $_POST['post_ID'];
-					// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Core workaround for custom status timestamp.
-					$ret = $wpdb->update( $wpdb->posts, [ 'post_status' => 'pending' ], [
-						'ID'            => $post_id,
-						'post_date_gmt' => '0000-00-00 00:00:00',
-					] );
-					clean_post_cache( $post_id );
-					foreach ( [ 'aa', 'mm', 'jj', 'hh', 'mn' ] as $timeunit ) {
-						if ( isset( $_POST[ $timeunit ] ) && ! empty( $_POST[ 'hidden_' . $timeunit ] ) && $_POST[ 'hidden_' . $timeunit ] != $_POST[ $timeunit ] ) {
-							$edit_date = '1';
-							break;
-						}
-					}
-					if ( $ret && empty( $edit_date ) ) {
-						add_filter( 'pre_post_date', [ $this, 'helper_timestamp_hack' ] );
-						add_filter( 'pre_post_date_gmt', [ $this, 'helper_timestamp_hack' ] );
+				// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Core workaround for custom status timestamp.
+				$ret = $wpdb->update( $wpdb->posts, [ 'post_status' => 'pending' ], [
+					'ID'            => $post_id,
+					'post_date_gmt' => '0000-00-00 00:00:00',
+				] );
+				clean_post_cache( $post_id );
+				foreach ( [ 'aa', 'mm', 'jj', 'hh', 'mn' ] as $timeunit ) {
+					if ( isset( $_POST[ $timeunit ] ) && ! empty( $_POST[ 'hidden_' . $timeunit ] ) && $_POST[ 'hidden_' . $timeunit ] != $_POST[ $timeunit ] ) {
+						$edit_date = '1';
+						break;
 					}
 				}
+				if ( $ret && empty( $edit_date ) ) {
+					add_filter( 'pre_post_date', [ $this, 'helper_timestamp_hack' ] );
+					add_filter( 'pre_post_date_gmt', [ $this, 'helper_timestamp_hack' ] );
+				}
 			}
+			// phpcs:enable WordPress.Security.NonceVerification.Missing
 		}
-		// phpcs:enable WordPress.Security.NonceVerification.Missing
 
 		/**
 		 * PHP < 5.3.x doesn't support anonymous functions.

--- a/modules/custom-status/lib/class-cli.php
+++ b/modules/custom-status/lib/class-cli.php
@@ -314,22 +314,14 @@ class EF_Custom_Status_CLI extends WP_CLI_Command {
 	 * @return array
 	 */
 	private function get_all_valid_statuses() {
-		$statuses = [];
-
-		// Add core statuses.
-		$core_statuses = [ 'publish', 'pending', 'draft', 'private', 'trash', 'future' ];
-		$statuses      = array_merge( $statuses, $core_statuses );
-
-		// Add custom statuses.
 		$custom_status_module = $this->get_custom_status_module();
-		if ( $custom_status_module ) {
-			$custom_statuses = $custom_status_module->get_custom_statuses();
-			foreach ( $custom_statuses as $status ) {
-				$statuses[] = $status->slug;
-			}
+
+		// Fall back to the core statuses if the module is somehow unavailable.
+		if ( ! $custom_status_module ) {
+			return [ 'publish', 'pending', 'draft', 'private', 'trash', 'future' ];
 		}
 
-		return array_unique( $statuses );
+		return $custom_status_module->get_all_valid_statuses();
 	}
 }
 

--- a/tests/Integration/CustomStatusTest.php
+++ b/tests/Integration/CustomStatusTest.php
@@ -894,4 +894,70 @@ class CustomStatusTest extends TestCase {
 
 		$this->assertEquals( $custom_post_name, $update_post->post_name );
 	}
+
+	/**
+	 * The status-migration allow-list must cover every core status and every registered
+	 * custom status, while rejecting anything that is not a real status. This is what the
+	 * migration handler validates the target against before reassigning posts.
+	 */
+	public function test_get_all_valid_statuses_includes_core_and_custom() {
+		$valid = self::$ef_custom_status->get_all_valid_statuses();
+
+		foreach ( array( 'publish', 'pending', 'draft', 'private', 'trash', 'future' ) as $core_status ) {
+			$this->assertContains( $core_status, $valid, "Core status '$core_status' should be a valid target." );
+		}
+
+		// 'pitch' is one of the default custom statuses installed in wpSetUpBeforeClass().
+		$this->assertContains( 'pitch', $valid, 'A registered custom status should be a valid target.' );
+
+		$this->assertNotContains( 'definitely-not-a-status', $valid, 'An unknown status must not be a valid target.' );
+	}
+
+	/**
+	 * The publish-timestamp workaround writes directly to the posts table, so it must not act
+	 * on a post.php request that lacks a valid edit nonce; otherwise a forged request could
+	 * flip another user's post to 'pending'. A properly nonced request still works.
+	 */
+	public function test_check_timestamp_on_publish_requires_valid_nonce() {
+		global $pagenow, $typenow, $wpdb;
+
+		wp_set_current_user( self::$admin_user_id );
+
+		$pagenow = 'post.php';
+		$typenow = 'post';
+
+		// Custom statuses must be active for this post type, or the workaround bails early.
+		if ( ! is_object( self::$ef_custom_status->module->options ) ) {
+			self::$ef_custom_status->module->options = new \stdClass();
+		}
+		self::$ef_custom_status->module->options->post_types = array(
+			'post' => 'on',
+			'page' => 'on',
+		);
+
+		$post_id = self::factory()->post->create( array(
+			'post_status' => 'draft',
+			'post_author' => self::$admin_user_id,
+		) );
+
+		// The workaround only fires when post_date_gmt is unset, so guarantee that state.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Test setup.
+		$wpdb->update( $wpdb->posts, array( 'post_date_gmt' => '0000-00-00 00:00:00' ), array( 'ID' => $post_id ) );
+		clean_post_cache( $post_id );
+
+		$_POST['publish'] = '1';
+		$_POST['post_ID'] = (string) $post_id;
+
+		// Without a nonce the handler must leave the post untouched.
+		unset( $_POST['_wpnonce'] );
+		self::$ef_custom_status->check_timestamp_on_publish();
+		$this->assertSame( 'draft', get_post_status( $post_id ), 'A request with no nonce must not change the status.' );
+
+		// With the correct post-edit nonce the workaround applies as before.
+		$_POST['_wpnonce'] = wp_create_nonce( 'update-post_' . $post_id );
+		self::$ef_custom_status->check_timestamp_on_publish();
+		$this->assertSame( 'pending', get_post_status( $post_id ), 'A correctly nonced request should apply the workaround.' );
+
+		$_POST = array();
+	}
 }


### PR DESCRIPTION
## Summary

Two long-standing rough edges in the custom-status module are tightened here.

The web status-migration handler used to reassign every post from one status to whatever target was submitted, without checking that the target was a real status. A typo or a forged value could therefore leave posts stranded in a status that does not exist. The handler now validates the submitted target against the full set of valid statuses — the core statuses plus every registered custom status. That set is exposed as a new public `get_all_valid_statuses()` method on the module, and the WP-CLI `migrate` command, which previously carried its own private copy of the same logic, now delegates to it so there is a single source of truth.

Separately, `check_timestamp_on_publish` is a workaround that writes `post_status` straight to the posts table when a post with no GMT timestamp transitions to publish, on both the `edit.php` bulk-edit path and the `post.php` single-publish path. It did no verification of its own. It now confirms the relevant edit nonce (`bulk-posts`, or `update-post_<id>`) and the per-post `edit_post` capability before writing. Because it runs on `admin_init`, it bails quietly rather than calling `wp_die` when a check fails, so legitimate requests are unaffected.

## Test plan

- `composer cs` and `parallel-lint` pass on the changed files.
- Two integration tests were added and pass: one confirms the valid-status allow-list covers both core and custom statuses, the other confirms the publish workaround makes no write without a valid nonce but still applies with one.
- The six pre-existing `CustomStatusTest` "post name not set" failures are unrelated to this branch and fail identically on `develop`.

Fixes VIPPLUG-22.