### PR TITLE
Tidy up bootstrap and select-form code quality

### DIFF
--- a/common/php/class-module.php
+++ b/common/php/class-module.php
@@ -553,7 +553,8 @@ if ( ! class_exists( 'EF_Module' ) ) {
 				'input_id'   => 'ef-selected-users',
 			);
 			$parsed_args = wp_parse_args( $args, $defaults );
-			extract( $parsed_args, EXTR_SKIP );
+			$list_class  = $parsed_args['list_class'];
+			$input_id    = $parsed_args['input_id'];
 
 			$args = array(
 				'capability' => 'publish_posts',

--- a/edit-flow.php
+++ b/edit-flow.php
@@ -8,4 +8,7 @@
  *
  * @package EditFlow
  */
+
+defined( 'ABSPATH' ) || exit;
+
 require_once __DIR__ . '/edit_flow.php';

--- a/edit_flow.php
+++ b/edit_flow.php
@@ -15,6 +15,8 @@
  * @package EditFlow
  */
 
+defined( 'ABSPATH' ) || exit;
+
 /**
  * Print admin notice regarding having an old version of PHP.
  *

--- a/modules/user-groups/user-groups.php
+++ b/modules/user-groups/user-groups.php
@@ -854,8 +854,10 @@ if ( ! class_exists( 'EF_User_Groups' ) ) {
 			);
 
 			$parsed_args = wp_parse_args( $args, $defaults );
-			extract( $parsed_args, EXTR_SKIP );
-			$usergroups = $this->get_usergroups();
+			$list_class  = $parsed_args['list_class'];
+			$list_id     = $parsed_args['list_id'];
+			$input_id    = $parsed_args['input_id'];
+			$usergroups  = $this->get_usergroups();
 			if ( empty( $usergroups ) ) {
 				?>
 			<p><?php esc_html_e( 'No user groups were found.', 'edit-flow' ); ?> <a href="<?php echo esc_url( $this->get_link() ); ?>" title="<?php esc_attr_e( 'Add a new user group. Opens new window.', 'edit-flow' ); ?>" target="_blank"><?php esc_html_e( 'Add a User Group', 'edit-flow' ); ?></a></p>

--- a/vipgo-helper.php
+++ b/vipgo-helper.php
@@ -28,21 +28,3 @@ add_filter( 'ef_edit_post_subscriptions_cap', function () {
 add_filter( 'ef_manage_usergroups_cap', function () {
 	return 'manage_options';
 } );
-
-add_action( 'after_setup_theme', 'edit_flow_wpcom_load_modules' );
-
-/**
- * Load Edit Flow modules for VIP Go environments.
- *
- * Edit Flow loads modules after plugins_loaded, which has already been fired
- * when loading via wpcom_vip_load_plugins. This runs the load method at
- * after_setup_theme instead.
- *
- * @return void
- */
-function edit_flow_wpcom_load_modules() {
-	global $edit_flow;
-	if ( method_exists( $edit_flow, 'action_ef_loaded_load_modules' ) ) {
-		$edit_flow->action_ef_loaded_load_modules();
-	}
-}

--- a/wpcom-helper.php
+++ b/wpcom-helper.php
@@ -29,23 +29,6 @@ add_filter( 'ef_manage_usergroups_cap', function () {
 	return 'manage_options';
 } );
 
-add_action( 'after_setup_theme', 'edit_flow_wpcom_load_modules' );
-
-/**
- * Load Edit Flow modules for WordPress.com environments.
- *
- * Edit Flow loads modules after plugins_loaded, which has already been fired
- * on WordPress.com. This runs the load method at after_setup_theme instead.
- *
- * @return void
- */
-function edit_flow_wpcom_load_modules() {
-	global $edit_flow;
-	if ( method_exists( $edit_flow, 'action_ef_loaded_load_modules' ) ) {
-		$edit_flow->action_ef_loaded_load_modules();
-	}
-}
-
 add_filter( 'redirect_canonical', 'edit_flow_wpcom_redirect_canonical' );
 
 /**


### PR DESCRIPTION
## Summary

A small code-quality tidy-up with no behaviour change.

The user and usergroup select-form helpers expanded their parsed arguments with `extract()`, which the project's own coding standards flag (`WordPress.PHP.DontExtract`) because it obscures which variables a function introduces. Those are replaced with explicit assignments of the few keys actually used.

The WordPress.com and VIP Go helper files each carried an `edit_flow_wpcom_load_modules()` function, hooked on `after_setup_theme`, whose body only ran behind a `method_exists()` check for `action_ef_loaded_load_modules` — a method that exists nowhere, since modules are loaded by `action_init()` on the `init` hook. The shim was therefore inert dead code, and is removed from both helpers.

Finally, the plugin loader (`edit-flow.php`) and the primary plugin file (`edit_flow.php`) gain the standard `defined( 'ABSPATH' ) || exit;` guard so neither does anything if requested directly rather than loaded through WordPress.

## Test plan

- [x] `composer cs` and `parallel-lint` pass.
- [x] The select-form behaviour is covered by existing tests (the `extract()` change is behaviour-preserving), and the full integration suite passes (273 tests).
- [x] An adversarial review of the diff (extract variable coverage, dead-loader removal safety, ABSPATH placement) found no issues.

Fixes VIPPLUG-11.