### PR TITLE
Declare WordPress 7.0 compatibility and add a wp.org asset-update workflow

### DIFF
--- a/.github/workflows/wordpress-org-assets.yml
+++ b/.github/workflows/wordpress-org-assets.yml
@@ -1,0 +1,42 @@
+name: Update WordPress.org assets and readme
+
+# Pushes the readme and the .wordpress-org assets (icons, banners, screenshots)
+# to the plugin's SVN trunk without cutting a new release. WordPress.org reads
+# "Tested up to", "Requires at least" and "Requires PHP" from trunk, so this is
+# how those compatibility headers are refreshed between releases. Run it manually
+# from the Actions tab after merging a readme or asset change to the default branch.
+on:
+  workflow_dispatch:
+
+# Workflow-level permissions set to none; jobs declare their own minimal permissions
+permissions: {}
+
+# Never interrupt an in-flight SVN commit
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+jobs:
+  update:
+    name: Update readme and assets on WordPress.org
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read # Only needs to read the repository to copy the readme and assets
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Update readme and assets
+        uses: 10up/action-wordpress-plugin-asset-update@2480306f6f693672726d08b5917ea114cb2825f7 # v2.2.0
+        env:
+          SLUG: edit-flow
+          SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
+          SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
+          # This plugin's readme is Markdown (README.md), not the default readme.txt.
+          README_NAME: README.md
+          # Only sync the readme and assets; never re-sync the plugin code to trunk.
+          IGNORE_OTHER_FILES: true

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Donate link: http://editflow.org/contribute/
 Tags: workflow, editorial, editorial calendar, custom status, newsroom  
 Requires at least: 6.4  
 Requires PHP: 7.4  
-Tested up to: 6.9  
+Tested up to: 7.0  
 Stable tag: 0.11.0  
 License: GPLv2 or later  
 License URI: https://www.gnu.org/licenses/gpl-2.0.html  


### PR DESCRIPTION
## Summary

WordPress 7.0 is now generally available, and the integration suite already exercises the plugin against WP latest, so the readme's `Tested up to` header is bumped from 6.9 to 7.0.

The more interesting half is *how that header reaches wordpress.org*. The directory reads the compatibility headers (`Tested up to`, `Requires at least`, `Requires PHP`) from SVN **trunk**, but our release deploy is the only thing that rewrites trunk — and it does so from this repo's `README.md`. That means a hand-edit made directly in SVN is silently reverted by the next release; that is exactly what happened to the previous `6.9.4` value, which the 0.11.0 deploy overwrote back to 6.9. Bumping the header in the repo is therefore the durable fix.

To update the published header *between* releases (rather than cutting a throwaway 0.11.1), this adds a manual `workflow_dispatch` workflow built on the pinned `10up/action-wordpress-plugin-asset-update` action. With `IGNORE_OTHER_FILES: true` it touches only the readme and the `.wordpress-org` assets — never the plugin code in trunk — and because it reads `Stable tag` from the readme, it refreshes both `trunk` and the `tags/0.11.0` readme. `README_NAME` is set because this plugin's readme is Markdown rather than the default `readme.txt`. The workflow mirrors the existing deploy workflow's hardening (no default permissions, pinned actions, no persisted credentials).

After this merges, running the workflow once will publish the 7.0 header to wordpress.org.