### PR TITLE
Fix two latent VIPCS phpcs violations blocking CI

### DIFF
--- a/modules/custom-status/lib/class-cli.php
+++ b/modules/custom-status/lib/class-cli.php
@@ -146,6 +146,7 @@ class EF_Custom_Status_CLI extends WP_CLI_Command {
 		// Get posts with the source status.
 		$query_args = [
 			'post_status'    => $from_status,
+			// phpcs:ignore WordPressVIPMinimum.Performance.NoPaging.posts_per_page_posts_per_page -- One-off WP-CLI migration fetching IDs only; pagination is not applicable in this context.
 			'posts_per_page' => -1,
 			'fields'         => 'ids',
 		];

--- a/tests/Integration/CustomStatusAddHandlerTest.php
+++ b/tests/Integration/CustomStatusAddHandlerTest.php
@@ -79,7 +79,7 @@ class CustomStatusAddHandlerTest extends TestCase {
 		$redirected = false;
 		add_filter(
 			'wp_redirect',
-			// phpcs:ignore WordPressVIPMinimum.Hooks.AlwaysReturnInFilter.MissingReturnStatement -- Intentionally throws to unwind the handler before its exit; it never returns.
+			// phpcs:ignore WordPressVIPMinimum.Hooks.AlwaysReturnInFilter.MissingReturnStatement, WordPressVIPMinimum.Hooks.AlwaysReturnInFilter.TerminatingInsteadOfReturn -- Intentionally throws to unwind the handler before its exit; it never returns.
 			function ( $location ) use ( &$redirected ) {
 				$redirected = true;
 				throw new \RuntimeException( 'wp_redirect intercepted' );


### PR DESCRIPTION
## Summary

CI recently began failing the PHP coding-standards job on branches that had not touched the offending code. The cause is a combination of two things. The repository has no committed `composer.lock`, so each CI run installs the latest `automattic/vipwpcs` matching `^3.0`; a newer 3.x release tightened two sniffs. The php-lint workflow also caches phpcs results with broad restore keys, so `develop`'s runs keep restoring a stale cache that marks the affected files clean and never re-evaluates them under the newer ruleset. The violations are therefore latent on `develop` and only surface when a pull request happens to run against a cold cache — at which point an unrelated PR is blocked by a failure it did not introduce.

Two lines are flagged. The WP-CLI status-migration command in `class-cli.php` queries with `posts_per_page => -1`, which the `NoPaging` sniff prohibits in a VIP context; here it is correct, because a one-off CLI migration should fetch every matching ID in a single pass and already limits itself to `'fields' => 'ids'`. Separately, a test callback on the `wp_redirect` filter throws to unwind the handler before it reaches `exit`, which the newer `AlwaysReturnInFilter` sniff now flags under a new `TerminatingInsteadOfReturn` sub-code that the existing ignore did not cover.

Rather than weaken the ruleset, both are addressed with justified, narrowly-scoped `phpcs:ignore` comments that document why the pattern is intentional. The existing ignore on the test is extended to list both sub-sniffs.

With these in place, a cold `composer cs` run is clean across the whole repository, so CI passes on any branch regardless of cache state.

## Test plan

- [ ] `rm -f .phpcs-cache && composer cs` exits 0 across the whole repository