### PR TITLE
Declare compatibility with WordPress 7.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Donate link: http://editflow.org/contribute/
 Tags: workflow, editorial, editorial calendar, custom status, newsroom  
 Requires at least: 6.4  
 Requires PHP: 7.4  
-Tested up to: 7.0  
+Tested up to: 7.1  
 Stable tag: 0.11.0  
 License: GPLv2 or later  
 License URI: https://www.gnu.org/licenses/gpl-2.0.html  


### PR DESCRIPTION
## Summary

WordPress 7.1 ships within a day and is currently at RC4, so the readme's `Tested up to` value of 7.0 is about to fall a release behind. Rather than claim compatibility speculatively, I booted the plugin against WordPress 7.1-RC4 with `wp-env` and ran the full integration suite in both configurations: single-site and multisite each pass with 284 tests and 574 assertions, including the new REST editorial-metadata read-exposure guard. On that verified basis this raises the `Tested up to` claim to 7.1.

Note that the existing `WP latest` integration job already exercises WordPress trunk (the 7.1 development line) on every push and has been green, so this is a documentation catch-up to a compatibility level CI has effectively been asserting all along.

## Test plan

- [x] `wp-env` booted on `WordPress/WordPress#7.1-branch` (reported `7.1-RC4`)
- [x] `composer test:integration` — 284 tests, 574 assertions, OK
- [x] multisite `WP_MULTISITE=1` run — 284 tests, 574 assertions, OK