### PR TITLE
Harden admin form and AJAX input handling

### DIFF
--- a/common/php/class-module.php
+++ b/common/php/class-module.php
@@ -461,11 +461,11 @@ if ( ! class_exists( 'EF_Module' ) ) {
 			}
 
 			// The current page better be in the array of registered settings view slugs.
-			if ( ! in_array( $_GET['page'], $settings_view_slugs ) ) {
+			if ( ! in_array( $_GET['page'], $settings_view_slugs, true ) ) {
 				return false;
 			}
 
-			if ( $module_name && $edit_flow->modules->$module_name->settings_slug != $_GET['page'] ) {
+			if ( $module_name && $edit_flow->modules->$module_name->settings_slug !== $_GET['page'] ) {
 				return false;
 			}
 			// phpcs:enable WordPress.Security.NonceVerification.Recommended
@@ -574,7 +574,7 @@ if ( ! class_exists( 'EF_Module' ) ) {
 			<ul class="<?php echo esc_attr( $list_class ); ?>">
 				<?php
 				foreach ( $users as $user ) :
-					$checked = in_array( $user->ID, $selected );
+					$checked = in_array( (int) $user->ID, array_map( 'intval', (array) $selected ), true );
 					?>
 					<li>
 						<label for="<?php echo esc_attr( $input_id . '-' . $user->ID ); ?>">

--- a/modules/custom-status/custom-status.php
+++ b/modules/custom-status/custom-status.php
@@ -1260,15 +1260,18 @@ if ( ! class_exists( 'EF_Custom_Status' ) ) {
 			// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Nonce value passed directly to wp_verify_nonce().
 			if ( ! isset( $_POST['custom_status_sortable_nonce'] ) || ! wp_verify_nonce( $_POST['custom_status_sortable_nonce'], 'custom-status-sortable' ) ) {
 				$this->print_ajax_response( 'error', esc_html( $this->module->messages['nonce-failed'] ) );
+				return;
 			}
 
 			if ( ! current_user_can( 'manage_options' ) ) {
 				$this->print_ajax_response( 'error', esc_html( $this->module->messages['invalid-permissions'] ) );
+				return;
 			}
 
 			// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Array is sanitized when processing each item.
 			if ( ! isset( $_POST['status_positions'] ) || ! is_array( $_POST['status_positions'] ) ) {
 				$this->print_ajax_response( 'error', esc_html__( 'Terms not set.', 'edit-flow' ) );
+				return;
 			}
 
 			// Update each custom status with its new position.

--- a/modules/custom-status/custom-status.php
+++ b/modules/custom-status/custom-status.php
@@ -917,31 +917,30 @@ if ( ! class_exists( 'EF_Custom_Status' ) ) {
 			 * - Name is required and can't conflict with an existing name or slug.
 			 * - Description is optional.
 			 */
-			$_REQUEST['form-errors'] = [];
+			EditFlow()->settings->form_errors = [];
 			// Check if name field was filled in.
 			if ( empty( $status_name ) ) {
-				$_REQUEST['form-errors']['name'] = __( 'Please enter a name for the status', 'edit-flow' );
+				EditFlow()->settings->form_errors['name'] = __( 'Please enter a name for the status', 'edit-flow' );
 			}
 			// Check that the name isn't numeric.
 			if ( 0 != (int) $status_name ) {
-				$_REQUEST['form-errors']['name'] = __( 'Please enter a valid, non-numeric name for the status.', 'edit-flow' );
+				EditFlow()->settings->form_errors['name'] = __( 'Please enter a valid, non-numeric name for the status.', 'edit-flow' );
 			}
 			// Check that the status name doesn't exceed 20 chars.
 			if ( strlen( $status_name ) > 20 ) {
-				$_REQUEST['form-errors']['name'] = __( 'Status name cannot exceed 20 characters. Please try a shorter name.', 'edit-flow' );
+				EditFlow()->settings->form_errors['name'] = __( 'Status name cannot exceed 20 characters. Please try a shorter name.', 'edit-flow' );
 			}
 			// Check to make sure the status doesn't already exist as another term.
 			if ( term_exists( $status_slug, self::taxonomy_key ) ) {
-				$_REQUEST['form-errors']['name'] = __( 'Status name conflicts with existing term. Please choose another.', 'edit-flow' );
+				EditFlow()->settings->form_errors['name'] = __( 'Status name conflicts with existing term. Please choose another.', 'edit-flow' );
 			}
 			// Check to make sure the name is not restricted.
 			if ( $this->is_restricted_status( strtolower( $status_slug ) ) ) {
-				$_REQUEST['form-errors']['name'] = __( 'Status name is restricted. Please choose another name.', 'edit-flow' );
+				EditFlow()->settings->form_errors['name'] = __( 'Status name is restricted. Please choose another name.', 'edit-flow' );
 			}
 
 			// If there were any form errors, kick out and return them.
-			// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotValidated
-			if ( count( $_REQUEST['form-errors'] ) ) {
+			if ( count( EditFlow()->settings->form_errors ) ) {
 				$_REQUEST['error'] = 'form-error';
 				return;
 			}
@@ -1002,37 +1001,36 @@ if ( ! class_exists( 'EF_Custom_Status' ) ) {
 			 * - 'name' is a required field and can't conflict with existing name or slug.
 			 * - 'description' is optional.
 			 */
-			$_REQUEST['form-errors'] = [];
+			EditFlow()->settings->form_errors = [];
 			// Check if name field was filled in.
 			if ( empty( $name ) ) {
-				$_REQUEST['form-errors']['name'] = __( 'Please enter a name for the status', 'edit-flow' );
+				EditFlow()->settings->form_errors['name'] = __( 'Please enter a name for the status', 'edit-flow' );
 			}
 			// Check that the name isn't numeric.
 			if ( is_numeric( $name ) ) {
-				$_REQUEST['form-errors']['name'] = __( 'Please enter a valid, non-numeric name for the status.', 'edit-flow' );
+				EditFlow()->settings->form_errors['name'] = __( 'Please enter a valid, non-numeric name for the status.', 'edit-flow' );
 			}
 			// Check that the status name doesn't exceed 20 chars.
 			if ( strlen( $name ) > 20 ) {
-				$_REQUEST['form-errors']['name'] = __( 'Status name cannot exceed 20 characters. Please try a shorter name.', 'edit-flow' );
+				EditFlow()->settings->form_errors['name'] = __( 'Status name cannot exceed 20 characters. Please try a shorter name.', 'edit-flow' );
 			}
 			// Check to make sure the status doesn't already exist as another term.
 			$term_exists = term_exists( sanitize_title( $name ), self::taxonomy_key );
 			if ( $term_exists && isset( $term_exists['term_id'] ) && $term_exists['term_id'] != $existing_status->term_id ) {
-				$_REQUEST['form-errors']['name'] = __( 'Status name conflicts with existing term. Please choose another.', 'edit-flow' );
+				EditFlow()->settings->form_errors['name'] = __( 'Status name conflicts with existing term. Please choose another.', 'edit-flow' );
 			}
 			// Check to make sure the status doesn't already exist.
 			$search_status = $this->get_custom_status_by( 'slug', sanitize_title( $name ) );
 			if ( $search_status && $search_status->term_id != $existing_status->term_id ) {
-				$_REQUEST['form-errors']['name'] = __( 'Status name conflicts with existing status. Please choose another.', 'edit-flow' );
+				EditFlow()->settings->form_errors['name'] = __( 'Status name conflicts with existing status. Please choose another.', 'edit-flow' );
 			}
 			// Check to make sure the name is not restricted.
 			if ( $this->is_restricted_status( strtolower( sanitize_title( $name ) ) ) ) {
-				$_REQUEST['form-errors']['name'] = __( 'Status name is restricted. Please choose another name.', 'edit-flow' );
+				EditFlow()->settings->form_errors['name'] = __( 'Status name is restricted. Please choose another name.', 'edit-flow' );
 			}
 
 			// Kick out if there are any errors.
-			// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotValidated
-			if ( count( $_REQUEST['form-errors'] ) ) {
+			if ( count( EditFlow()->settings->form_errors ) ) {
 				$_REQUEST['error'] = 'form-error';
 				return;
 			}

--- a/modules/editorial-comments/editorial-comments.php
+++ b/modules/editorial-comments/editorial-comments.php
@@ -353,6 +353,19 @@ if ( ! class_exists( 'EF_Editorial_Comments' ) ) {
 				wp_die( esc_html__( 'Sorry, you don\'t have the privileges to add editorial comments. Please talk to your Administrator.', 'edit-flow' ) );
 			}
 
+			// If this is a reply, the parent must be an editorial comment on this same post,
+			// so a request cannot thread a comment under an unrelated post's comment.
+			if ( $parent ) {
+				$parent_comment = get_comment( $parent );
+				if (
+					! $parent_comment
+					|| (int) $parent_comment->comment_post_ID !== $post_id
+					|| self::comment_type !== $parent_comment->comment_type
+				) {
+					wp_die( esc_html__( 'The comment you are replying to is invalid.', 'edit-flow' ) );
+				}
+			}
+
 			// Verify that comment was actually entered.
 			// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Content is sanitized by wp_kses when building $data.
 			$comment_content = isset( $_POST['content'] ) ? trim( $_POST['content'] ) : '';

--- a/modules/editorial-metadata/editorial-metadata.php
+++ b/modules/editorial-metadata/editorial-metadata.php
@@ -263,14 +263,14 @@ if ( ! class_exists( 'EF_Editorial_Metadata' ) ) {
 			// Add the metabox date picker JS and CSS.
 			$current_post_type    = $this->get_current_post_type();
 			$supported_post_types = $this->get_post_types_for_module( $this->module );
-			if ( in_array( $current_post_type, $supported_post_types ) ) {
+			if ( in_array( $current_post_type, $supported_post_types, true ) ) {
 				$this->enqueue_datepicker_resources();
 
 				// Now add the rest of the metabox CSS.
 				wp_enqueue_style( 'edit_flow-editorial_metadata-styles', $this->module_url . 'lib/editorial-metadata.css', false, EDIT_FLOW_VERSION, 'all' );
 			}
 			// A bit of custom CSS for the Manage Posts view if we have viewable metadata.
-			if ( 'edit' == $current_screen->base && in_array( $current_post_type, $supported_post_types ) ) {
+			if ( 'edit' === $current_screen->base && in_array( $current_post_type, $supported_post_types, true ) ) {
 				$terms          = $this->get_editorial_metadata_terms();
 				$viewable_terms = array();
 				foreach ( $terms as $term ) {
@@ -1302,18 +1302,18 @@ if ( ! class_exists( 'EF_Editorial_Metadata' ) ) {
 			}
 
 			$term_exists = term_exists( sanitize_title( $new_name ) );
-			if ( $term_exists && $term_exists != $existing_term->term_id ) {
+			if ( $term_exists && (int) $term_exists !== (int) $existing_term->term_id ) {
 				$_REQUEST['form-errors']['name'] = __( 'Metadata name conflicts with existing term. Please choose another.', 'edit-flow' );
 			}
 
 			// Check to ensure a term with the same name doesn't exist.
 			$search_term = $this->get_editorial_metadata_term_by( 'name', $new_name );
-			if ( is_object( $search_term ) && $search_term->term_id != $existing_term->term_id ) {
+			if ( is_object( $search_term ) && (int) $search_term->term_id !== (int) $existing_term->term_id ) {
 				$_REQUEST['form-errors']['name'] = __( 'Name already in use. Please choose another.', 'edit-flow' );
 			}
 			// Or that the term name doesn't map to an existing term's slug.
 			$search_term = $this->get_editorial_metadata_term_by( 'slug', sanitize_title( $new_name ) );
-			if ( is_object( $search_term ) && $search_term->term_id != $existing_term->term_id ) {
+			if ( is_object( $search_term ) && (int) $search_term->term_id !== (int) $existing_term->term_id ) {
 				$_REQUEST['form-errors']['name'] = __( 'Name conflicts with slug for another term. Please choose something else.', 'edit-flow' );
 			}
 
@@ -1363,7 +1363,7 @@ if ( ! class_exists( 'EF_Editorial_Metadata' ) ) {
 			// phpcs:disable WordPress.Security.NonceVerification.Recommended -- Nonce verified below.
 			// Check that the current GET request is our GET request.
 			if ( ! isset( $_GET['page'], $_GET['action'], $_GET['term-id'], $_GET['nonce'] )
-			|| $_GET['page'] != $this->module->settings_slug || ! in_array( $_GET['action'], array( 'make-viewable', 'make-hidden' ) ) ) {
+			|| $_GET['page'] !== $this->module->settings_slug || ! in_array( $_GET['action'], array( 'make-viewable', 'make-hidden' ), true ) ) {
 				return;
 			}
 			// phpcs:enable WordPress.Security.NonceVerification.Recommended
@@ -1447,21 +1447,21 @@ if ( ! class_exists( 'EF_Editorial_Metadata' ) ) {
 
 			// Check to make sure the status doesn't already exist as another term because otherwise we'd get a fatal error.
 			$term_exists = term_exists( sanitize_title( $metadata_name ) );
-			if ( $term_exists && $term_exists != $term_id ) {
+			if ( $term_exists && (int) $term_exists !== (int) $term_id ) {
 				$change_error = new WP_Error( 'invalid', esc_html__( 'Metadata name conflicts with existing term. Please choose another.', 'edit-flow' ) );
 				wp_die( esc_html( $change_error->get_error_message() ) );
 			}
 
 			// Check to ensure a term with the same name doesn't exist.
 			$search_term = $this->get_editorial_metadata_term_by( 'name', $metadata_name );
-			if ( is_object( $search_term ) && $search_term->term_id != $existing_term->term_id ) {
+			if ( is_object( $search_term ) && (int) $search_term->term_id !== (int) $existing_term->term_id ) {
 				$change_error = new WP_Error( 'invalid', esc_html__( 'Name already in use. Please choose another.', 'edit-flow' ) );
 				wp_die( esc_html( $change_error->get_error_message() ) );
 			}
 
 			// Or that the term name doesn't map to an existing term's slug.
 			$search_term = $this->get_editorial_metadata_term_by( 'slug', sanitize_title( $metadata_name ) );
-			if ( is_object( $search_term ) && $search_term->term_id != $existing_term->term_id ) {
+			if ( is_object( $search_term ) && (int) $search_term->term_id !== (int) $existing_term->term_id ) {
 				$change_error = new WP_Error( 'invalid', esc_html__( 'Name conflicts with slug for another term. Please choose again.', 'edit-flow' ) );
 				wp_die( esc_html( $change_error->get_error_message() ) );
 			}
@@ -1777,7 +1777,7 @@ if ( ! class_exists( 'EF_Editorial_Metadata' ) ) {
 				<?php
 					$metadata_types = $this->get_supported_metadata_types();
 					// Select the previously selected metadata type if a valid one exists.
-					$current_metadata_type = ( isset( $_POST['metadata_type'] ) && in_array( $_POST['metadata_type'], array_keys( $metadata_types ) ) ) ? $_POST['metadata_type'] : false;
+					$current_metadata_type = ( isset( $_POST['metadata_type'] ) && in_array( $_POST['metadata_type'], array_keys( $metadata_types ), true ) ) ? $_POST['metadata_type'] : false;
 				?>
 				<select id="metadata_type" name="metadata_type">
 				<?php foreach ( $metadata_types as $metadata_type => $metadata_type_name ) : ?>
@@ -1793,7 +1793,7 @@ if ( ! class_exists( 'EF_Editorial_Metadata' ) ) {
 						'no'  => __( 'No', 'edit-flow' ),
 						'yes' => __( 'Yes', 'edit-flow' ),
 					);
-					$current_metadata_viewable = ( isset( $_POST['metadata_viewable'] ) && in_array( $_POST['metadata_viewable'], array_keys( $metadata_viewable_options ) ) ) ? $_POST['metadata_viewable'] : 'no';
+					$current_metadata_viewable = ( isset( $_POST['metadata_viewable'] ) && in_array( $_POST['metadata_viewable'], array_keys( $metadata_viewable_options ), true ) ) ? $_POST['metadata_viewable'] : 'no';
 					?>
 				<select id="metadata_viewable" name="metadata_viewable">
 				<?php foreach ( $metadata_viewable_options as $metadata_viewable_key => $metadata_viewable_value ) : ?>

--- a/modules/editorial-metadata/editorial-metadata.php
+++ b/modules/editorial-metadata/editorial-metadata.php
@@ -1496,14 +1496,17 @@ if ( ! class_exists( 'EF_Editorial_Metadata' ) ) {
 			// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Nonce value passed directly to wp_verify_nonce().
 			if ( ! isset( $_POST['editorial_metadata_sortable_nonce'] ) || ! wp_verify_nonce( $_POST['editorial_metadata_sortable_nonce'], 'editorial-metadata-sortable' ) ) {
 				$this->print_ajax_response( 'error', $this->module->messages['nonce-failed'] );
+				return;
 			}
 
 			if ( ! current_user_can( 'manage_options' ) ) {
 				$this->print_ajax_response( 'error', $this->module->messages['invalid-permissions'] );
+				return;
 			}
 
 			if ( ! isset( $_POST['term_positions'] ) || ! is_array( $_POST['term_positions'] ) ) {
 				$this->print_ajax_response( 'error', __( 'Terms not set.', 'edit-flow' ) );
+				return;
 			}
 
 			// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Values are cast to int below.

--- a/modules/editorial-metadata/editorial-metadata.php
+++ b/modules/editorial-metadata/editorial-metadata.php
@@ -1182,7 +1182,7 @@ if ( ! class_exists( 'EF_Editorial_Metadata' ) ) {
 			$term_description = isset( $_POST['metadata_description'] ) ? stripslashes( wp_filter_nohtml_kses( trim( $_POST['metadata_description'] ) ) ) : '';
 			$term_type        = isset( $_POST['metadata_type'] ) ? sanitize_key( $_POST['metadata_type'] ) : '';
 
-			$_REQUEST['form-errors'] = array();
+			EditFlow()->settings->form_errors = array();
 
 			/**
 			 * Form validation for adding new editorial metadata term.
@@ -1193,32 +1193,32 @@ if ( ! class_exists( 'EF_Editorial_Metadata' ) ) {
 			 */
 			// Field is required.
 			if ( empty( $term_name ) ) {
-				$_REQUEST['form-errors']['name'] = __( 'Please enter a name for the editorial metadata.', 'edit-flow' );
+				EditFlow()->settings->form_errors['name'] = __( 'Please enter a name for the editorial metadata.', 'edit-flow' );
 			}
 			// Field is required.
 			if ( empty( $term_slug ) ) {
-				$_REQUEST['form-errors']['slug'] = __( 'Please enter a slug for the editorial metadata.', 'edit-flow' );
+				EditFlow()->settings->form_errors['slug'] = __( 'Please enter a slug for the editorial metadata.', 'edit-flow' );
 			}
 			if ( term_exists( $term_slug ) ) {
-				$_REQUEST['form-errors']['name'] = __( 'Name conflicts with existing term. Please choose another.', 'edit-flow' );
+				EditFlow()->settings->form_errors['name'] = __( 'Name conflicts with existing term. Please choose another.', 'edit-flow' );
 			}
 			// Check to ensure a term with the same name doesn't exist.
 			if ( $this->get_editorial_metadata_term_by( 'name', $term_name, self::metadata_taxonomy ) ) {
-				$_REQUEST['form-errors']['name'] = __( 'Name already in use. Please choose another.', 'edit-flow' );
+				EditFlow()->settings->form_errors['name'] = __( 'Name already in use. Please choose another.', 'edit-flow' );
 			}
 			// Check to ensure a term with the same slug doesn't exist.
 			if ( $this->get_editorial_metadata_term_by( 'slug', $term_slug ) ) {
-				$_REQUEST['form-errors']['slug'] = __( 'Slug already in use. Please choose another.', 'edit-flow' );
+				EditFlow()->settings->form_errors['slug'] = __( 'Slug already in use. Please choose another.', 'edit-flow' );
 			}
 			// Check to make sure the status doesn't already exist as another term because otherwise we'd get a weird slug.
 			// Check that the term name doesn't exceed 200 chars.
 			if ( strlen( $term_name ) > 200 ) {
-				$_REQUEST['form-errors']['name'] = __( 'Name cannot exceed 200 characters. Please try a shorter name.', 'edit-flow' );
+				EditFlow()->settings->form_errors['name'] = __( 'Name cannot exceed 200 characters. Please try a shorter name.', 'edit-flow' );
 			}
 			// Metadata type needs to pass our whitelist check.
 			$metadata_types = $this->get_supported_metadata_types();
 			if ( empty( $_POST['metadata_type'] ) || ! isset( $metadata_types[ $_POST['metadata_type'] ] ) ) {
-				$_REQUEST['form-errors']['type'] = __( 'Please select a valid metadata type.', 'edit-flow' );
+				EditFlow()->settings->form_errors['type'] = __( 'Please select a valid metadata type.', 'edit-flow' );
 			}
 			// Metadata viewable needs to be a valid Yes or No.
 			$term_viewable = false;
@@ -1227,8 +1227,7 @@ if ( ! class_exists( 'EF_Editorial_Metadata' ) ) {
 			}
 
 			// Kick out if there are any errors.
-			// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotValidated
-			if ( count( $_REQUEST['form-errors'] ) ) {
+			if ( count( EditFlow()->settings->form_errors ) ) {
 				$_REQUEST['error'] = 'form-error';
 				return;
 			}
@@ -1290,36 +1289,36 @@ if ( ! class_exists( 'EF_Editorial_Metadata' ) ) {
 			 * - "name", "slug", and "type" are required fields
 			 * - "description" can accept a limited amount of HTML, and is optional
 			 */
-			$_REQUEST['form-errors'] = array();
+			EditFlow()->settings->form_errors = array();
 			// Check if name field was filled in.
 			if ( empty( $new_name ) ) {
-				$_REQUEST['form-errors']['name'] = __( 'Please enter a name for the editorial metadata', 'edit-flow' );
+				EditFlow()->settings->form_errors['name'] = __( 'Please enter a name for the editorial metadata', 'edit-flow' );
 			}
 
 			// Check that the name isn't numeric.
 			if ( is_numeric( $new_name ) ) {
-				$_REQUEST['form-errors']['name'] = __( 'Please enter a valid, non-numeric name for the editorial metadata.', 'edit-flow' );
+				EditFlow()->settings->form_errors['name'] = __( 'Please enter a valid, non-numeric name for the editorial metadata.', 'edit-flow' );
 			}
 
 			$term_exists = term_exists( sanitize_title( $new_name ) );
 			if ( $term_exists && (int) $term_exists !== (int) $existing_term->term_id ) {
-				$_REQUEST['form-errors']['name'] = __( 'Metadata name conflicts with existing term. Please choose another.', 'edit-flow' );
+				EditFlow()->settings->form_errors['name'] = __( 'Metadata name conflicts with existing term. Please choose another.', 'edit-flow' );
 			}
 
 			// Check to ensure a term with the same name doesn't exist.
 			$search_term = $this->get_editorial_metadata_term_by( 'name', $new_name );
 			if ( is_object( $search_term ) && (int) $search_term->term_id !== (int) $existing_term->term_id ) {
-				$_REQUEST['form-errors']['name'] = __( 'Name already in use. Please choose another.', 'edit-flow' );
+				EditFlow()->settings->form_errors['name'] = __( 'Name already in use. Please choose another.', 'edit-flow' );
 			}
 			// Or that the term name doesn't map to an existing term's slug.
 			$search_term = $this->get_editorial_metadata_term_by( 'slug', sanitize_title( $new_name ) );
 			if ( is_object( $search_term ) && (int) $search_term->term_id !== (int) $existing_term->term_id ) {
-				$_REQUEST['form-errors']['name'] = __( 'Name conflicts with slug for another term. Please choose something else.', 'edit-flow' );
+				EditFlow()->settings->form_errors['name'] = __( 'Name conflicts with slug for another term. Please choose something else.', 'edit-flow' );
 			}
 
 			// Check that the term name doesn't exceed 200 chars.
 			if ( strlen( $new_name ) > 200 ) {
-				$_REQUEST['form-errors']['name'] = __( 'Name cannot exceed 200 characters. Please try a shorter name.', 'edit-flow' );
+				EditFlow()->settings->form_errors['name'] = __( 'Name cannot exceed 200 characters. Please try a shorter name.', 'edit-flow' );
 			}
 			// Make sure the viewable state is valid.
 			$new_viewable = false;
@@ -1328,8 +1327,7 @@ if ( ! class_exists( 'EF_Editorial_Metadata' ) ) {
 			}
 
 			// Kick out if there are any errors.
-			// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotValidated
-			if ( count( $_REQUEST['form-errors'] ) ) {
+			if ( count( EditFlow()->settings->form_errors ) ) {
 				$_REQUEST['error'] = 'form-error';
 				return;
 			}

--- a/modules/settings/settings.php
+++ b/modules/settings/settings.php
@@ -132,9 +132,11 @@ if ( ! class_exists( 'EF_Settings' ) ) {
 				wp_die( '-1' );
 			}
 
-			if ( 'enable' == $module_action ) {
+			$return = false;
+
+			if ( 'enable' === $module_action ) {
 				$return = $edit_flow->update_module_option( $module->name, 'enabled', 'on' );
-			} elseif ( 'disable' == $module_action ) {
+			} elseif ( 'disable' === $module_action ) {
 				$return = $edit_flow->update_module_option( $module->name, 'enabled', 'off' );
 			}
 

--- a/modules/settings/settings.php
+++ b/modules/settings/settings.php
@@ -20,6 +20,18 @@ if ( ! class_exists( 'EF_Settings' ) ) {
 		public $module;
 
 		/**
+		 * Validation errors for the settings and term forms, keyed by field name.
+		 *
+		 * The module form handlers populate this on a failed submission and
+		 * helper_print_error_or_description() reads it back when the form re-renders in the
+		 * same request. Holding it here rather than on $_REQUEST means a crafted query string
+		 * cannot inject fake inline error messages onto the settings screens.
+		 *
+		 * @var array
+		 */
+		public $form_errors = array();
+
+		/**
 		 * Register the module with Edit Flow but don't do anything else.
 		 */
 		public function __construct() {
@@ -352,12 +364,10 @@ if ( ! class_exists( 'EF_Settings' ) ) {
 		 * @param string $description Unlocalized string to display if there was no error with the given field.
 		 */
 		public function helper_print_error_or_description( $field, $description ) {
-			// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Just checking for error display, no data modification.
-			if ( isset( $_REQUEST['form-errors'][ $field ] ) ) :
+			if ( isset( $this->form_errors[ $field ] ) ) :
 				?>
 			<div class="form-error">
-				<?php // phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Display only, esc_html handles output. ?>
-				<p><?php echo esc_html( $_REQUEST['form-errors'][ $field ] ); ?></p>
+				<p><?php echo esc_html( $this->form_errors[ $field ] ); ?></p>
 			</div>
 			<?php else : ?>
 			<p class="description"><?php echo esc_html( $description ); ?></p>

--- a/modules/user-groups/user-groups.php
+++ b/modules/user-groups/user-groups.php
@@ -417,12 +417,12 @@ if ( ! class_exists( 'EF_User_Groups' ) ) {
 			}
 			// Check to ensure a term with the same name doesn't exist.
 			$search_term = $this->get_usergroup_by( 'name', $name );
-			if ( is_object( $search_term ) && $search_term->term_id != $existing_usergroup->term_id ) {
+			if ( is_object( $search_term ) && (int) $search_term->term_id !== (int) $existing_usergroup->term_id ) {
 				$_REQUEST['form-errors']['name'] = __( 'Name already in use. Please choose another.', 'edit-flow' );
 			}
 			// Check to ensure a term with the same slug doesn't exist.
 			$search_term = $this->get_usergroup_by( 'slug', sanitize_title( $name ) );
-			if ( is_object( $search_term ) && $search_term->term_id != $existing_usergroup->term_id ) {
+			if ( is_object( $search_term ) && (int) $search_term->term_id !== (int) $existing_usergroup->term_id ) {
 				$_REQUEST['form-errors']['name'] = __( 'Name conflicts with slug for another term. Please choose again.', 'edit-flow' );
 			}
 			if ( strlen( $name ) > 40 ) {
@@ -532,13 +532,13 @@ if ( ! class_exists( 'EF_User_Groups' ) ) {
 			}
 			// Check to ensure a term with the same name doesn't exist.
 			$search_term = $this->get_usergroup_by( 'name', $name );
-			if ( is_object( $search_term ) && $search_term->term_id != $existing_term->term_id ) {
+			if ( is_object( $search_term ) && (int) $search_term->term_id !== (int) $existing_term->term_id ) {
 				$change_error = new WP_Error( 'invalid', esc_html__( 'Name already in use. Please choose another.', 'edit-flow' ) );
 				wp_die( esc_html( $change_error->get_error_message() ) );
 			}
 			// Check to ensure a term with the same slug doesn't exist.
 			$search_term = $this->get_usergroup_by( 'slug', sanitize_title( $name ) );
-			if ( is_object( $search_term ) && $search_term->term_id != $existing_term->term_id ) {
+			if ( is_object( $search_term ) && (int) $search_term->term_id !== (int) $existing_term->term_id ) {
 				$change_error = new WP_Error( 'invalid', esc_html__( 'Name conflicts with slug for another term. Please choose again.', 'edit-flow' ) );
 				wp_die( esc_html( $change_error->get_error_message() ) );
 			}
@@ -801,7 +801,7 @@ if ( ! class_exists( 'EF_User_Groups' ) ) {
 				$usergroups     = isset( $_POST['ef_usergroups'] ) ? array_map( 'intval', (array) $_POST['ef_usergroups'] ) : array();
 				$all_usergroups = $this->get_usergroups();
 				foreach ( $all_usergroups as $usergroup ) {
-					if ( in_array( $usergroup->term_id, $usergroups ) ) {
+					if ( in_array( (int) $usergroup->term_id, $usergroups, true ) ) {
 						$this->add_user_to_usergroup( $user->ID, $usergroup->term_id );
 					} else {
 						$this->remove_user_from_usergroup( $user->ID, $usergroup->term_id );
@@ -873,7 +873,7 @@ if ( ! class_exists( 'EF_User_Groups' ) ) {
 				<li>
 					<label for="<?php echo esc_attr( $input_id ) . esc_attr( $usergroup->term_id ); ?>" title="<?php echo esc_attr( $usergroup->description ); ?>">
 						<div class="ef-user-subscribe-actions">
-							<input type="checkbox" id="<?php echo esc_attr( $input_id . $usergroup->term_id ); ?>" name="<?php echo esc_attr( $input_id ); ?>[]" value="<?php echo esc_attr( $usergroup->term_id ); ?>"<?php echo checked( in_array( $usergroup->term_id, $selected ) ); ?> />
+							<input type="checkbox" id="<?php echo esc_attr( $input_id . $usergroup->term_id ); ?>" name="<?php echo esc_attr( $input_id ); ?>[]" value="<?php echo esc_attr( $usergroup->term_id ); ?>"<?php echo checked( in_array( (int) $usergroup->term_id, array_map( 'intval', (array) $selected ), true ) ); ?> />
 						</div>
 						<span class="ef-usergroup_name"><?php echo esc_html( $usergroup->name ); ?></span>
 						<span class="ef-usergroup_description" title="<?php echo esc_attr( $usergroup->description ); ?>">
@@ -1117,7 +1117,7 @@ if ( ! class_exists( 'EF_User_Groups' ) ) {
 				$usergroup = $this->get_usergroup_by( 'id', $usergroup_id );
 
 				// Skip if user is already in this group.
-				if ( in_array( $user_id, $usergroup->user_ids, true ) ) {
+				if ( in_array( (int) $user_id, array_map( 'intval', (array) $usergroup->user_ids ), true ) ) {
 					continue;
 				}
 
@@ -1152,7 +1152,7 @@ if ( ! class_exists( 'EF_User_Groups' ) ) {
 				$usergroup = $this->get_usergroup_by( 'id', $usergroup_id );
 				// @todo I bet there's a PHP function for this I couldn't look up at 35,000 over the Atlantic.
 				foreach ( $usergroup->user_ids as $key => $usergroup_user_id ) {
-					if ( $usergroup_user_id == $user_id ) {
+					if ( (int) $usergroup_user_id === (int) $user_id ) {
 						unset( $usergroup->user_ids[ $key ] );
 					}
 				}
@@ -1188,7 +1188,7 @@ if ( ! class_exists( 'EF_User_Groups' ) ) {
 				$usergroup_objects_or_ids = array();
 				foreach ( $all_usergroups as $usergroup ) {
 					// Not in this usergroup, so keep going.
-					if ( ! in_array( $user_id, $usergroup->user_ids ) ) {
+					if ( ! in_array( (int) $user_id, array_map( 'intval', (array) $usergroup->user_ids ), true ) ) {
 						continue;
 					}
 					if ( 'ids' == $ids_or_objects ) {

--- a/modules/user-groups/user-groups.php
+++ b/modules/user-groups/user-groups.php
@@ -314,7 +314,7 @@ if ( ! class_exists( 'EF_User_Groups' ) ) {
 			// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Values are sanitized below.
 			$description = ( isset( $_POST['description'] ) ) ? stripslashes( wp_filter_nohtml_kses( trim( $_POST['description'] ) ) ) : '';
 
-			$_REQUEST['form-errors'] = array();
+			EditFlow()->settings->form_errors = array();
 
 			/*
 			 * Form validation for adding new Usergroup.
@@ -325,22 +325,21 @@ if ( ! class_exists( 'EF_User_Groups' ) ) {
 			 */
 			// Field is required.
 			if ( empty( $name ) ) {
-				$_REQUEST['form-errors']['name'] = __( 'Please enter a name for the user group.', 'edit-flow' );
+				EditFlow()->settings->form_errors['name'] = __( 'Please enter a name for the user group.', 'edit-flow' );
 			}
 			// Check to ensure a term with the same name doesn't exist.
 			if ( $this->get_usergroup_by( 'name', $name ) ) {
-				$_REQUEST['form-errors']['name'] = __( 'Name already in use. Please choose another.', 'edit-flow' );
+				EditFlow()->settings->form_errors['name'] = __( 'Name already in use. Please choose another.', 'edit-flow' );
 			}
 			// Check to ensure a term with the same slug doesn't exist.
 			if ( $this->get_usergroup_by( 'slug', sanitize_title( $name ) ) ) {
-				$_REQUEST['form-errors']['name'] = __( 'Name conflicts with slug for another term. Please choose again.', 'edit-flow' );
+				EditFlow()->settings->form_errors['name'] = __( 'Name conflicts with slug for another term. Please choose again.', 'edit-flow' );
 			}
 			if ( strlen( $name ) > 40 ) {
-				$_REQUEST['form-errors']['name'] = __( 'User group name cannot exceed 40 characters. Please try a shorter name.', 'edit-flow' );
+				EditFlow()->settings->form_errors['name'] = __( 'User group name cannot exceed 40 characters. Please try a shorter name.', 'edit-flow' );
 			}
 			// Kick out if there are any errors.
-			// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotValidated
-			if ( count( $_REQUEST['form-errors'] ) ) {
+			if ( count( EditFlow()->settings->form_errors ) ) {
 				$_REQUEST['error'] = 'form-error';
 				return;
 			}
@@ -402,7 +401,7 @@ if ( ! class_exists( 'EF_User_Groups' ) ) {
 			// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Values are sanitized below.
 			$description = isset( $_POST['description'] ) ? stripslashes( wp_filter_nohtml_kses( trim( $_POST['description'] ) ) ) : '';
 
-			$_REQUEST['form-errors'] = array();
+			EditFlow()->settings->form_errors = array();
 
 			/*
 			 * Form validation for editing a Usergroup.
@@ -413,24 +412,23 @@ if ( ! class_exists( 'EF_User_Groups' ) ) {
 			 */
 			// Field is required.
 			if ( empty( $name ) ) {
-				$_REQUEST['form-errors']['name'] = __( 'Please enter a name for the user group.', 'edit-flow' );
+				EditFlow()->settings->form_errors['name'] = __( 'Please enter a name for the user group.', 'edit-flow' );
 			}
 			// Check to ensure a term with the same name doesn't exist.
 			$search_term = $this->get_usergroup_by( 'name', $name );
 			if ( is_object( $search_term ) && (int) $search_term->term_id !== (int) $existing_usergroup->term_id ) {
-				$_REQUEST['form-errors']['name'] = __( 'Name already in use. Please choose another.', 'edit-flow' );
+				EditFlow()->settings->form_errors['name'] = __( 'Name already in use. Please choose another.', 'edit-flow' );
 			}
 			// Check to ensure a term with the same slug doesn't exist.
 			$search_term = $this->get_usergroup_by( 'slug', sanitize_title( $name ) );
 			if ( is_object( $search_term ) && (int) $search_term->term_id !== (int) $existing_usergroup->term_id ) {
-				$_REQUEST['form-errors']['name'] = __( 'Name conflicts with slug for another term. Please choose again.', 'edit-flow' );
+				EditFlow()->settings->form_errors['name'] = __( 'Name conflicts with slug for another term. Please choose again.', 'edit-flow' );
 			}
 			if ( strlen( $name ) > 40 ) {
-				$_REQUEST['form-errors']['name'] = __( 'User group name cannot exceed 40 characters. Please try a shorter name.', 'edit-flow' );
+				EditFlow()->settings->form_errors['name'] = __( 'User group name cannot exceed 40 characters. Please try a shorter name.', 'edit-flow' );
 			}
 			// Kick out if there are any errors.
-			// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotValidated
-			if ( count( $_REQUEST['form-errors'] ) ) {
+			if ( count( EditFlow()->settings->form_errors ) ) {
 				$_REQUEST['error'] = 'form-error';
 				return;
 			}

--- a/tests/Integration/EditorialCommentsAjaxTest.php
+++ b/tests/Integration/EditorialCommentsAjaxTest.php
@@ -211,4 +211,83 @@ class EditorialCommentsAjaxTest extends AjaxTestCase {
 		$comment = get_comment( (int) $matches[1] );
 		$this->assertSame( "O'Brien", $comment->comment_author, 'Author should be stored verbatim without escape sequences.' );
 	}
+
+	/**
+	 * Test: a reply whose parent comment belongs to a different post is rejected, so a comment
+	 * cannot be threaded under an unrelated post's comment.
+	 */
+	public function test_insert_comment_rejects_reply_parent_from_another_post(): void {
+		$author_user_id = $this->factory->user->create( array( 'role' => 'author' ) );
+		wp_set_current_user( $author_user_id );
+
+		$post_a = $this->factory->post->create( array(
+			'post_status' => 'draft',
+			'post_author' => $author_user_id,
+		) );
+		$post_b = $this->factory->post->create( array(
+			'post_status' => 'draft',
+			'post_author' => $author_user_id,
+		) );
+
+		$parent_on_a = $this->factory->comment->create( array(
+			'comment_post_ID' => $post_a,
+			'comment_type'    => 'editorial-comment',
+		) );
+
+		$_POST['_nonce']  = wp_create_nonce( 'comment' );
+		$_POST['post_id'] = $post_b;
+		$_POST['parent']  = $parent_on_a;
+		$_POST['content'] = 'Reply pointed at another post';
+
+		global $current_user, $user_ID;
+		$current_user = wp_get_current_user();
+		$user_ID      = $author_user_id;
+
+		$this->expectException( WPAjaxDieStopException::class );
+		$this->_handleAjax( 'editflow_ajax_insert_comment' );
+	}
+
+	/**
+	 * Test: a reply whose parent is an editorial comment on the same post is accepted and
+	 * threaded under that parent.
+	 */
+	public function test_insert_comment_allows_reply_parent_on_same_post(): void {
+		$author_user_id = $this->factory->user->create( array( 'role' => 'author' ) );
+		wp_set_current_user( $author_user_id );
+
+		$post_id = $this->factory->post->create( array(
+			'post_status' => 'draft',
+			'post_author' => $author_user_id,
+		) );
+
+		$parent = $this->factory->comment->create( array(
+			'comment_post_ID' => $post_id,
+			'comment_type'    => 'editorial-comment',
+		) );
+
+		$_POST['_nonce']  = wp_create_nonce( 'comment' );
+		$_POST['post_id'] = $post_id;
+		$_POST['parent']  = $parent;
+		$_POST['content'] = 'A valid threaded reply';
+
+		global $current_user, $user_ID;
+		$current_user = wp_get_current_user();
+		$user_ID      = $author_user_id;
+
+		$caught = false;
+		try {
+			$this->_handleAjax( 'editflow_ajax_insert_comment' );
+		} catch ( WPAjaxDieContinueException $e ) {
+			$caught = true;
+			unset( $e );
+		}
+
+		$this->assertTrue( $caught, 'A reply with a valid same-post parent should succeed.' );
+
+		preg_match( '/<comment id=\'(\d+)\'/', $this->_last_response, $matches );
+		$this->assertNotEmpty( $matches, 'Comment ID should be extracted from response.' );
+
+		$comment = get_comment( (int) $matches[1] );
+		$this->assertSame( (int) $parent, (int) $comment->comment_parent, 'Reply should be threaded under the parent.' );
+	}
 }

--- a/tests/Integration/EditorialMetadataTest.php
+++ b/tests/Integration/EditorialMetadataTest.php
@@ -195,4 +195,79 @@ class EditorialMetadataTest extends TestCase {
 		$this->assertSame( 'sanitize_textarea_field', $registered[ $paragraph_key ]['sanitize_callback'] );
 		$this->assertSame( 'sanitize_text_field', $registered[ $number_key ]['sanitize_callback'] );
 	}
+
+	/**
+	 * Renaming a term to a name already used by ANOTHER term must report a conflict. This guards
+	 * the strict term_exists() comparison so it keeps detecting genuine name collisions.
+	 */
+	public function test_edit_term_rename_to_other_existing_name_reports_conflict() {
+		global $edit_flow;
+		wp_set_current_user( self::$admin_user_id );
+
+		$edit_flow->editorial_metadata->insert_editorial_metadata_term( array(
+			'name' => 'Alpha EM',
+			'type' => 'text',
+		) );
+		$beta = $edit_flow->editorial_metadata->insert_editorial_metadata_term( array(
+			'name' => 'Beta EM',
+			'type' => 'text',
+		) );
+
+		$_GET['page']      = $edit_flow->editorial_metadata->module->settings_slug;
+		$_GET['action']    = 'edit-term';
+		$_GET['term-id']   = $beta['term_id'];
+		$_POST['submit']   = 'Submit';
+		$_POST['_wpnonce'] = wp_create_nonce( 'editorial-metadata-edit-nonce' );
+		$_POST['name']     = 'Alpha EM';
+
+		$edit_flow->settings->form_errors = array();
+		$edit_flow->editorial_metadata->handle_edit_editorial_metadata();
+
+		$this->assertArrayHasKey( 'name', $edit_flow->settings->form_errors, "Renaming to another term's name should report a conflict." );
+	}
+
+	/**
+	 * Renaming a term to its OWN current name must NOT report a conflict: term_exists() returns
+	 * the term itself. This locks the self-rename behaviour of the conflict check — in particular
+	 * it would fail if the comparison were tightened to a strict !== without int-casting
+	 * term_exists()'s numeric-string return against the integer term_id.
+	 */
+	public function test_edit_term_rename_to_same_name_is_allowed() {
+		global $edit_flow;
+		wp_set_current_user( self::$admin_user_id );
+
+		$gamma = $edit_flow->editorial_metadata->insert_editorial_metadata_term( array(
+			'name' => 'Gamma EM',
+			'type' => 'text',
+		) );
+
+		$_GET['page']      = $edit_flow->editorial_metadata->module->settings_slug;
+		$_GET['action']    = 'edit-term';
+		$_GET['term-id']   = $gamma['term_id'];
+		$_POST['submit']   = 'Submit';
+		$_POST['_wpnonce'] = wp_create_nonce( 'editorial-metadata-edit-nonce' );
+		$_POST['name']     = 'Gamma EM';
+
+		$edit_flow->settings->form_errors = array();
+
+		// The no-conflict path ends in wp_redirect(); exit — intercept the redirect so the test
+		// process survives and we can assert no conflict was recorded.
+		$redirected = false;
+		$catch      = function () use ( &$redirected ) {
+			$redirected = true;
+			throw new \RuntimeException( 'redirected' );
+		};
+		add_filter( 'wp_redirect', $catch );
+
+		try {
+			$edit_flow->editorial_metadata->handle_edit_editorial_metadata();
+		} catch ( \Throwable $e ) {
+			unset( $e );
+		} finally {
+			remove_filter( 'wp_redirect', $catch );
+		}
+
+		$this->assertTrue( $redirected, 'A self-rename should pass validation and reach the redirect.' );
+		$this->assertArrayNotHasKey( 'name', $edit_flow->settings->form_errors, 'A self-rename must not report a name conflict.' );
+	}
 }

--- a/tests/Integration/SettingsTest.php
+++ b/tests/Integration/SettingsTest.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * Settings module integration tests.
+ *
+ * @package Automattic\EditFlow\Tests\Integration
+ */
+
+declare( strict_types=1 );
+
+namespace Automattic\EditFlow\Tests\Integration;
+
+use EF_Settings;
+use Yoast\WPTestUtils\WPIntegration\TestCase;
+
+class SettingsTest extends TestCase {
+
+	protected static $ef_settings;
+
+	public static function wpSetUpBeforeClass( $factory ) {
+		self::$ef_settings = new EF_Settings();
+	}
+
+	public static function wpTearDownAfterClass() {
+		self::$ef_settings = null;
+	}
+
+	protected function tearDown(): void {
+		self::$ef_settings->form_errors = array();
+		unset( $_REQUEST['form-errors'] );
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Render the error-or-description helper and capture its output.
+	 *
+	 * @param string $field       Field name to render.
+	 * @param string $description Description shown when there is no error.
+	 * @return string Captured HTML.
+	 */
+	private function render_field( string $field, string $description ): string {
+		ob_start();
+		self::$ef_settings->helper_print_error_or_description( $field, $description );
+		return (string) ob_get_clean();
+	}
+
+	/**
+	 * A server-set form error is displayed, escaped, in place of the field description.
+	 */
+	public function test_displays_form_error_when_set() {
+		self::$ef_settings->form_errors['name'] = '<b>Name is required</b>';
+
+		$html = $this->render_field( 'name', 'The field description.' );
+
+		$this->assertStringContainsString( 'form-error', $html );
+		$this->assertStringContainsString( esc_html( '<b>Name is required</b>' ), $html );
+		$this->assertStringNotContainsString( '<b>Name is required</b>', $html, 'Raw markup must not survive into the output.' );
+		$this->assertStringNotContainsString( 'The field description.', $html );
+	}
+
+	/**
+	 * The field description shows when there is no error for that field.
+	 */
+	public function test_displays_description_when_no_error() {
+		$html = $this->render_field( 'name', 'The field description.' );
+
+		$this->assertStringContainsString( 'class="description"', $html );
+		$this->assertStringContainsString( 'The field description.', $html );
+		$this->assertStringNotContainsString( 'form-error', $html );
+	}
+
+	/**
+	 * A form error injected via the request (e.g. a crafted query string) must not be rendered:
+	 * errors are read from the module property, not $_REQUEST, so inline messages cannot be spoofed.
+	 */
+	public function test_ignores_form_error_injected_via_request() {
+		$_REQUEST['form-errors']['name'] = 'Spoofed error from the URL';
+
+		$html = $this->render_field( 'name', 'The field description.' );
+
+		$this->assertStringNotContainsString( 'Spoofed error from the URL', $html );
+		$this->assertStringContainsString( 'The field description.', $html );
+	}
+}


### PR DESCRIPTION
## Summary

This is a defence-in-depth pass over Edit Flow's admin form and AJAX handlers.

ID comparisons and `in_array()` checks are made strict, int-casting operands that can legitimately arrive as numeric strings — term IDs returned by `term_exists()`, and user or usergroup IDs coming from forms or decoded from encoded term descriptions. That strictness also fixes a latent de-duplication bug in `add_user_to_usergroup()`, where comparing an integer user ID strictly against possibly-string stored IDs could fail to spot an existing member and re-add them.

The custom-status and editorial-metadata reorder handlers now `return` after each error guard, so they stay fail-closed however the shared AJAX response helper ends the request, and the settings enable/disable handler initialises its return flag so an unrecognised action can no longer read an undefined variable. An editorial-comment reply now verifies that its parent comment belongs to the same post and is itself an editorial comment, so a request cannot thread a comment beneath an unrelated post's comment. Finally, form validation errors move off `$_REQUEST` onto a shared settings property that the display helper reads, so a crafted query string can no longer inject inline error text onto the admin screens.

One deliberate omission worth flagging: a missing `wp_unslash()` was suggested for several name/title fields, but those values are handed to `wp_insert_post()`/`wp_insert_term()`/`wp_update_term()`/`add_*_meta()`, which unslash internally (confirmed in the bundled core source). Unslashing in the handler would double-unslash and strip legitimate backslashes, so leaving the values slashed is correct and that change was not made.

## Test plan

- [x] `composer cs` and `parallel-lint` pass on the changed files.
- [x] New integration tests cover the reply-parent validation (rejects a cross-post parent, allows a same-post parent), the settings error helper (shows the property, ignores request injection), and editorial-metadata term-rename conflict behaviour.
- [x] Full integration suite green (272 tests, 542 assertions).

Fixes VIPPLUG-8.