### PR TITLE
Keep post_date_gmt in sync when dragging posts on the calendar

### DIFF
--- a/modules/calendar/calendar.php
+++ b/modules/calendar/calendar.php
@@ -1779,7 +1779,7 @@ if ( ! class_exists( 'EF_Calendar' ) ) {
 			// If the user desires that to be the behavior, they can set the result of this filter to 'true'.
 			// With how WordPress works internally, setting 'post_date_gmt' will set the timestamp.
 			if ( apply_filters( 'ef_calendar_allow_ajax_to_set_timestamp', false ) ) {
-				$post_placeholder['post_date_gmt'] = date( 'Y-m-d H:i:s', strtotime( $post_date ) );
+				$post_placeholder['post_date_gmt'] = get_gmt_from_date( $post_placeholder['post_date'] );
 			}
 
 			// Create the post.

--- a/modules/calendar/calendar.php
+++ b/modules/calendar/calendar.php
@@ -425,11 +425,13 @@ if ( ! class_exists( 'EF_Calendar' ) ) {
 		}
 
 		/**
-		 * Handle an AJAX request from the calendar to update a post's timestamp.
+		 * Handle an AJAX request from the calendar to update a post's date.
 		 * Notes:
-		 * - For Post Time, if the post is unpublished, the change sets the publication timestamp
-		 * - If the post was published or scheduled for the future, the change will change the timestamp. 'publish' posts
-		 * will become scheduled if moved past today and 'future' posts will be published if moved before today
+		 * - Published and private posts can't be moved; an error is returned
+		 * - Scheduled ('future') posts keep their publish timestamp in sync with the new date and have
+		 * their publish cron event rescheduled; one moved before the present publishes on the next cron run
+		 * - Posts with a floating date keep it floating, unless the
+		 * 'ef_calendar_allow_ajax_to_set_timestamp' filter is set to true
 		 * - Need to respect user permissions. Editors can move all, authors can move their own, and contributors can't move at all
 		 *
 		 * @since 0.7
@@ -475,19 +477,22 @@ if ( ! class_exists( 'EF_Calendar' ) ) {
 
 			// Persist the old hourstamp because we can't manipulate the exact time on the calendar.
 			// Bump the last modified timestamps too.
-			$existing_time     = date( 'H:i:s', strtotime( $post->post_date ) );
-			$existing_time_gmt = date( 'H:i:s', strtotime( $post->post_date_gmt ) );
-			$new_values        = array(
+			$existing_time = date( 'H:i:s', strtotime( $post->post_date ) );
+			$new_values    = array(
 				'post_date'         => date( 'Y-m-d', $next_date_full ) . ' ' . $existing_time,
 				'post_modified'     => current_time( 'mysql' ),
 				'post_modified_gmt' => current_time( 'mysql', 1 ),
 			);
 
-			// By default, changing a post on the calendar won't set the timestamp.
-			// If the user desires that to be the behaviour, they can set the result of this filter to 'true'.
-			// With how WordPress works internally, setting 'post_date_gmt' will set the timestamp.
-			if ( apply_filters( 'ef_calendar_allow_ajax_to_set_timestamp', false ) ) {
-				$new_values['post_date_gmt'] = date( 'Y-m-d', $next_date_full ) . ' ' . $existing_time_gmt;
+			// A concrete post_date_gmt is an explicit publish timestamp (e.g. a scheduled post) and must
+			// be kept in sync with post_date: core publishes on post_date_gmt, so leaving it behind would
+			// publish the post at the old time while displaying the new date.
+			// A zeroed post_date_gmt is a floating date ("publish immediately"); leave it floating so that
+			// moving a post on the calendar stays a planning action rather than scheduling it, unless the
+			// site opts in to drag-to-schedule via the filter.
+			$has_publish_timestamp = '0000-00-00 00:00:00' !== $post->post_date_gmt;
+			if ( $has_publish_timestamp || apply_filters( 'ef_calendar_allow_ajax_to_set_timestamp', false ) ) {
+				$new_values['post_date_gmt'] = get_gmt_from_date( $new_values['post_date'] );
 			}
 
 			// We have to do SQL unfortunately because of core bugginess.
@@ -499,6 +504,14 @@ if ( ! class_exists( 'EF_Calendar' ) ) {
 
 			if ( ! $response ) {
 				$this->print_ajax_response( 'error', $this->module->messages['update-error'] );
+			}
+
+			// The direct database update bypasses _future_post_hook(), so the publish_future_post cron
+			// event would still fire at the old time. Reschedule it to match the new date; an event in
+			// the past runs on the next cron spawn, publishing a post that was moved before the present.
+			if ( 'future' === $post->post_status && isset( $new_values['post_date_gmt'] ) ) {
+				wp_clear_scheduled_hook( 'publish_future_post', array( $post->ID ) );
+				wp_schedule_single_event( strtotime( $new_values['post_date_gmt'] . ' GMT' ), 'publish_future_post', array( $post->ID ) );
 			}
 
 			$this->print_ajax_response( 'success', $this->module->messages['post-date-updated'] );

--- a/tests/Integration/CalendarDragDropAjaxTest.php
+++ b/tests/Integration/CalendarDragDropAjaxTest.php
@@ -1,0 +1,180 @@
+<?php
+/**
+ * Calendar drag-and-drop AJAX integration tests.
+ *
+ * @package Automattic\EditFlow\Tests\Integration
+ */
+
+declare( strict_types=1 );
+
+namespace Automattic\EditFlow\Tests\Integration;
+
+use WPAjaxDieContinueException;
+use WPAjaxDieStopException;
+
+/**
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ */
+class CalendarDragDropAjaxTest extends AjaxTestCase {
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		// Use a non-UTC timezone so post_date and post_date_gmt genuinely differ,
+		// proving the GMT conversion rather than passing vacuously on UTC.
+		update_option( 'timezone_string', 'America/New_York' );
+
+		global $edit_flow;
+		$edit_flow->calendar->install();
+
+		// Install and initialise custom statuses so draft dates float as they do in
+		// production: EF re-registers 'draft' without 'date_floating' and relies on
+		// fix_custom_status_timestamp() to keep an unset post_date_gmt zeroed.
+		$edit_flow->custom_status->install();
+		$edit_flow->custom_status->init();
+
+		// EF_Calendar::init() only registers its AJAX actions for users who can view the
+		// calendar; in production that runs per-request as the logged-in user. Set such a
+		// user before init() so the ef_calendar_drag_and_drop action is actually wired up.
+		wp_set_current_user( $this->factory->user->create( array( 'role' => 'administrator' ) ) );
+		$edit_flow->calendar->init();
+	}
+
+	/**
+	 * Test: dragging a scheduled post keeps post_date_gmt in sync with post_date
+	 * and reschedules the publish_future_post cron event.
+	 *
+	 * @see https://github.com/Automattic/edit-flow/issues/1008
+	 */
+	public function test_drag_scheduled_post_keeps_post_date_gmt_in_sync(): void {
+		$post_id = $this->factory->post->create( array(
+			'post_status' => 'future',
+			'post_date'   => date( 'Y-m-d', strtotime( '+5 days' ) ) . ' 10:00:00',
+		) );
+
+		$post = get_post( $post_id );
+		$this->assertNotEquals(
+			'0000-00-00 00:00:00',
+			$post->post_date_gmt,
+			'Fixture sanity: a scheduled post must have a concrete post_date_gmt.'
+		);
+
+		$target_day = date( 'Y-m-d', strtotime( '+10 days' ) );
+
+		$response_body = $this->drag_post_to_date( $post_id, $target_day );
+		$this->assertStringContainsString( '"status":"success"', $response_body );
+
+		$post = get_post( $post_id );
+		$this->assertSame( $target_day . ' 10:00:00', $post->post_date, 'post_date should move to the new day, keeping the time.' );
+		$this->assertSame(
+			get_gmt_from_date( $post->post_date ),
+			$post->post_date_gmt,
+			'post_date_gmt must be updated to match the new post_date.'
+		);
+		$this->assertSame(
+			strtotime( $post->post_date_gmt . ' GMT' ),
+			wp_next_scheduled( 'publish_future_post', array( $post_id ) ),
+			'The publish cron event must be rescheduled to the new publish time.'
+		);
+	}
+
+	/**
+	 * Test: dragging a scheduled post to a day in the past schedules its publish
+	 * cron event in the past, so it publishes on the next cron run.
+	 */
+	public function test_drag_scheduled_post_to_past_schedules_immediate_publish(): void {
+		$post_id = $this->factory->post->create( array(
+			'post_status' => 'future',
+			'post_date'   => date( 'Y-m-d', strtotime( '+5 days' ) ) . ' 10:00:00',
+		) );
+
+		$target_day = date( 'Y-m-d', strtotime( '-3 days' ) );
+
+		$response_body = $this->drag_post_to_date( $post_id, $target_day );
+		$this->assertStringContainsString( '"status":"success"', $response_body );
+
+		$post           = get_post( $post_id );
+		$next_scheduled = wp_next_scheduled( 'publish_future_post', array( $post_id ) );
+
+		$this->assertSame( get_gmt_from_date( $post->post_date ), $post->post_date_gmt );
+		$this->assertSame( strtotime( $post->post_date_gmt . ' GMT' ), $next_scheduled );
+		$this->assertLessThan( time(), $next_scheduled, 'The cron event should be due immediately.' );
+	}
+
+	/**
+	 * Test: dragging a post with a floating date keeps it floating, preserving
+	 * "publish immediately when published" semantics.
+	 */
+	public function test_drag_floating_date_post_keeps_date_floating(): void {
+		$post_id = $this->factory->post->create( array(
+			'post_status' => 'draft',
+		) );
+
+		$post = get_post( $post_id );
+		$this->assertSame(
+			'0000-00-00 00:00:00',
+			$post->post_date_gmt,
+			'Fixture sanity: a draft without an explicit date must have a floating post_date_gmt.'
+		);
+
+		$target_day = date( 'Y-m-d', strtotime( '+7 days' ) );
+
+		$response_body = $this->drag_post_to_date( $post_id, $target_day );
+		$this->assertStringContainsString( '"status":"success"', $response_body );
+
+		$post = get_post( $post_id );
+		$this->assertSame( $target_day, substr( $post->post_date, 0, 10 ), 'post_date should move to the new day.' );
+		$this->assertSame(
+			'0000-00-00 00:00:00',
+			$post->post_date_gmt,
+			'A floating post_date_gmt must stay floating by default.'
+		);
+	}
+
+	/**
+	 * Test: the ef_calendar_allow_ajax_to_set_timestamp filter still opts a
+	 * floating-date post into having its publish timestamp set.
+	 */
+	public function test_drag_floating_date_post_sets_timestamp_when_filter_enabled(): void {
+		add_filter( 'ef_calendar_allow_ajax_to_set_timestamp', '__return_true' );
+
+		$post_id = $this->factory->post->create( array(
+			'post_status' => 'draft',
+		) );
+
+		$target_day = date( 'Y-m-d', strtotime( '+7 days' ) );
+
+		$response_body = $this->drag_post_to_date( $post_id, $target_day );
+		$this->assertStringContainsString( '"status":"success"', $response_body );
+
+		$post = get_post( $post_id );
+		$this->assertSame(
+			get_gmt_from_date( $post->post_date ),
+			$post->post_date_gmt,
+			'With the filter enabled, post_date_gmt must be set to the GMT equivalent of the new post_date.'
+		);
+	}
+
+	/**
+	 * Drag a post to a new date via the AJAX endpoint and capture the JSON response body.
+	 *
+	 * @param int    $post_id  Post to move.
+	 * @param string $new_date Target date in Y-m-d format.
+	 */
+	private function drag_post_to_date( int $post_id, string $new_date ): string {
+		$_POST['nonce']     = wp_create_nonce( 'ef-calendar-modify' );
+		$_POST['post_id']   = $post_id;
+		$_POST['next_date'] = $new_date;
+
+		try {
+			$this->_handleAjax( 'ef_calendar_drag_and_drop' );
+		} catch ( WPAjaxDieContinueException $e ) {
+			unset( $e );
+		} catch ( WPAjaxDieStopException $e ) {
+			$this->fail( 'Unexpected stop exception: ' . $e->getMessage() );
+		}
+
+		return (string) $this->_last_response;
+	}
+}


