### PR TITLE
Guard against non-npmjs lockfile registry URLs

### DIFF
--- a/.github/workflows/lockfile-registry.yml
+++ b/.github/workflows/lockfile-registry.yml
@@ -1,0 +1,55 @@
+name: Lockfile Registry
+
+on:
+  push:
+    paths:
+      - 'package-lock.json'
+      - '.github/workflows/lockfile-registry.yml'
+  pull_request:
+    branches: [develop, main]
+    paths:
+      - 'package-lock.json'
+      - '.github/workflows/lockfile-registry.yml'
+  workflow_dispatch:
+
+# Disable all permissions by default; grant minimal permissions per job
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  registry:
+    name: Resolved URLs on official registry
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Check resolved URLs point to registry.npmjs.org
+        run: |
+          # Every package tarball in the lockfile must resolve from the public
+          # npm registry. A local proxy or mirror (e.g. an internal caching
+          # registry) baked into "resolved" URLs breaks `npm ci` for anyone
+          # outside that network and leaks internal hostnames into a public repo.
+          offenders="$(grep -oE '"resolved": *"https?://[^"]+"' package-lock.json \
+            | grep -vE '"resolved": *"https://registry\.npmjs\.org/' \
+            | sort -u || true)"
+
+          if [ -n "$offenders" ]; then
+            echo "::error file=package-lock.json::Found resolved URLs outside https://registry.npmjs.org/"
+            echo "Offending entries:"
+            echo "$offenders"
+            echo
+            echo "Regenerate the lockfile against the official registry, for example:"
+            echo "  npm install --registry https://registry.npmjs.org/"
+            exit 1
+          fi
+
+          echo "All resolved URLs point to https://registry.npmjs.org/"


### PR DESCRIPTION
## Summary

A Dependabot lockfile regeneration on this repository recently came back with all of its `resolved` URLs rewritten from `registry.npmjs.org` to an internal caching proxy. The cause was a proxy tool that silently rewrites the registry in the developer's global `~/.npmrc`, so any full `npm install` bakes the proxy host into every entry of `package-lock.json`.

For a public repository that is more than cosmetic. GitHub-hosted runners cannot reach an internal proxy, so `npm ci` fails outright (it returns `418 I'm a Teapot` on the first tarball), and the same breakage hits any external contributor. It also leaks internal hostnames, and the access token embedded in the proxy URL, into public git history. The poisoned lockfile is otherwise indistinguishable from a legitimate one in review, which is exactly how it nearly slipped through.

This adds a small workflow that runs whenever `package-lock.json` changes and fails if any `resolved` URL points anywhere other than `https://registry.npmjs.org/`. It is a plain `grep` with no dependencies to install, so it completes in seconds, and it follows the repository's existing hardening conventions: no default permissions, a read-only job, a SHA-pinned checkout, and `persist-credentials: false`. The remedy is printed in the failure output so the fix is obvious to whoever hits it.

The check is deliberately broad rather than proxy-specific, so it also catches accidental mirror configuration or registry drift introduced on any contributor's machine, not just this one tool.

## Test plan

- [ ] CI runs the new check and passes against the current lockfile, which already resolves entirely from `registry.npmjs.org`.
- [ ] Verified locally that the guard passes on the clean lockfile and fails on a lockfile carrying proxy URLs (252 offending entries correctly flagged).