### PR TITLE
Stop the integration test suite terminating early

### DIFF
--- a/tests/Integration/AjaxTestCase.php
+++ b/tests/Integration/AjaxTestCase.php
@@ -24,10 +24,6 @@ abstract class AjaxTestCase extends TestCase {
 	 * Taken from testcase-ajax.php setUpBeforeClass function
 	 */
 	public static function setUpBeforeClass(): void {
-		if ( ! defined( 'DOING_AJAX' ) ) {
-			define( 'DOING_AJAX', true );
-		}
-
 		remove_action( 'admin_init', '_maybe_update_core' );
 		remove_action( 'admin_init', '_maybe_update_plugins' );
 		remove_action( 'admin_init', '_maybe_update_themes' );
@@ -43,6 +39,22 @@ abstract class AjaxTestCase extends TestCase {
 	 */
 	protected function setUp(): void {
 		parent::setUp();
+
+		/*
+		 * Define DOING_AJAX here, in setUp(), rather than in setUpBeforeClass().
+		 *
+		 * AJAX test classes run each test method in a separate process
+		 * (@runTestsInSeparateProcesses), so setUp() executes inside the child
+		 * process where the AJAX request is actually exercised. setUpBeforeClass(),
+		 * by contrast, also runs in the parent PHPUnit process — defining the
+		 * constant there permanently leaks DOING_AJAX into the parent. Every
+		 * later non-AJAX test then sees wp_doing_ajax() as true, so any wp_die()
+		 * routes to the real AJAX die handler instead of the test framework's
+		 * throwing handler, killing the whole PHPUnit run with exit code 0.
+		 */
+		if ( ! defined( 'DOING_AJAX' ) ) {
+			define( 'DOING_AJAX', true );
+		}
 
 		add_filter( 'wp_die_ajax_handler', array( $this, 'getDieHandler' ), 1, 1 );
 

--- a/tests/Integration/CustomStatusAddHandlerTest.php
+++ b/tests/Integration/CustomStatusAddHandlerTest.php
@@ -71,7 +71,23 @@ class CustomStatusAddHandlerTest extends TestCase {
 	public function test_handle_add_custom_status_succeeds_for_admin() {
 		wp_set_current_user( self::$admin_user_id );
 
-		$status_name = 'Security Test Status ' . wp_generate_password( 6, false );
+		// The handler's success path ends with wp_redirect(); exit. A bare exit
+		// would terminate the whole PHPUnit process, so intercept wp_redirect and
+		// throw: the exception unwinds the handler before it reaches exit, while
+		// still proving the success path was taken and letting us assert the
+		// status was created.
+		$redirected = false;
+		add_filter(
+			'wp_redirect',
+			// phpcs:ignore WordPressVIPMinimum.Hooks.AlwaysReturnInFilter.MissingReturnStatement -- Intentionally throws to unwind the handler before its exit; it never returns.
+			function ( $location ) use ( &$redirected ) {
+				$redirected = true;
+				throw new \RuntimeException( 'wp_redirect intercepted' );
+			}
+		);
+
+		// The handler rejects names longer than 20 characters, so keep it short.
+		$status_name = 'Sec ' . wp_generate_password( 6, false );
 
 		$_POST['submit']      = 'Add New Status';
 		$_POST['action']      = 'add-new';
@@ -81,12 +97,15 @@ class CustomStatusAddHandlerTest extends TestCase {
 
 		try {
 			$this->custom_status->handle_add_custom_status();
-			// Successful paths end with wp_redirect(); exit. The test framework
-			// may or may not throw depending on configuration, so both outcomes
-			// are acceptable.
+			$this->fail( 'Handler should have redirected after a successful add.' );
 		} catch ( \WPDieException $e ) {
 			$this->fail( 'Admin should not hit wp_die on a valid add request: ' . $e->getMessage() );
+		} catch ( \RuntimeException $e ) {
+			// Expected: the success path reached wp_redirect().
+			$this->assertSame( 'wp_redirect intercepted', $e->getMessage() );
 		}
+
+		$this->assertTrue( $redirected, 'Handler should redirect after adding the status.' );
 
 		$status = $this->custom_status->get_custom_status_by( 'slug', sanitize_title( $status_name ) );
 		$this->assertNotFalse( $status, 'Custom status should have been created.' );

--- a/tests/Integration/CustomStatusRestApiDateTest.php
+++ b/tests/Integration/CustomStatusRestApiDateTest.php
@@ -10,7 +10,6 @@ declare( strict_types=1 );
 
 namespace Automattic\EditFlow\Tests\Integration;
 
-use EF_Custom_Status;
 use Yoast\WPTestUtils\WPIntegration\TestCase;
 
 /**
@@ -27,15 +26,18 @@ class CustomStatusRestApiDateTest extends TestCase {
 	protected static $ef_custom_status;
 
 	public static function wpSetUpBeforeClass( $factory ) {
+		global $edit_flow;
+
 		self::$admin_user_id = $factory->user->create( array( 'role' => 'administrator' ) );
 
-		self::$ef_custom_status = new EF_Custom_Status();
+		// Use the registered module instance from $edit_flow, not a bare
+		// new EF_Custom_Status(): get_post_types_for_module() reads the module's
+		// configured options (post_types), which only the registered instance
+		// has. A fresh instance reports no post types, so register_rest_api_filters()
+		// would add no rest_prepare_{post_type} filters at all.
+		self::$ef_custom_status = $edit_flow->custom_status;
 		self::$ef_custom_status->install();
 		self::$ef_custom_status->init();
-
-		// Ensure our REST filters are registered; rest_api_init only fires once
-		// per REST request boot, so we invoke the registrar directly for tests.
-		self::$ef_custom_status->register_rest_api_filters();
 	}
 
 	public static function wpTearDownAfterClass() {
@@ -46,6 +48,13 @@ class CustomStatusRestApiDateTest extends TestCase {
 	protected function setUp(): void {
 		parent::setUp();
 		wp_set_current_user( self::$admin_user_id );
+
+		// Register the REST filters in setUp(), not wpSetUpBeforeClass(): the
+		// WP test case backs up and restores $wp_filter around every test, which
+		// strips any filter added once at class set-up. rest_api_init only fires
+		// once per REST boot, so we invoke the registrar directly here to ensure
+		// the filter is present for each test.
+		self::$ef_custom_status->register_rest_api_filters();
 	}
 
 	/**


### PR DESCRIPTION
## Summary

While working through the Edit Flow security fixes, the full `composer test:integration` run was repeatedly seen to stop part way through on `develop` — no PHPUnit summary was printed, yet the job still passed. A green CI therefore meant nothing: an entire tail of test classes never ran, and any failures among them went unnoticed.

The cause was a leak in the AJAX test base. `AjaxTestCase::setUpBeforeClass()` defined the `DOING_AJAX` constant, but `setUpBeforeClass()` also runs in the parent PHPUnit process — and a constant cannot be unset. Once any AJAX class had been set up, every later non-AJAX test saw `wp_doing_ajax()` as true, so any `wp_die()` routed to the real AJAX die handler instead of the test framework's throwing handler. That terminated the whole run with exit code 0, which is why CI never noticed. It was order dependent, so it surfaced as an intermittent early stop around the Calendar/Story Budget area. Defining `DOING_AJAX` in `setUp()` instead keeps it in the separate child process where the AJAX request is actually exercised, leaving the parent process clean.

With the suite running to completion again, it immediately exposed two genuinely masked failures, both fixed here. The custom status add-handler test used a name longer than the handler's 20-character limit, so nothing was ever created, and it carried a latent bare `exit`; it now uses a short name and intercepts `wp_redirect` to unwind before the exit, then asserts the status was created. The REST date tests (#925) used an unconfigured `EF_Custom_Status` instance — so `register_rest_api_filters()` added no filters at all — and registered them in `wpSetUpBeforeClass()`, which the WP test case strips between tests; they now use the registered `$edit_flow->custom_status` and register per test in `setUp()`.

The root cause was specific to this plugin's tests, so no test-runner or CI plumbing has changed: `composer.json` and the workflow remain identical to the rest of the fleet.

## Test plan

- [x] Full integration suite now runs to completion: `OK (261 tests, 513 assertions)` — single site and multisite, and stable across repeated runs under the config's `depends,defects` ordering (previously it died around test ~30).
- [x] PHPCS passes on the changed files.

Fixes VIPPLUG-14.