### PR TITLE
Use the slug-specific template when previewing custom statuses

### DIFF
--- a/modules/custom-status/custom-status.php
+++ b/modules/custom-status/custom-status.php
@@ -143,6 +143,7 @@ if ( ! class_exists( 'EF_Custom_Status' ) ) {
 			add_filter( 'page_link', [ $this, 'fix_preview_link_part_two' ], 10, 3 );
 			add_filter( 'post_type_link', [ $this, 'fix_preview_link_part_two' ], 10, 3 );
 			add_filter( 'preview_post_link', [ $this, 'fix_preview_link_part_three' ], 11, 2 );
+			add_action( 'template_redirect', [ $this, 'fix_preview_template' ] );
 			add_filter( 'get_sample_permalink', [ $this, 'fix_get_sample_permalink' ], 10, 5 );
 			add_filter( 'get_sample_permalink_html', [ $this, 'fix_get_sample_permalink_html' ], 10, 5 );
 			add_filter( 'post_row_actions', [ $this, 'fix_post_row_actions' ], 10, 2 );
@@ -1926,6 +1927,76 @@ if ( ! class_exists( 'EF_Custom_Status' ) ) {
 				}
 			}
 			return remove_query_arg( [ 'preview_nonce' ], $preview_link );
+		}
+
+		/**
+		 * Another hack! hack! hack! until core better supports custom statuses.
+		 *
+		 * Posts and pages with a custom status are kept with an empty `post_name`
+		 * (see `maybe_keep_post_name_empty()` and `fix_unique_post_slug()`). WordPress's
+		 * template hierarchy resolves slug-specific templates — `page-{slug}.php` and
+		 * `single-{post-type}-{slug}.php` — from `$post->post_name`, so an empty slug
+		 * silently degrades template selection when the post is previewed: only the
+		 * generic `page.php` / `single.php` fallback can match. The same empty slug also
+		 * breaks template-based conditional logic such as ACF location rules.
+		 *
+		 * Here we synthesise a slug from the title on the queried object in memory only,
+		 * for the duration of the preview request. Nothing is persisted: the stored
+		 * `post_name` stays empty, so none of the slug-emptying behaviour changes.
+		 *
+		 * @since 0.11.0
+		 *
+		 * @see https://github.com/Automattic/Edit-Flow/issues/933
+		 */
+		public function fix_preview_template() {
+			// Only singular requests resolve a slug-specific template from post_name.
+			if ( ! is_singular() ) {
+				return;
+			}
+
+			$post = get_queried_object();
+
+			// Nothing to do unless we have a titled post whose slug is empty.
+			if ( ! $post instanceof WP_Post
+			|| ! empty( $post->post_name )
+			|| empty( $post->post_title ) ) {
+				return;
+			}
+
+			// Only act on the pre-publish custom statuses and post types we support.
+			$status_slugs = wp_list_pluck( $this->get_custom_statuses(), 'slug' );
+			if ( ! in_array( $post->post_status, $status_slugs, true )
+			|| ! in_array( $post->post_type, $this->get_post_types_for_module( $this->module ), true ) ) {
+				return;
+			}
+
+			/**
+			 * Filters the slug synthesised in memory for template selection while
+			 * previewing a custom-status post. Return an empty string to leave the
+			 * slug empty and disable this behaviour for the post.
+			 *
+			 * @since 0.11.0
+			 *
+			 * @param string  $post_name Slug derived from the post title.
+			 * @param WP_Post $post      The post being previewed.
+			 */
+			$post_name = apply_filters( 'ef_preview_template_post_name', sanitize_title( $post->post_title ), $post );
+
+			if ( '' === $post_name ) {
+				return;
+			}
+
+			// Set it on the queried object (used by the template hierarchy) and keep the
+			// loop post and global in sync for template tags and conditional logic.
+			$post->post_name = $post_name;
+
+			global $wp_query;
+			if ( isset( $wp_query->post ) && $wp_query->post instanceof WP_Post && $wp_query->post->ID === $post->ID ) {
+				$wp_query->post->post_name = $post_name;
+			}
+			if ( isset( $GLOBALS['post'] ) && $GLOBALS['post'] instanceof WP_Post && $GLOBALS['post']->ID === $post->ID ) {
+				$GLOBALS['post']->post_name = $post_name;
+			}
 		}
 
 		/**

--- a/tests/Integration/CustomStatusTest.php
+++ b/tests/Integration/CustomStatusTest.php
@@ -9,7 +9,6 @@ declare( strict_types=1 );
 
 namespace Automattic\EditFlow\Tests\Integration;
 
-use EF_Custom_Status;
 use WP_REST_Request;
 use Yoast\WPTestUtils\WPIntegration\TestCase;
 
@@ -22,7 +21,15 @@ class CustomStatusTest extends TestCase {
 	public static function wpSetUpBeforeClass( $factory ) {
 		self::$admin_user_id = $factory->user->create( array( 'role' => 'administrator' ) );
 
-		self::$ef_custom_status = new EF_Custom_Status();
+		// Use the singleton the plugin bootstraps, rather than a second, separately
+		// constructed instance. A parallel instance never has its module options loaded
+		// (EditFlow::load_module_options() only runs for the registered singleton), so its
+		// custom-status filters silently bail and the slug-emptying behaviour is not applied.
+		// On WordPress 7.0 the resulting double registration also lets core mint a slug for
+		// custom-status posts. init() is idempotent for the singleton's hooks and re-runs the
+		// status registration now that install() has seeded the default terms.
+		global $edit_flow;
+		self::$ef_custom_status = $edit_flow->custom_status;
 		self::$ef_custom_status->install();
 		self::$ef_custom_status->init();
 	}
@@ -959,5 +966,158 @@ class CustomStatusTest extends TestCase {
 		$this->assertSame( 'pending', get_post_status( $post_id ), 'A correctly nonced request should apply the workaround.' );
 
 		$_POST = array();
+	}
+
+	/**
+	 * Capture the page template hierarchy candidates for the current main query.
+	 *
+	 * @return string[] The ordered list of candidate template file names.
+	 */
+	private function capture_page_template_candidates() {
+		$candidates = array();
+		$callback   = function ( $templates ) use ( &$candidates ) {
+			$candidates = $templates;
+			return $templates;
+		};
+		add_filter( 'page_template_hierarchy', $callback, 99 );
+		get_page_template();
+		remove_filter( 'page_template_hierarchy', $callback, 99 );
+
+		return $candidates;
+	}
+
+	/**
+	 * The fix_preview_template() method should be hooked to template_redirect.
+	 */
+	public function test_fix_preview_template_is_registered() {
+		$this->assertNotFalse(
+			has_action( 'template_redirect', array( self::$ef_custom_status, 'fix_preview_template' ) )
+		);
+	}
+
+	/**
+	 * When previewing a custom-status page, the slug-specific template should be a
+	 * candidate even though the stored post_name is empty.
+	 */
+	public function test_fix_preview_template_adds_slug_template_for_custom_status_page() {
+		wp_set_current_user( self::$admin_user_id );
+
+		$id = self::factory()->post->create(
+			array(
+				'post_title'  => 'My Test Page',
+				'post_type'   => 'page',
+				'post_status' => 'pitch',
+				'post_author' => self::$admin_user_id,
+			)
+		);
+
+		// Edit Flow keeps the slug empty for custom statuses.
+		$this->assertEmpty( get_post( $id )->post_name );
+
+		$this->go_to( '/?page_id=' . $id . '&preview_id=' . $id );
+
+		// Without the fix, only page-{id}.php and page.php would be candidates.
+		$this->assertNotContains( 'page-my-test-page.php', $this->capture_page_template_candidates() );
+
+		self::$ef_custom_status->fix_preview_template();
+
+		$this->assertContains( 'page-my-test-page.php', $this->capture_page_template_candidates() );
+	}
+
+	/**
+	 * The fix should also help the "draft" custom status, where the empty slug is
+	 * actually WordPress core's own behaviour for draft/pending posts.
+	 */
+	public function test_fix_preview_template_adds_slug_template_for_draft_status_page() {
+		wp_set_current_user( self::$admin_user_id );
+
+		$id = self::factory()->post->create(
+			array(
+				'post_title'  => 'My Test Page',
+				'post_type'   => 'page',
+				'post_status' => 'draft',
+				'post_author' => self::$admin_user_id,
+			)
+		);
+
+		$this->assertEmpty( get_post( $id )->post_name );
+
+		$this->go_to( '/?page_id=' . $id . '&preview_id=' . $id );
+		self::$ef_custom_status->fix_preview_template();
+
+		$this->assertContains( 'page-my-test-page.php', $this->capture_page_template_candidates() );
+	}
+
+	/**
+	 * The synthesised slug is in-memory only and must never be persisted.
+	 */
+	public function test_fix_preview_template_does_not_persist_slug() {
+		wp_set_current_user( self::$admin_user_id );
+
+		$id = self::factory()->post->create(
+			array(
+				'post_title'  => 'My Test Page',
+				'post_type'   => 'page',
+				'post_status' => 'pitch',
+				'post_author' => self::$admin_user_id,
+			)
+		);
+
+		$this->go_to( '/?page_id=' . $id . '&preview_id=' . $id );
+		self::$ef_custom_status->fix_preview_template();
+
+		// The in-memory queried object carries the synthesised slug...
+		$this->assertSame( 'my-test-page', get_queried_object()->post_name );
+
+		// ...but nothing is written to the database.
+		clean_post_cache( $id );
+		$this->assertEmpty( get_post( $id )->post_name );
+	}
+
+	/**
+	 * A published page already has a real slug and must be left untouched.
+	 */
+	public function test_fix_preview_template_leaves_published_page_untouched() {
+		wp_set_current_user( self::$admin_user_id );
+
+		$id = self::factory()->post->create(
+			array(
+				'post_title'  => 'My Test Page',
+				'post_name'   => 'a-real-slug',
+				'post_type'   => 'page',
+				'post_status' => 'publish',
+				'post_author' => self::$admin_user_id,
+			)
+		);
+
+		$this->go_to( '/?page_id=' . $id );
+		self::$ef_custom_status->fix_preview_template();
+
+		$this->assertSame( 'a-real-slug', get_queried_object()->post_name );
+	}
+
+	/**
+	 * The ef_preview_template_post_name filter can return '' to opt out.
+	 */
+	public function test_fix_preview_template_respects_opt_out_filter() {
+		wp_set_current_user( self::$admin_user_id );
+
+		$id = self::factory()->post->create(
+			array(
+				'post_title'  => 'My Test Page',
+				'post_type'   => 'page',
+				'post_status' => 'pitch',
+				'post_author' => self::$admin_user_id,
+			)
+		);
+
+		$this->go_to( '/?page_id=' . $id . '&preview_id=' . $id );
+
+		add_filter( 'ef_preview_template_post_name', '__return_empty_string' );
+		self::$ef_custom_status->fix_preview_template();
+		remove_filter( 'ef_preview_template_post_name', '__return_empty_string' );
+
+		$this->assertEmpty( get_queried_object()->post_name );
+		$this->assertNotContains( 'page-my-test-page.php', $this->capture_page_template_candidates() );
 	}
 }


