### PR TITLE
Escape admin screen output consistently

### DIFF
--- a/common/php/class-module.php
+++ b/common/php/class-module.php
@@ -375,7 +375,11 @@ if ( ! class_exists( 'EF_Module' ) ) {
 		 * @since 0.7
 		 *
 		 * @param string $status    Whether it was a 'success' or an 'error'.
-		 * @param string $message   Optional message to include.
+		 * @param string $message   Optional message. SECURITY: the caller is responsible for
+		 *                          escaping this. Several JS consumers insert it as HTML (e.g.
+		 *                          via jQuery .html()), so pass only fixed/translated strings,
+		 *                          esc_html()'d values, or trusted server-generated markup —
+		 *                          never raw, unescaped user input.
 		 * @param int    $http_code HTTP response code.
 		 */
 		protected function print_ajax_response( $status, $message = '', $http_code = 200 ) {

--- a/modules/calendar/calendar.php
+++ b/modules/calendar/calendar.php
@@ -1169,7 +1169,7 @@ if ( ! class_exists( 'EF_Calendar' ) ) {
 								<?php $editable_class = $values['editable'] ? 'editable-value' : ''; ?>
 								<td class="value <?php echo esc_attr( $editable_class ); ?>"><?php echo esc_html( $values['value'] ); ?></td>
 								<?php if ( $values['editable'] ) : ?>
-									<td class="editable-html hidden" data-type="<?php echo esc_attr( $values['type'] ); ?>" data-metadataterm="<?php echo esc_attr( str_replace( 'editorial-metadata-', '', str_replace( 'tax_', '', $field ) ) ); ?>"><?php echo $this->get_editable_html( $values['type'], $values['value'] ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></td>
+									<td class="editable-html hidden" data-type="<?php echo esc_attr( $values['type'] ); ?>" data-metadataterm="<?php echo esc_attr( str_replace( 'editorial-metadata-', '', str_replace( 'tax_', '', $field ) ) ); ?>"><?php echo $this->get_editable_html( $values['type'], $values['value'] ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- get_editable_html() escapes each branch (esc_attr/esc_html) and otherwise returns only static markup or core-escaped wp_dropdown_users() output. ?></td>
 								<?php endif; ?>
 							<?php else : ?>
 								<td class="value"><?php echo esc_html( $values['value'] ); ?></td>

--- a/modules/editorial-comments/editorial-comments.php
+++ b/modules/editorial-comments/editorial-comments.php
@@ -214,7 +214,7 @@ if ( ! class_exists( 'EF_Editorial_Comments' ) ) {
 			<input type="hidden" value="" id="ef-comment_parent" name="ef-comment_parent" />
 			<input type="hidden" name="ef-post_id" id="ef-post_id" value="<?php echo esc_attr( $post->ID ); ?>" />
 
-			<?php wp_nonce_field( 'comment', 'ef_comment_nonce', false ); ?>
+			<?php wp_nonce_field( 'ef-insert-editorial-comment-' . $post->ID, 'ef_comment_nonce', false ); ?>
 
 			<br class="clear" />
 		</div>
@@ -332,18 +332,19 @@ if ( ! class_exists( 'EF_Editorial_Comments' ) ) {
 		public function ajax_insert_comment() {
 			global $current_user, $user_ID, $wpdb;
 
-			// Verify nonce.
+			// Set up the target post first; the nonce is tied to it.
+			// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotValidated
+			$post_id = isset( $_POST['post_id'] ) ? absint( $_POST['post_id'] ) : 0;
+
+			// Verify the nonce, which is namespaced to the post being commented on.
 			// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Nonces don't need sanitization, just verification.
-			if ( ! isset( $_POST['_nonce'] ) || ! wp_verify_nonce( $_POST['_nonce'], 'comment' ) ) {
+			if ( ! isset( $_POST['_nonce'] ) || ! wp_verify_nonce( $_POST['_nonce'], 'ef-insert-editorial-comment-' . $post_id ) ) {
 				wp_die( esc_html__( "Nonce check failed. Please ensure you're supposed to be adding editorial comments.", 'edit-flow' ) );
 			}
 
 			// Get user info.
 			wp_get_current_user();
 
-			// Set up comment data.
-			// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotValidated
-			$post_id = absint( $_POST['post_id'] );
 			// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotValidated
 			$parent = absint( $_POST['parent'] );
 

--- a/modules/editorial-comments/editorial-comments.php
+++ b/modules/editorial-comments/editorial-comments.php
@@ -270,7 +270,7 @@ if ( ! class_exists( 'EF_Editorial_Comments' ) ) {
 				// The output for this has been individually escaped. Escaping the entire string will break comment reply functionality.
 				// ToDo: Use wp_kses with a custom set of allowed tags instead.
 				// phpcs:ignore Squiz.Commenting.InlineComment.InvalidEndChar -- ToDo comment.
-				$actions['reply'] = '<a onclick="editorialCommentReply.open(\'' . esc_html( $comment->comment_ID ) . '\',\'' . esc_html( $comment->comment_post_ID ) . '\');return false;" class="vim-r hide-if-no-js" title="' . esc_attr( __( 'Reply to this comment', 'edit-flow' ) ) . '" href="#">' . esc_html__( 'Reply', 'edit-flow' ) . '</a>';
+				$actions['reply'] = '<a onclick="editorialCommentReply.open(\'' . (int) $comment->comment_ID . '\',\'' . (int) $comment->comment_post_ID . '\');return false;" class="vim-r hide-if-no-js" title="' . esc_attr( __( 'Reply to this comment', 'edit-flow' ) ) . '" href="#">' . esc_html__( 'Reply', 'edit-flow' ) . '</a>';
 
 				$sep = ' ';
 				$i   = 0;

--- a/modules/editorial-metadata/editorial-metadata.php
+++ b/modules/editorial-metadata/editorial-metadata.php
@@ -519,7 +519,7 @@ if ( ! class_exists( 'EF_Editorial_Metadata' ) ) {
 							break;
 						case 'paragraph':
 							echo '<label for="' . esc_attr( $postmeta_key ) . '">' . esc_html( $term->name ) . wp_kses_post( $description_span ) . '</label>';
-							echo '<textarea id="' . esc_attr( $postmeta_key ) . '" name="' . esc_attr( $postmeta_key ) . '">' . esc_html( $current_metadata ) . '</textarea>';
+							echo '<textarea id="' . esc_attr( $postmeta_key ) . '" name="' . esc_attr( $postmeta_key ) . '">' . esc_textarea( $current_metadata ) . '</textarea>';
 							break;
 						case 'checkbox':
 							echo '<label for="' . esc_attr( $postmeta_key ) . '">' . esc_html( $term->name ) . wp_kses_post( $description_span ) . '</label>';
@@ -1760,17 +1760,17 @@ if ( ! class_exists( 'EF_Editorial_Metadata' ) ) {
 			<form class="add:the-list:" action="<?php echo esc_url( add_query_arg( array( 'page' => $this->module->settings_slug ), get_admin_url( null, 'admin.php' ) ) ); ?>" method="post" id="addmetadata" name="addmetadata">
 			<div class="form-field form-required">
 				<label for="metadata_name"><?php _e( 'Name', 'edit-flow' ); ?></label>
-					<input type="text" aria-required="true" size="20" maxlength="200" id="metadata_name" name="metadata_name" value="<?php echo ( empty( $_POST['metadata_name'] ) ? '' : esc_attr( $_POST['metadata_name'] ) ); ?>" />
+					<input type="text" aria-required="true" size="20" maxlength="200" id="metadata_name" name="metadata_name" value="<?php echo ( empty( $_POST['metadata_name'] ) ? '' : esc_attr( wp_unslash( $_POST['metadata_name'] ) ) ); ?>" />
 				<?php $edit_flow->settings->helper_print_error_or_description( 'name', __( 'The name is for labeling the metadata field.', 'edit-flow' ) ); ?>
 			</div>
 			<div class="form-field form-required">
 				<label for="metadata_slug"><?php _e( 'Slug', 'edit-flow' ); ?></label>
-					<input type="text" aria-required="true" size="20" maxlength="200" id="metadata_slug" name="metadata_slug" value="<?php echo ( empty( $_POST['metadata_slug'] ) ? '' : esc_attr( $_POST['metadata_slug'] ) ); ?>" />
+					<input type="text" aria-required="true" size="20" maxlength="200" id="metadata_slug" name="metadata_slug" value="<?php echo ( empty( $_POST['metadata_slug'] ) ? '' : esc_attr( wp_unslash( $_POST['metadata_slug'] ) ) ); ?>" />
 				<?php $edit_flow->settings->helper_print_error_or_description( 'slug', __( 'The "slug" is the URL-friendly version of the name. It is usually all lowercase and contains only letters, numbers, and hyphens.', 'edit-flow' ) ); ?>
 			</div>
 			<div class="form-field">
 				<label for="metadata_description"><?php _e( 'Description', 'edit-flow' ); ?></label>
-					<textarea cols="40" rows="5" id="metadata_description" name="metadata_description"><?php echo ( empty( $_POST['metadata_description'] ) ? '' : esc_attr( $_POST['metadata_description'] ) ); ?></textarea>
+					<textarea cols="40" rows="5" id="metadata_description" name="metadata_description"><?php echo ( empty( $_POST['metadata_description'] ) ? '' : esc_textarea( sanitize_textarea_field( wp_unslash( $_POST['metadata_description'] ) ) ) ); ?></textarea>
 				<?php $edit_flow->settings->helper_print_error_or_description( 'description', __( 'The description can be used to communicate with your team about what the metadata is for.', 'edit-flow' ) ); ?>
 			</div>
 			<div class="form-field form-required">
@@ -1998,8 +1998,8 @@ class EF_Editorial_Metadata_List_Table extends WP_List_Table {
 
 		$out .= $this->row_actions( $actions, false );
 		$out .= '<div class="hidden" id="inline_' . $item->term_id . '">';
-		$out .= '<div class="name">' . $item->name . '</div>';
-		$out .= '<div class="description">' . $item->description . '</div>';
+		$out .= '<div class="name">' . esc_html( $item->name ) . '</div>';
+		$out .= '<div class="description">' . esc_html( $item->description ) . '</div>';
 		$out .= '</div>';
 
 		return $out;

--- a/modules/notifications/notifications.php
+++ b/modules/notifications/notifications.php
@@ -1020,7 +1020,12 @@ if ( ! class_exists( 'EF_Notifications' ) ) {
 				return;
 			}
 
-			// Set up the payload.
+			// Set up the payload. The message embeds user-controlled values (display name, post
+			// title, comment text). It is delivered as a JSON-encoded body below, so it cannot
+			// break out of the request structure; the only residual is that a destination which
+			// renders Slack mrkdwn will format any markup characters within those values. That is
+			// cosmetic and the feature is opt-in; a site that needs to neutralise it can rewrite
+			// the text via the payload filter.
 			$payload = [
 				'text' => $message,
 			];

--- a/modules/story-budget/story-budget.php
+++ b/modules/story-budget/story-budget.php
@@ -494,7 +494,7 @@ class EF_Story_Budget extends EF_Module {
 		<div class="<?php echo esc_attr( $wrap_classes ); ?>" id="ef-story-budget-wrap">
 			<div id="ef-story-budget-title">
 				<?php echo '<img src="' . esc_url( $this->module->img_url ) . '" class="module-icon icon32" />'; ?>
-				<h2><?php _e( 'Story Budget', 'edit-flow' ); ?></h2>
+				<h2><?php esc_html_e( 'Story Budget', 'edit-flow' ); ?></h2>
 			</div><!-- /Story Budget Title -->
 			<?php $this->print_messages(); ?>
 			<?php $this->table_navigation(); ?>
@@ -683,7 +683,7 @@ class EF_Story_Budget extends EF_Module {
 				</tbody>
 			</table>
 			<?php else : ?>
-			<div class="message info"><p><?php _e( 'There are no posts for this term in the range or filter specified.', 'edit-flow' ); ?></p></div>
+			<div class="message info"><p><?php esc_html_e( 'There are no posts for this term in the range or filter specified.', 'edit-flow' ); ?></p></div>
 			<?php endif; ?>
 		</div>
 	</div>
@@ -739,10 +739,10 @@ class EF_Story_Budget extends EF_Module {
 		switch ( $column_name ) {
 			case 'status':
 				$status_name = get_post_status_object( $post->post_status );
-				return $status_name->label;
+				return $status_name ? esc_html( $status_name->label ) : '';
 			case 'author':
 				$post_author = get_userdata( $post->post_author );
-				return $post_author->display_name;
+				return $post_author ? esc_html( $post_author->display_name ) : '';
 			case 'post_date':
 				$output = get_the_time( get_option( 'date_format' ), $post->ID );
 				// Only show time if it's not midnight (indicating a specific time was set).
@@ -774,7 +774,7 @@ class EF_Story_Budget extends EF_Module {
 		$post_type_object = get_post_type_object( $post->post_type );
 		$can_edit_post    = current_user_can( $post_type_object->cap->edit_post, $post->ID );
 		if ( $can_edit_post ) {
-			$output = '<strong><a href="' . get_edit_post_link( $post->ID ) . '">' . esc_html( $post_title ) . '</a></strong>';
+			$output = '<strong><a href="' . esc_url( get_edit_post_link( $post->ID ) ) . '">' . esc_html( $post_title ) . '</a></strong>';
 		} else {
 			$output = '<strong>' . esc_html( $post_title ) . '</strong>';
 		}
@@ -798,19 +798,19 @@ class EF_Story_Budget extends EF_Module {
 		$output      .= '<div class="row-actions">';
 		$item_actions = array();
 		if ( $can_edit_post ) {
-			$item_actions['edit'] = '<a title="' . __( 'Edit this post', 'edit-flow' ) . '" href="' . get_edit_post_link( $post->ID ) . '">' . __( 'Edit', 'edit-flow' ) . '</a>';
+			$item_actions['edit'] = '<a title="' . esc_attr__( 'Edit this post', 'edit-flow' ) . '" href="' . esc_url( get_edit_post_link( $post->ID ) ) . '">' . esc_html__( 'Edit', 'edit-flow' ) . '</a>';
 		}
 		if ( EMPTY_TRASH_DAYS > 0 && current_user_can( $post_type_object->cap->delete_post, $post->ID ) ) {
-			$item_actions['trash'] = '<a class="submitdelete" title="' . __( 'Move this item to the Trash', 'edit-flow' ) . '" href="' . get_delete_post_link( $post->ID ) . '">' . __( 'Trash', 'edit-flow' ) . '</a>';
+			$item_actions['trash'] = '<a class="submitdelete" title="' . esc_attr__( 'Move this item to the Trash', 'edit-flow' ) . '" href="' . esc_url( get_delete_post_link( $post->ID ) ) . '">' . esc_html__( 'Trash', 'edit-flow' ) . '</a>';
 		}
 
 		// Display a View or a Preview link depending on whether the post has been published or not.
 		if ( in_array( $post->post_status, array( 'publish' ) ) ) {
 			/* translators: %s: post title */
-			$item_actions['view'] = '<a href="' . get_permalink( $post->ID ) . '" title="' . esc_attr( sprintf( __( 'View &#8220;%s&#8221;', 'edit-flow' ), $post_title ) ) . '" rel="permalink">' . __( 'View', 'edit-flow' ) . '</a>';
+			$item_actions['view'] = '<a href="' . esc_url( get_permalink( $post->ID ) ) . '" title="' . esc_attr( sprintf( __( 'View &#8220;%s&#8221;', 'edit-flow' ), $post_title ) ) . '" rel="permalink">' . esc_html__( 'View', 'edit-flow' ) . '</a>';
 		} elseif ( $can_edit_post ) {
 			/* translators: %s: post title */
-			$item_actions['previewpost'] = '<a href="' . esc_url( apply_filters( 'preview_post_link', add_query_arg( 'preview', 'true', get_permalink( $post->ID ) ), $post ) ) . '" title="' . esc_attr( sprintf( __( 'Preview &#8220;%s&#8221;', 'edit-flow' ), $post_title ) ) . '" rel="permalink">' . __( 'Preview', 'edit-flow' ) . '</a>';
+			$item_actions['previewpost'] = '<a href="' . esc_url( apply_filters( 'preview_post_link', add_query_arg( 'preview', 'true', get_permalink( $post->ID ) ), $post ) ) . '" title="' . esc_attr( sprintf( __( 'Preview &#8220;%s&#8221;', 'edit-flow' ), $post_title ) ) . '" rel="permalink">' . esc_html__( 'Preview', 'edit-flow' ) . '</a>';
 		}
 
 		$item_actions = apply_filters( 'ef_story_budget_item_actions', $item_actions, $post->ID );

--- a/modules/user-groups/user-groups.php
+++ b/modules/user-groups/user-groups.php
@@ -702,13 +702,12 @@ if ( ! class_exists( 'EF_User_Groups' ) ) {
 					<div class="form-field form-required">
 						<label for="name"><?php _e( 'Name', 'edit-flow' ); ?></label>
 						<?php // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Value is escaped with esc_attr. ?>
-						<input type="text" aria-required="true" id="name" name="name" maxlength="40" value="<?php echo ( empty( $_POST['name'] ) ? '' : esc_attr( $_POST['name'] ) ); ?>"/>
+						<input type="text" aria-required="true" id="name" name="name" maxlength="40" value="<?php echo ( empty( $_POST['name'] ) ? '' : esc_attr( wp_unslash( $_POST['name'] ) ) ); ?>"/>
 						<?php $edit_flow->settings->helper_print_error_or_description( 'name', __( 'The name is used to identify the user group.', 'edit-flow' ) ); ?>
 					</div>
 					<div class="form-field">
 						<label for="description"><?php _e( 'Description', 'edit-flow' ); ?></label>
-						<?php // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Value is escaped with esc_attr. ?>
-						<textarea cols="40" rows="5" id="description" name="description"><?php echo ( empty( $_POST['description'] ) ? '' : esc_attr( $_POST['description'] ) ); ?></textarea>
+						<textarea cols="40" rows="5" id="description" name="description"><?php echo ( empty( $_POST['description'] ) ? '' : esc_textarea( sanitize_textarea_field( wp_unslash( $_POST['description'] ) ) ) ); ?></textarea>
 						<?php $edit_flow->settings->helper_print_error_or_description( 'description', __( 'The description is primarily for administrative use, to give you some context on what the user group is to be used for.', 'edit-flow' ) ); ?>
 					</div>
 					<?php wp_nonce_field( 'add-usergroup' ); ?>
@@ -875,7 +874,7 @@ if ( ! class_exists( 'EF_User_Groups' ) ) {
 						</div>
 						<span class="ef-usergroup_name"><?php echo esc_html( $usergroup->name ); ?></span>
 						<span class="ef-usergroup_description" title="<?php echo esc_attr( $usergroup->description ); ?>">
-							<?php echo ( strlen( $usergroup->description ) >= 50 ) ? esc_html( substr_replace( esc_html( $usergroup->description ), '...', 50 ) ) : esc_html( $usergroup->description ); ?>
+							<?php echo esc_html( wp_html_excerpt( $usergroup->description, 50, '...' ) ); ?>
 						</span>
 					</label>
 				</li>
@@ -1319,15 +1318,15 @@ if ( ! class_exists( 'EF_Usergroups_List_Table' ) ) {
 			) ) ) . '">' . esc_html( $usergroup->name ) . '</a></strong>';
 
 			$actions                            = array();
-			$actions['edit edit-usergroup']     = sprintf( '<a href="%1$s">' . __( 'Edit', 'edit-flow' ) . '</a>', $edit_flow->user_groups->get_link( array(
+			$actions['edit edit-usergroup']     = sprintf( '<a href="%1$s">' . __( 'Edit', 'edit-flow' ) . '</a>', esc_url( $edit_flow->user_groups->get_link( array(
 				'action'       => 'edit-usergroup',
 				'usergroup-id' => $usergroup->term_id,
-			) ) );
+			) ) ) );
 			$actions['inline hide-if-no-js']    = '<a href="#" class="editinline">' . __( 'Quick&nbsp;Edit', 'edit-flow' ) . '</a>';
-			$actions['delete delete-usergroup'] = sprintf( '<a href="%1$s">' . __( 'Delete', 'edit-flow' ) . '</a>', $edit_flow->user_groups->get_link( array(
+			$actions['delete delete-usergroup'] = sprintf( '<a href="%1$s">' . __( 'Delete', 'edit-flow' ) . '</a>', esc_url( $edit_flow->user_groups->get_link( array(
 				'action'       => 'delete-usergroup',
 				'usergroup-id' => $usergroup->term_id,
-			) ) );
+			) ) ) );
 
 			$output .= $this->row_actions( $actions, false );
 			$output .= '<div class="hidden" id="inline_' . $usergroup->term_id . '">';

--- a/tests/Integration/EditorialCommentsAjaxTest.php
+++ b/tests/Integration/EditorialCommentsAjaxTest.php
@@ -40,7 +40,7 @@ class EditorialCommentsAjaxTest extends AjaxTestCase {
 		) );
 
 		// Set up the AJAX request
-		$_POST['_nonce']  = wp_create_nonce( 'comment' );
+		$_POST['_nonce']  = wp_create_nonce( 'ef-insert-editorial-comment-' . $post_id );
 		$_POST['post_id'] = $post_id;
 		$_POST['parent']  = 0;
 		$_POST['content'] = 'This is a test editorial comment.';
@@ -122,7 +122,7 @@ class EditorialCommentsAjaxTest extends AjaxTestCase {
 			'post_author' => $author_id,
 		) );
 
-		$_POST['_nonce']  = wp_create_nonce( 'comment' );
+		$_POST['_nonce']  = wp_create_nonce( 'ef-insert-editorial-comment-' . $post_id );
 		$_POST['post_id'] = $post_id;
 		$_POST['content'] = 'Test comment';
 
@@ -142,7 +142,7 @@ class EditorialCommentsAjaxTest extends AjaxTestCase {
 			'post_author' => $author_user_id,
 		) );
 
-		$_POST['_nonce']  = wp_create_nonce( 'comment' );
+		$_POST['_nonce']  = wp_create_nonce( 'ef-insert-editorial-comment-' . $post_id );
 		$_POST['post_id'] = $post_id;
 		$_POST['content'] = '';
 
@@ -162,7 +162,7 @@ class EditorialCommentsAjaxTest extends AjaxTestCase {
 			'post_author' => $author_user_id,
 		) );
 
-		$_POST['_nonce']  = wp_create_nonce( 'comment' );
+		$_POST['_nonce']  = wp_create_nonce( 'ef-insert-editorial-comment-' . $post_id );
 		$_POST['post_id'] = $post_id;
 		$_POST['content'] = '   ';
 
@@ -190,7 +190,7 @@ class EditorialCommentsAjaxTest extends AjaxTestCase {
 			'post_author' => $author_user_id,
 		) );
 
-		$_POST['_nonce']  = wp_create_nonce( 'comment' );
+		$_POST['_nonce']  = wp_create_nonce( 'ef-insert-editorial-comment-' . $post_id );
 		$_POST['post_id'] = $post_id;
 		$_POST['parent']  = 0;
 		$_POST['content'] = 'Comment from O\'Brien';
@@ -234,7 +234,7 @@ class EditorialCommentsAjaxTest extends AjaxTestCase {
 			'comment_type'    => 'editorial-comment',
 		) );
 
-		$_POST['_nonce']  = wp_create_nonce( 'comment' );
+		$_POST['_nonce']  = wp_create_nonce( 'ef-insert-editorial-comment-' . $post_b );
 		$_POST['post_id'] = $post_b;
 		$_POST['parent']  = $parent_on_a;
 		$_POST['content'] = 'Reply pointed at another post';
@@ -265,7 +265,7 @@ class EditorialCommentsAjaxTest extends AjaxTestCase {
 			'comment_type'    => 'editorial-comment',
 		) );
 
-		$_POST['_nonce']  = wp_create_nonce( 'comment' );
+		$_POST['_nonce']  = wp_create_nonce( 'ef-insert-editorial-comment-' . $post_id );
 		$_POST['post_id'] = $post_id;
 		$_POST['parent']  = $parent;
 		$_POST['content'] = 'A valid threaded reply';

--- a/tests/Integration/StoryBudgetTest.php
+++ b/tests/Integration/StoryBudgetTest.php
@@ -256,4 +256,25 @@ class StoryBudgetTest extends TestCase {
 
 		$this->assertContains( 'future', $statuses );
 	}
+
+	/**
+	 * The author column must escape the display name, which is the one attacker-influenced value
+	 * in that column, so a user whose display name contains markup cannot inject it into the
+	 * Story Budget table.
+	 */
+	public function test_author_column_escapes_display_name() {
+		global $edit_flow;
+
+		$author_id = self::factory()->user->create( array( 'role' => 'author' ) );
+		wp_update_user( array(
+			'ID'           => $author_id,
+			'display_name' => 'A & B <evil>',
+		) );
+		$post_id = self::factory()->post->create( array( 'post_author' => $author_id ) );
+
+		$output = $edit_flow->story_budget->term_column_default( get_post( $post_id ), 'author', null );
+
+		$this->assertStringContainsString( '&amp;', $output, 'The display name should be HTML-escaped at output.' );
+		$this->assertStringNotContainsString( '<evil>', $output, 'Raw markup must not survive into the author column.' );
+	}
 }


### PR DESCRIPTION
## Summary

This is an output-escaping consistency pass across Edit Flow's admin screens. Each value is now escaped with the escaper that matches its output context. On the Story Budget the status label and author name are escaped at source (the author name being the one attacker-influenced value), along with the title-column links. User-group action links pass through `esc_url()`, and the truncated group description uses `esc_html( wp_html_excerpt() )` rather than a nested `esc_html()`/`substr_replace()` that could split a multibyte character or an entity. The editorial-metadata Quick-Edit hidden divs are `esc_html()`'d, and the reply-comment IDs in an inline `onclick` are cast to `(int)`, which is the right treatment for integers in a JavaScript context. The editorial-comment nonce is also namespaced per post (`ef-insert-editorial-comment-<post_id>`) so a token only authorises commenting on the post it was issued for. Finally, two blanket safety annotations gain rationale: the calendar editable-html ignore is justified inline, and `print_ajax_response()`'s message-escaping contract is documented.

One subtlety is worth flagging. A `<textarea>` body wants `esc_textarea()`, but only where the value is raw. The add-new forms repopulate from raw `$_POST`, so those textareas move to `esc_textarea()` (with the value unslashed and sanitised, and the sibling text inputs unslashed to match). The edit forms read a value that is already kses-entity-encoded at rest, so they keep `esc_html()`: `esc_textarea()` double-encodes (it calls `htmlspecialchars` with `double_encode` defaulting to true) and would turn a stored `&amp;` into a visible `&amp;amp;`, whereas `esc_html()` does not. None of these is a live XSS as written; the change is for correctness and resilience to future refactors.

The branch is deliberately split into one focused commit per concern to make review straightforward.

## Test plan

- [x] `composer cs` and `parallel-lint` pass.
- [x] An adversarial review of the diff was run; its findings (the textarea double-encode regression, a Preview link-text inconsistency, and add-form input repopulation) were fixed before opening.
- [x] A new author-column escaping test was added, and the full integration suite passes (273 tests, 544 assertions).

Fixes VIPPLUG-10.