### PR DESCRIPTION
Fixes #1008

Dragging a post to a different day on the calendar only updated `post_date`, leaving `post_date_gmt` behind on the old date. For scheduled posts that pairing is never valid: core publishes on `post_date_gmt`, so the post went live at the old time while displaying the new date. Because the handler writes via a direct database update (the long-standing core #18362 workaround), `_future_post_hook()` never fired either, so the `publish_future_post` cron event kept its old time regardless of which direction the post was moved.

The `ef_calendar_allow_ajax_to_set_timestamp` filter (default false) dates from 2011 and exists so that moving a floating-date post (pitch, draft) on the calendar stays a planning action — the post still publishes "now" when it's eventually published. That behaviour is preserved. What changes is that a post which already has a concrete publish timestamp now always has it kept in sync with the new date, and its publish cron event is rescheduled to match, so a scheduled post moved earlier or later actually publishes when the calendar says it will.

The new GMT value is derived with `get_gmt_from_date()` rather than reusing the old GMT time-of-day, which mishandled posts whose local and GMT dates fall on different days, and DST changes between the old and new dates. The opt-in path in quick-create gets the same treatment, as it previously stored site-local time as GMT verbatim.

Integration tests cover the scheduled-post sync and cron rescheduling, the moved-to-the-past case, and both floating-date behaviours (default, and opted in via the filter), running under a non-UTC site timezone so the GMT conversion is genuinely exercised.