### PR TITLE
Block PHP object injection when decoding term descriptions

### DIFF
--- a/common/php/class-module.php
+++ b/common/php/class-module.php
@@ -501,7 +501,21 @@ if ( ! class_exists( 'EF_Module' ) ) {
 		 */
 		public function get_unencoded_description( $string_to_unencode ) {
 			// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode -- Required for term description retrieval.
-			return maybe_unserialize( base64_decode( $string_to_unencode ) );
+			$decoded = base64_decode( $string_to_unencode );
+
+			/*
+			 * Edit Flow only ever stores a serialized array here (see get_encoded_description()),
+			 * so forbid object instantiation during unserialisation. Without allowed_classes a
+			 * crafted term description could trigger PHP object injection. is_serialized() mirrors
+			 * maybe_unserialize()'s own gate, so a plain (unencoded) description still round-trips
+			 * unchanged and the callers' is_array() checks keep working.
+			 */
+			if ( is_serialized( $decoded ) ) {
+				// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_unserialize -- Hardened with allowed_classes => false; stored data is always a scalar array.
+				return unserialize( $decoded, array( 'allowed_classes' => false ) );
+			}
+
+			return $decoded;
 		}
 
 		/**

--- a/tests/Integration/ModuleTest.php
+++ b/tests/Integration/ModuleTest.php
@@ -145,6 +145,39 @@ class ModuleTest extends TestCase {
 	}
 
 	/**
+	 * A legitimate encoded description (a base64'd serialized array) must decode back to
+	 * the original array, so the allowed_classes hardening does not regress normal storage.
+	 */
+	function test_get_unencoded_description_round_trips_array() {
+		$data = array(
+			'description' => "O'Brien & co <stuff>",
+			'position'    => 3,
+			'viewable'    => false,
+		);
+
+		$encoded = self::$EditFlowModule->get_encoded_description( $data );
+		$decoded = self::$EditFlowModule->get_unencoded_description( $encoded );
+
+		$this->assertSame( $data, $decoded, 'A legitimate encoded array should round-trip unchanged.' );
+	}
+
+	/**
+	 * A crafted term description containing a serialized object must never be instantiated as
+	 * that class: unserialisation here forbids objects, so PHP object injection cannot fire.
+	 */
+	function test_get_unencoded_description_blocks_object_injection() {
+		// A serialized stdClass object (O:8:"stdClass":0:{}) standing in for any gadget payload.
+		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode -- Building a hostile payload for the test.
+		$payload = base64_encode( 'O:8:"stdClass":0:{}' );
+
+		$decoded = self::$EditFlowModule->get_unencoded_description( $payload );
+
+		// allowed_classes => false turns any object into an inert __PHP_Incomplete_Class, so it is
+		// never a real instance of the named class. Without the hardening this would be a stdClass.
+		$this->assertNotInstanceOf( \stdClass::class, $decoded, 'A serialized object must not be instantiated as its class.' );
+	}
+
+	/**
 	 * Capture the echoed output of users_select_form().
 	 *
 	 * @param array $selected User IDs to mark as selected.


### PR DESCRIPTION
## Summary

Edit Flow stores pseudo term-meta (custom-status position and viewability, user-group membership, and similar) as a base64-encoded serialized array tucked into a term's description field, and read it back through the shared `EF_Module::get_unencoded_description()` helper using `maybe_unserialize( base64_decode( ... ) )`. Because `maybe_unserialize()` will happily instantiate any object encoded in the payload, that helper was a PHP object-injection surface, and the callers only inspect the result with `is_array()` *after* the unserialise has already run, so they could not prevent an object being constructed.

The decode is now gated with `is_serialized()` and uses `unserialize()` with `array( 'allowed_classes' => false )`, so no object can ever be instantiated. A plain, unencoded description still passes through unchanged, and the encode side is untouched, so existing stored data continues to read correctly with no migration.

An alternative was to migrate the format to JSON, but `allowed_classes => false` fully neutralises the object-injection threat with zero back-compat risk and without leaving a permanent legacy read path behind, so that is the route taken here.

## Test plan

- [x] `composer cs` and `parallel-lint` pass on the changed files.
- [x] Two integration tests added and passing: a legitimate encoded array round-trips unchanged, and a serialized object payload is not instantiated as its class. The full `ModuleTest` class passes.

Fixes VIPPLUG-9.