### PR TITLE
Hold React-19-blocking @wordpress updates in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -64,3 +64,19 @@ updates:
       prefix: "npm"
       include: "scope"
     open-pull-requests-limit: 5
+    ignore:
+      # The following @wordpress/* packages are pinned to their last
+      # React-18-compatible, CommonJS line until two follow-ups land:
+      # a React 18 -> 19 upgrade and an ESM migration of the E2E harness.
+      # Remove each entry once its blocker is cleared.
+      #
+      # components 34+ requires react ^19 as a peer dependency.
+      - dependency-name: "@wordpress/components"
+        update-types: ["version-update:semver-major"]
+      # plugins 7.47+ transitively requires @wordpress/components ^34 (React 19).
+      - dependency-name: "@wordpress/plugins"
+        versions: [">=7.47.0"]
+      # e2e-test-utils-playwright 1.47+ ships a raw ESM entry point that the
+      # CommonJS tests/e2e/global-setup.js cannot require.
+      - dependency-name: "@wordpress/e2e-test-utils-playwright"
+        versions: [">=1.47.0"]


### PR DESCRIPTION
## Summary

Three `@wordpress/*` dev dependencies cannot be updated while the plugin targets React 18 and runs its Playwright E2E harness as CommonJS. Dependabot does not know that, so it re-raises them in the weekly grouped update every time, and every one of those PRs fails CI. The grouped update was closed once already (#976), only for Dependabot to open the identical group again the next day (#1003). Without intervention that loop repeats indefinitely and trains everyone to ignore red Dependabot PRs.

This adds `ignore` rules to the npm section of the Dependabot config so the noise stops at source rather than being closed by hand each week:

- **`@wordpress/components`** — major bumps (34+) require `react ^19` as a peer dependency.
- **`@wordpress/plugins`** — from `7.47` it transitively requires `@wordpress/components ^34`, pulling React 19 in by the back door, so the rule holds everything from `7.47.0`.
- **`@wordpress/e2e-test-utils-playwright`** — from `1.47` its package entry point is raw ESM, which the CommonJS `tests/e2e/global-setup.js` cannot `require`.

Each rule carries an inline comment naming its blocker, and is intended to be removed once that blocker clears: a React 18 → 19 upgrade for the first two, and an ESM migration of the E2E harness for the third. The pins are deliberately narrow, so non-breaking minor and patch updates to these packages on their current line still come through; only the versions that are known to break CI are held back.

## Test plan

- [ ] Dependabot validates the config on its next run (the YAML parses and the three rules load — confirmed locally).
- [ ] The recurring grouped `@wordpress/*` PR is no longer reopened once this lands; #1003 can then be closed without it returning.