### PR DESCRIPTION
## Summary

A user reported that previewing a page with a custom status rendered `page.php` rather than their theme's `page-{slug}.php`, and that deactivating Edit Flow fixed it. The cause is Edit Flow's deliberate emptying of `post_name` for custom-status posts (`maybe_keep_post_name_empty()` and `fix_unique_post_slug()`): WordPress resolves slug-specific templates — `page-{slug}.php`, `single-{post-type}-{slug}.php` — from `post_name`, so an empty slug leaves only the generic fallback able to match. The same empty slug also breaks template-based conditional logic such as ACF location rules.

Re-verifying the premise against current WordPress (7.0) and the block editor showed the slug-emptying is still doing real work — core auto-mints a slug for the `pitch`, `assigned` and `in-progress` statuses — so removing it wholesale is not safe. It also showed the breakage is partly inherent to core: a plain draft or pending page with no explicit slug previews through `page.php` too, because core keeps draft/pending posts slug-less. Synthesising the slug at preview time therefore fixes the symptom for every pre-publish status without changing what is stored.

`fix_preview_template()` hooks `template_redirect` and, for a singular preview of a supported custom-status post whose `post_name` is empty, sets a title-derived slug on the queried object **in memory only**. Nothing is persisted, so none of the slug-emptying assertions change, and the stored `post_name` stays empty. Gating is on `is_singular()` rather than `is_preview()` because Edit Flow's page preview uses `?page_id=&preview_id=` with no `preview` query var. A new `ef_preview_template_post_name` filter lets a site opt out.

While adding coverage, six existing custom-status tests were found to fail on WordPress 7.0. The fixture constructed a second `EF_Custom_Status` instance whose module options never load (`EditFlow::load_module_options()` only runs for the registered singleton), so its filters silently bailed and core minted slugs that the tests expected to be empty. The fixture now uses the bootstrapped singleton, exercising the plugin as a site really runs it.

Fixes #933.

## Test plan

- [ ] In a theme, add `page-my-test-page.php` with obvious markup.
- [ ] Create a page titled "My Test Page" in a custom status (e.g. Pitch) with no slug set, and preview it.
- [ ] Confirm `page-my-test-page.php` renders, and that the page's stored slug remains empty (Quick Edit shows no slug).
- [ ] `composer test:integration` passes.